### PR TITLE
docs: gate subtree syncs and branch cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,16 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 - For `apple-dev-skills`, `python-skills`, and `SpeakSwiftlyServer`, keep subtree sync operations explicit and isolated from unrelated edits.
 - When a child repo gains, removes, or moves plugin packaging, update [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json), [README.md](./README.md), and the root maintainer docs in the same pass.
 
+### Subtree Sync And Branch Accounting Gates
+
+- Treat subtree sync completion and branch accounting as hard gates, not follow-up cleanup.
+- Before claiming a subtree-managed task is done, verify whether the corresponding child-repo work also needs an explicit `git subtree pull` or `git subtree push` in `socket`, and either perform that sync or say plainly why no sync is required.
+- Before claiming a release, publish, merge, or cleanup step is done, enumerate every local branch that is still not contained by local `main` and account for each one explicitly as one of: already preserved elsewhere, intentionally still in progress, newly archived, newly merged, or safe to delete.
+- Do not say work is "on main", "merged", "recovered", "preserved", or "safe to clean up" until commit reachability has been verified in the exact repository and remote that statement refers to.
+- Do not delete local branches, remote branches, worktrees, archive refs, or temporary rescue refs until the branch-accounting pass has been completed and any non-`main` history is either merged or preserved on an explicit archive ref.
+- After a subtree sync lands, re-check `git log origin/main..main` and `git branch --no-merged main` so the superproject does not silently stay ahead with imported child-repo history or stranded local refs.
+- If a child repo release lands outside `socket`, do not consider the overall workflow complete until `socket` has either been synced to that child-repo state or the absence of a `socket` sync has been surfaced explicitly to Gale before cleanup.
+
 ### Source of Truth
 
 - Treat managed production installs such as `~/.agents/skills` as read-only deployment artifacts while working in these development repositories.
@@ -95,6 +105,8 @@ Use these commands only when the work is intentionally publishing or syncing one
 - Root docs and marketplace wiring are updated together when packaging or policy changed.
 - The root validation path ran when marketplace metadata or packaged plugin paths changed.
 - Child-repo-specific validation ran from the relevant child repo when the real change lives there.
+- Any required subtree pull or subtree push has either been completed or called out explicitly as intentionally not done.
+- Every local branch not contained by `main` has been accounted for explicitly before cleanup, and no branch or archive ref was deleted before that accounting pass finished.
 
 ## Safety Boundaries
 

--- a/plugins/SpeakSwiftlyServer/AGENTS.md
+++ b/plugins/SpeakSwiftlyServer/AGENTS.md
@@ -28,6 +28,14 @@
 - Treat `macOS 15` as the current standalone package baseline and keep the host and state model friendly to a near-future `iOS 18` reuse path.
 - Prefer maintainable Apple-platform architecture over speculative Linux abstraction. If Linux support would require major design compromise, stop and discuss whether a separate Rust implementation is the cleaner path.
 
+## Sync And Branch Accounting Gates
+
+- Treat superproject sync verification and local-branch accounting as hard gates before cleanup, release closeout, or "done" claims.
+- When work here is performed from the `socket` superproject copy or is expected to ship back through `socket`, verify whether `socket` now needs an explicit `git subtree pull --prefix=plugins/SpeakSwiftlyServer speak-swiftly-server main` or equivalent sync commit, and either complete it or say plainly why no `socket` sync is required.
+- Do not say a release, merge, or recovery is complete until the exact commit reachability has been verified in this repository and, when relevant, in `socket`.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.
+
 ## Monorepo And Submodule Handoff
 
 - Treat `../../speak-to-user/monorepo/packages/SpeakSwiftlyServer` as the integration submodule copy, not as the primary development home.
@@ -62,3 +70,4 @@
 - Use repository docs to describe the real current command path and artifact layout; do not leave scaffold wording or guessed maintenance files behind.
 - When the source split changes meaningfully, refresh `docs/maintainers/source-layout.md` in the same pass.
 - When the HTTP, MCP, LaunchAgent, or release workflow changes, update the operator-facing docs in the same change instead of deferring that cleanup.
+- Do not close out subtree-visible work until any required `socket` sync has been completed or surfaced explicitly.

--- a/plugins/agent-plugin-skills/AGENTS.md
+++ b/plugins/agent-plugin-skills/AGENTS.md
@@ -36,6 +36,14 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 - If docs and shipped skill behavior diverge, fix the skill or narrow the docs so they match instead of preserving soft ambiguity.
 - When a wording choice could overstate Codex packaging behavior, prefer the narrower documented claim and name the exact surface involved.
 
+### Sync And Branch Accounting Gates
+
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit subtree or nested-repo sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.
+
 ## Commands
 
 ### Setup
@@ -67,6 +75,8 @@ There are no additional repo-level commands worth calling out beyond the `uv` sy
 - The changed surface is consistent across the relevant skill, maintainer doc, and test coverage.
 - README, CONTRIBUTING, AGENTS, and ROADMAP stay aligned with the current repo shape when one of them materially changes.
 - `uv run pytest` passes after changes that touch shipped skills, maintainer automation, or docs-backed audit expectations.
+- Any required superproject or nested-repo sync has been completed or surfaced explicitly before cleanup.
+- Local branches not contained by `main` have been accounted for explicitly before deleting anything.
 
 ## Safety Boundaries
 

--- a/plugins/apple-dev-skills/AGENTS.md
+++ b/plugins/apple-dev-skills/AGENTS.md
@@ -25,6 +25,14 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 - If a task starts needing a new active skill, a new export surface, or a broad repo-structure change, stop and surface that scope change before continuing.
 - Collapse retired historical planning notes into `ROADMAP.md` or still-live maintainer docs instead of preserving stale standalone docs.
 
+### Sync And Branch Accounting Gates
+
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup, release closeout, or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit subtree sync and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.
+
 ### Source of Truth
 
 - For Swift, Apple framework, Apple platform, SwiftUI, SwiftData, Observation, AppKit, UIKit, Foundation-on-Apple, or Xcode-related guidance, require reading the relevant Apple documentation before proposing implementation changes.
@@ -81,6 +89,8 @@ Use the extra validator when a change touches the skill-creator contract or repo
 - The changed root docs, maintainer docs, validator rules, and tests all describe the same live repository behavior.
 - Grounded validation has been run or any skipped checks are called out plainly.
 - Nearby docs and roadmap history have been updated when the change retires stale planning notes or changes the public workflow contract.
+- Any required superproject or subtree sync has been completed or surfaced explicitly before cleanup.
+- Local branches not contained by `main` have been accounted for explicitly before deleting anything.
 
 ## Safety Boundaries
 

--- a/plugins/dotnet-skills/AGENTS.md
+++ b/plugins/dotnet-skills/AGENTS.md
@@ -10,3 +10,8 @@
 - [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) is the required plugin root today.
 - Do not add extra packaging layers, repo-local install machinery, or broad maintainer automation before the repo ships real skill content.
 - Prefer adding actual skill content before expanding docs or workflow complexity.
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.

--- a/plugins/productivity-skills/AGENTS.md
+++ b/plugins/productivity-skills/AGENTS.md
@@ -12,3 +12,8 @@
 - Treat standalone skill installation as the primary distribution story, with plugin packaging and marketplace metadata as thin additive discovery layers.
 - Keep documentation-maintenance skills split by document type instead of collapsing README, AGENTS, CONTRIBUTING, and ROADMAP maintenance into one oversized workflow.
 - Keep stack-specific or repo-family-specific maintainer skills in the dedicated repos that own them. Historical note: `bootstrap-skills-plugin-repo` and `sync-skills-repo-guidance` moved out to `agent-plugin-skills` and should stay there.
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.

--- a/plugins/python-skills/AGENTS.md
+++ b/plugins/python-skills/AGENTS.md
@@ -39,6 +39,14 @@ Use this file for durable repo-local guidance before changing code, docs, metada
 - Run the repo validation path before landing documentation or metadata changes.
 - If docs and validator behavior disagree, update them in the same pass instead of leaving a split-brain repo state.
 
+### Sync And Branch Accounting Gates
+
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup, release closeout, or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit subtree sync and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.
+
 ## Commands
 
 ### Setup
@@ -68,6 +76,8 @@ uv run pytest
 - Root docs reflect the current active skill inventory and packaging shape.
 - The repo root still reads as the plugin root for Codex without a second packaged subtree.
 - `uv run scripts/validate_repo_metadata.py` and `uv run pytest` pass when the touched work should affect them.
+- Any required superproject or subtree sync has been completed or surfaced explicitly before cleanup.
+- Local branches not contained by `main` have been accounted for explicitly before deleting anything.
 
 ## Safety Boundaries
 

--- a/plugins/rust-skills/AGENTS.md
+++ b/plugins/rust-skills/AGENTS.md
@@ -10,3 +10,8 @@
 - [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) is the required plugin root today.
 - Do not add extra packaging layers, repo-local install machinery, or broad maintainer automation before the repo ships real skill content.
 - Prefer adding actual skill content before expanding docs or workflow complexity.
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.

--- a/plugins/things-app/AGENTS.md
+++ b/plugins/things-app/AGENTS.md
@@ -37,6 +37,14 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 - Start from the bundled server docs when the task is really about FastMCP behavior, AppleScript routing, auth-token handling, or HTTP smoke flows.
 - Stop and surface the tradeoff before broadening the repo from its current two-skill scope into a larger Things automation bundle or a materially different plugin packaging model.
 
+### Sync And Branch Accounting Gates
+
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.
+
 ## Commands
 
 ### Setup
@@ -96,6 +104,8 @@ make smoke-read
 - The change is grounded in the correct source-of-truth surface for the behavior you touched.
 - The relevant validation commands ran for the changed surface.
 - Nearby docs and packaging metadata were updated when behavior, install wiring, or contributor workflow changed.
+- Any required superproject or nested-repo sync has been completed or surfaced explicitly before cleanup.
+- Local branches not contained by `main` have been accounted for explicitly before deleting anything.
 
 ## Safety Boundaries
 

--- a/plugins/web-dev-skills/AGENTS.md
+++ b/plugins/web-dev-skills/AGENTS.md
@@ -10,3 +10,8 @@
 - [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) is the required plugin root today.
 - Do not recreate nested repo-local marketplace wiring or bundled copies of other plugin repos here.
 - Do not present this repository as already shipping real skills before those skills exist.
+- Treat repo-sync verification and local-branch accounting as hard gates before cleanup or "done" claims.
+- When work in this repository is performed from the `socket` superproject or is expected to ship back through `socket`, verify whether `socket` now needs an explicit sync step and either complete it or say plainly why no sync is required.
+- Before saying work is merged, preserved, or safe to delete, verify the exact commit reachability in the repo and remote being discussed.
+- Before deleting local branches, remote branches, worktrees, or rescue refs, enumerate every local branch not contained by `main` and account for each one explicitly as preserved elsewhere, intentionally in progress, newly archived, newly merged, or safe to delete.
+- Do not treat branch cleanup as routine hygiene that can happen before that accounting pass.


### PR DESCRIPTION
## Summary
- add hard subtree-sync and branch-accounting gates to the root `socket` AGENTS guide
- add the same cleanup and reachability gates to every top-level child repo `AGENTS.md`
- require explicit sync verification before calling subtree or child-repo work done

## Verification
- reviewed the changed guidance surfaces directly
