### PR TITLE
Fix repo-maintenance root resolution in generated toolkit

### DIFF
--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/assets/repo-maintenance/lib/common.sh
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/assets/repo-maintenance/lib/common.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+COMMON_CONTEXT_DIR=${SELF_DIR:-}
+[ -n "$COMMON_CONTEXT_DIR" ] || COMMON_CONTEXT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -f "$COMMON_CONTEXT_DIR/lib/common.sh" ]; then
+  REPO_MAINTENANCE_ROOT="$COMMON_CONTEXT_DIR"
+else
+  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_CONTEXT_DIR/.." && pwd)
+fi
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
 REPO_MAINTENANCE_PROFILE="generic"
 REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/assets/repo-maintenance/lib/common.sh
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/assets/repo-maintenance/lib/common.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+COMMON_CONTEXT_DIR=${SELF_DIR:-}
+[ -n "$COMMON_CONTEXT_DIR" ] || COMMON_CONTEXT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -f "$COMMON_CONTEXT_DIR/lib/common.sh" ]; then
+  REPO_MAINTENANCE_ROOT="$COMMON_CONTEXT_DIR"
+else
+  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_CONTEXT_DIR/.." && pwd)
+fi
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
 REPO_MAINTENANCE_PROFILE="generic"
 REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/repo-maintenance/lib/common.sh
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/repo-maintenance/lib/common.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+COMMON_CONTEXT_DIR=${SELF_DIR:-}
+[ -n "$COMMON_CONTEXT_DIR" ] || COMMON_CONTEXT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -f "$COMMON_CONTEXT_DIR/lib/common.sh" ]; then
+  REPO_MAINTENANCE_ROOT="$COMMON_CONTEXT_DIR"
+else
+  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_CONTEXT_DIR/.." && pwd)
+fi
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
 REPO_MAINTENANCE_PROFILE="generic"
 REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/repo-maintenance/lib/common.sh
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/repo-maintenance/lib/common.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+COMMON_CONTEXT_DIR=${SELF_DIR:-}
+[ -n "$COMMON_CONTEXT_DIR" ] || COMMON_CONTEXT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -f "$COMMON_CONTEXT_DIR/lib/common.sh" ]; then
+  REPO_MAINTENANCE_ROOT="$COMMON_CONTEXT_DIR"
+else
+  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_CONTEXT_DIR/.." && pwd)
+fi
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
 REPO_MAINTENANCE_PROFILE="generic"
 REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."

--- a/plugins/apple-dev-skills/tests/test_swift_package_guidance_sync_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_swift_package_guidance_sync_workflow.py
@@ -94,6 +94,24 @@ class SwiftPackageGuidanceSyncWorkflowTests(unittest.TestCase):
             )
             self.assertTrue(Path(tmpdir, ".github/workflows/validate-repo-maintenance.yml").is_file())
 
+    def test_generated_repo_maintenance_validation_uses_repo_self_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "Package.swift").write_text("// swift-tools-version: 6.0\n", encoding="utf-8")
+            code, payload = self.run_script("--repo-root", tmpdir)
+            self.assertEqual(code, 0)
+            self.assertEqual(payload["status"], "success")
+
+            subprocess.run(["git", "init"], cwd=tmpdir, check=True, capture_output=True, text=True)
+            proc = subprocess.run(
+                ["sh", "scripts/repo-maintenance/validate-all.sh"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr or proc.stdout)
+            self.assertIn("Repo-maintenance validation completed successfully.", proc.stdout)
+
     def test_sync_appends_section_to_existing_agents(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             Path(tmpdir, "Package.swift").write_text("// swift-tools-version: 6.0\n", encoding="utf-8")

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/lib/common.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/lib/common.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-COMMON_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_DIR/.." && pwd)
+COMMON_CONTEXT_DIR=${SELF_DIR:-}
+[ -n "$COMMON_CONTEXT_DIR" ] || COMMON_CONTEXT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -f "$COMMON_CONTEXT_DIR/lib/common.sh" ]; then
+  REPO_MAINTENANCE_ROOT="$COMMON_CONTEXT_DIR"
+else
+  REPO_MAINTENANCE_ROOT=$(CDPATH= cd -- "$COMMON_CONTEXT_DIR/.." && pwd)
+fi
 REPO_ROOT=$(CDPATH= cd -- "$REPO_MAINTENANCE_ROOT/../.." && pwd)
 REPO_MAINTENANCE_PROFILE="generic"
 REPO_MAINTENANCE_PROFILE_DESCRIPTION="Generic repo-maintenance baseline with no Swift or Xcode specialization."

--- a/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
+++ b/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
@@ -48,6 +48,37 @@ class RepoMaintenanceToolkitWorkflowTests(unittest.TestCase):
             self.assertIn('REPO_MAINTENANCE_PROFILE="swift-package"', Path(tmpdir, "scripts/repo-maintenance/config/profile.env").read_text(encoding="utf-8"))
             self.assertTrue(Path(tmpdir, ".github/workflows/validate-repo-maintenance.yml").is_file())
 
+    def test_generated_validation_uses_repo_maintenance_self_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            code, payload = self.run_script("--repo-root", tmpdir, "--operation", "install")
+            self.assertEqual(code, 0)
+            self.assertEqual(payload["status"], "success")
+
+            Path(tmpdir, "AGENTS.md").write_text(
+                "\n".join(
+                    [
+                        "# AGENTS.md",
+                        "",
+                        "- scripts/repo-maintenance/validate-all.sh",
+                        "- scripts/repo-maintenance/sync-shared.sh",
+                        "- scripts/repo-maintenance/release.sh",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init"], cwd=tmpdir, check=True, capture_output=True, text=True)
+
+            proc = subprocess.run(
+                ["sh", "scripts/repo-maintenance/validate-all.sh"],
+                cwd=tmpdir,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr or proc.stdout)
+            self.assertIn("Repo-maintenance validation completed successfully.", proc.stdout)
+
     def test_refresh_preserves_repo_specific_extra_script(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             code, payload = self.run_script("--repo-root", tmpdir, "--operation", "install")


### PR DESCRIPTION
## Summary
- fix the socket-owned repo-maintenance toolkit assets in productivity-skills
- mirror the same root-resolution fix in the apple-dev-skills subtree payload
- add regression tests that run generated validate-all.sh inside a real temp git repo

## Verification
- uv run python -m unittest plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
- uv run python -m unittest plugins/apple-dev-skills/tests/test_swift_package_guidance_sync_workflow.py

Closes #10