### PR TITLE
build: sync SpeakSwiftly subtree and marketplace state

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,7 @@
 #:schema https://developers.openai.com/codex/config-schema.json
 
-[features]
-codex_hooks = true
-
 # Experimental probe: record whatever payload Codex sends to the notify command.
 notify = ["node", ".codex/hooks/notify-dump.mjs"]
+
+[features]
+codex_hooks = true

--- a/.codex/hooks/notify-dump.mjs
+++ b/.codex/hooks/notify-dump.mjs
@@ -2,8 +2,10 @@
 
 import { mkdir, appendFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const hookRoot = path.resolve(process.cwd(), ".codex");
+const scriptPath = fileURLToPath(import.meta.url);
+const hookRoot = path.resolve(path.dirname(scriptPath), "..");
 const logDir = path.join(hookRoot, "logs");
 const logPath = path.join(logDir, "notify-events.jsonl");
 

--- a/.codex/hooks/stop-tts.mjs
+++ b/.codex/hooks/stop-tts.mjs
@@ -2,8 +2,10 @@
 
 import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const hookRoot = path.resolve(process.cwd(), ".codex");
+const scriptPath = fileURLToPath(import.meta.url);
+const hookRoot = path.resolve(path.dirname(scriptPath), "..");
 const stateDir = path.join(hookRoot, "state");
 const logDir = path.join(hookRoot, "logs");
 const seenTurnsPath = path.join(stateDir, "stop-tts-seen-turns.json");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@
 - Treat Gale's local `socket` checkout as a real base checkout that should normally stay on `main` and stay clean.
 - For substantive work in `socket`, prefer a feature branch or a dedicated worktree instead of doing the work directly on the base `main` checkout.
 - Use branch-in-place on the base checkout only for very small, low-risk root-maintenance edits when Gale explicitly wants that path.
+- Prefer small, focused commits over broad mixed changes.
+- Use the shared house style for commit messages across terminal Git, Codex-driven commits, and subtree-managed child repo work.
+- Default commit subject format: `<scope>: <imperative summary>` with a short lowercase kebab-case scope and no trailing period.
+- For bigger, wider, riskier, refactor, breaking, or release commits, keep the same scoped subject and add concise body sections when relevant in this order: `Why:`, `Breaking:`, `Verification:`.
+- Prefer concrete scopes such as `runtime`, `normalize`, `forensics`, `models`, `docs`, `tests`, `release`, `build`, `plugin`, or `subtree`, and describe the real changed surface instead of vague intent.
 - Start from the root docs when the task is about the mixed monorepo model, root marketplace wiring, subtree sync for `apple-dev-skills`, `python-skills`, or `SpeakSwiftlyServer`, or superproject release flow.
 - Start from the child repo docs when the task is really about one child repo's own behavior.
 - When a child repository already exists under `plugins/`, do the work in the monorepo copy first unless Gale explicitly asks for a separate checkout, worktree, or direct child-repo workflow.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,3 +185,13 @@ Current note: this milestone turns the live-service reliability work into a pack
 - [x] Harden configuration and persisted runtime state handling, including precedence rules, atomic writes, corruption or repair behavior, runtime-configuration persistence, and test isolation for profile-root-sensitive state.
 - [x] Harden the HTTP and MCP transport surface with clearer readiness policy, stronger request validation and operator-facing errors, reusable smoke coverage, and release verification that proves the staged live service can answer both transport health checks.
 - [x] Finish the full hardening program with a package-wide review, quick fixes discovered during the passes, and a cleanup sweep across docs, tests, and maintainer tooling.
+
+## Milestone 17: Codex Hooks And Operator Workflow
+
+Current note: the repo already has a working local Codex hooks prototype for
+Stop-hook speech and notify payload inspection. This milestone tracks turning
+that into a more intentional operator-facing workflow instead of a one-off
+prototype.
+
+- [x] Re-check the repo-local Codex hook scripts against the current official Codex hooks event shapes and stable-path guidance.
+- [ ] Add a maintained repo-local "use this with Codex hooks" guide or skill so Gale can enable, understand, and validate the speech-hook workflow without reverse-engineering the prototype files.

--- a/docs/codex-hooks-tts.md
+++ b/docs/codex-hooks-tts.md
@@ -1,7 +1,7 @@
 # Codex Hooks TTS Prototype
 
-This worktree includes a small repo-local Codex prototype for speaking final
-assistant replies and inspecting Codex notification payloads.
+This worktree includes a small repo-local Codex hooks prototype for speaking
+final assistant replies and inspecting Codex notification payloads.
 
 ## Files
 
@@ -26,6 +26,11 @@ assistant replies and inspecting Codex notification payloads.
 - `.codex/state/stop-tts-seen-turns.json`
   Dedupe state keyed by `session_id + turn_id`.
 
+Both hook scripts now resolve their `.codex` state and log directories from the
+script location itself instead of from `process.cwd()`. That matches the
+official Codex hooks guidance to keep repo-local hook paths stable even when
+Codex is started from a subdirectory.
+
 ## Environment Overrides
 
 The `Stop` hook script accepts a few optional environment overrides:
@@ -42,10 +47,24 @@ The `Stop` hook script accepts a few optional environment overrides:
 
 ## Validation Notes
 
-The current prototype was validated with a synthetic `Stop` payload and queued a
-live speech request successfully against the local server.
+The current prototype was rechecked against the current official Codex hooks
+documentation:
 
-The current `notify` probe was validated with synthetic JSON passed both as the
-documented command-line argument and over `stdin`. The current Codex docs say
-the notify command receives a single JSON argument, so the probe now logs both
-paths in case any Codex surface differs in practice.
+- `Stop` receives one JSON object on `stdin`, including `turn_id`,
+  `stop_hook_active`, and `last_assistant_message`.
+- `Stop` must not emit plain text on `stdout`.
+- repo-local hooks should resolve from the git root or another stable path, not
+  by assuming the session `cwd` is the repository root.
+
+The `Stop` hook script matches that current payload shape and was validated with
+a synthetic `Stop` payload plus real runtime requests queued through the local
+server.
+
+Observed current behavior in this repo's live Codex TUI runs:
+
+- the `Stop` hook payload arrives on `stdin`
+- the `notify` command currently arrives as one JSON command-line argument
+- the current notify runs observed here did not include any `stdin` payload
+
+The `notify` probe still logs both the documented JSON argument and any `stdin`
+payload so future Codex surfaces can be compared without rewriting the hook.

--- a/plugins/SpeakSwiftlyServer/.agents/plugins/marketplace.json
+++ b/plugins/SpeakSwiftlyServer/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "speak-swiftly-server-local",
   "interface": {
-    "displayName": "SpeakSwiftlyServer Local Plugins"
+    "displayName": "SpeakSwiftly Local Plugins"
   },
   "plugins": [
     {

--- a/plugins/SpeakSwiftlyServer/.codex-plugin/plugin.json
+++ b/plugins/SpeakSwiftlyServer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, focused operator skills, and shared local MCP configuration.",
   "author": {
     "name": "Gale",
@@ -21,7 +21,7 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "SpeakSwiftlyServer",
+    "displayName": "SpeakSwiftly",
     "shortDescription": "Local speech and playback workflows for Codex.",
     "longDescription": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, including focused skills for runtime operation, voice workflows, and text-profile authoring.",
     "developerName": "Gale",

--- a/plugins/SpeakSwiftlyServer/.mcp.json
+++ b/plugins/SpeakSwiftlyServer/.mcp.json
@@ -3,7 +3,7 @@
     "speak_swiftly": {
       "type": "http",
       "url": "http://127.0.0.1:7337/mcp",
-      "note": "Connects to the local SpeakSwiftlyServer MCP surface exposed by the shared HTTP server. Expected local defaults are APP_MCP_ENABLED=true, APP_MCP_PATH=/mcp, and APP_PORT=7337."
+      "note": "Connects to the local SpeakSwiftlyServer MCP surface exposed by the shared HTTP server. The usual live local service listens on APP_PORT=7337 with APP_MCP_PATH=/mcp, but built-in runtime defaults keep APP_MCP_ENABLED=false until MCP is turned on through APP_CONFIG_FILE or APP_MCP_ENABLED=true."
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "0.8.0"
+version = "0.8.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
Why:
Pull the latest SpeakSwiftlyServer patch release into socket, keep the socket patch bump and marketplace sync on one branch, and add the repo-local commit message guidance to the root AGENTS file.

Verification:
- pulled SpeakSwiftlyServer main into plugins/SpeakSwiftlyServer as subtree commit 57bf2c9
- bumped socket version to 0.8.1
- synced ~/.agents/plugins/marketplace.json to the socket marketplace inventory using local absolute paths
- pushed plugin/speak-swiftly-marketplace-sync to origin