### PR TITLE
docs: prefer isolated socket feature work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@
 
 ## Working Here
 
+- Treat Gale's local `socket` checkout as a real base checkout that should normally stay on `main` and stay clean.
+- For substantive work in `socket`, prefer a feature branch or a dedicated worktree instead of doing the work directly on the base `main` checkout.
+- Use branch-in-place on the base checkout only for very small, low-risk root-maintenance edits when Gale explicitly wants that path.
 - Start from the root docs when the task is about the mixed monorepo model, root marketplace wiring, subtree sync for `apple-dev-skills`, `python-skills`, or `SpeakSwiftlyServer`, or superproject release flow.
 - Start from the child repo docs when the task is really about one child repo's own behavior.
 - When a child repository already exists under `plugins/`, do the work in the monorepo copy first unless Gale explicitly asks for a separate checkout, worktree, or direct child-repo workflow.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ When the work is really about one child repository's own behavior, start from th
 
 ### Setup
 
-Work in the monorepo copy first. Use `plugins/<repo>/` for child-repository changes unless the task is explicitly about the root marketplace or root maintainer docs.
+Treat Gale's local `socket` checkout as the clean base checkout. Work in the monorepo copy first, but prefer a feature branch or a dedicated worktree for substantive superproject changes instead of editing directly on base `main`. Use `plugins/<repo>/` for child-repository changes unless the task is explicitly about the root marketplace or root maintainer docs.
 
 ### Workflow
 
@@ -74,6 +74,7 @@ Keep root docs and marketplace wiring in sync with packaging changes in the same
 
 - For monorepo-owned child directories, edit `plugins/<repo>/` directly and commit in `socket`.
 - For `apple-dev-skills`, `python-skills`, and `SpeakSwiftlyServer`, keep subtree sync operations explicit and isolated.
+- For substantive `socket` work, prefer a feature branch or worktree and treat local `main` as the stable base checkout.
 - Before removing or moving a plugin surface, verify whether the root marketplace or maintainer docs still reference it.
 
 ## Verification
@@ -164,6 +165,7 @@ The mixed shape is intentional for now. `socket` does not try to flatten those c
 
 - Use the root docs when you need the mixed monorepo model, marketplace wiring, or subtree workflow.
 - Use child-repo docs when you are changing a child repo's own skills, packaging, tests, or release guidance.
+- Treat this local checkout as the base `main` checkout and prefer a feature branch or worktree for substantive changes.
 - For ordinary fixes in monorepo-owned child directories, edit the copy in `plugins/<name>/` directly.
 - For `apple-dev-skills`, `python-skills`, and `SpeakSwiftlyServer`, keep subtree pull and push work explicit and separate from unrelated edits.
 - Update the root marketplace and root docs whenever a child repo gains, moves, or removes plugin packaging.

--- a/docs/maintainers/subtree-workflow.md
+++ b/docs/maintainers/subtree-workflow.md
@@ -11,6 +11,10 @@ This document explains how `socket` is maintained after the monorepo simplificat
 - the maintainer docs that explain the mixed monorepo experiment
 - release tags and release notes for the superproject itself
 
+Treat Gale's local `socket` checkout as the clean base checkout on `main`.
+
+For substantive superproject work, prefer a feature branch or a dedicated worktree instead of editing directly on that base checkout.
+
 `socket` is the source of truth for every child directory under `plugins/` except `plugins/apple-dev-skills/`, `plugins/python-skills/`, and `plugins/SpeakSwiftlyServer/`.
 
 For ordinary child-directory fixes, work in the monorepo copy under `plugins/<name>/` and commit in `socket`.


### PR DESCRIPTION
## Summary
- treat the local socket checkout as the clean base checkout on `main`
- prefer feature branches by default and worktrees when explicitly requested or repo guidance warrants them
- keep the socket maintainer docs aligned with that workflow

## Verification
- gh api repos/gaelic-ghost/socket/branches/main/protection
- uv run scripts/validate_socket_metadata.py
