### PR TITLE
Update maintainer docs and bump socket subtree versions

### DIFF
--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "1.5.2"
+version = "1.6.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "1.5.2"
+version = "1.6.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Refresh root `socket` docs to reflect the current mixed-monorepo and release-prep guidance
- Align `agent-plugin-skills` maintainer docs with the latest Codex plugin guidance and add a dedicated `CONTRIBUTING.md`
- Bump versions for `socket`, `agent-plugin-skills`, and `python-skills` to the next minor releases

## Testing
- `uv run scripts/validate_socket_metadata.py`
- `uv run pytest` in `plugins/agent-plugin-skills`
- `uv run scripts/validate_repo_metadata.py` in `plugins/python-skills`
- `uv run pytest` in `plugins/python-skills`