### PR TITLE
plugin: register Xcode MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Treat `socket` as the canonical home for the monorepo-owned child directories an
 - `apple-dev-skills` and `SpeakSwiftlyServer` preserve explicit subtree sync paths.
 - `python-skills` is monorepo-owned here even though its upstream GitHub repository still exists as an archival or private remote source.
 - Child repos may expose plugin packaging from their own repo roots whether they are monorepo-owned here or still preserve subtree sync.
+- `apple-dev-skills` packages from its child-repo root at `./plugins/apple-dev-skills`, and its Codex plugin manifest registers Xcode's built-in MCP bridge through a root `.mcp.json`.
 - `things-app` packages from its child-repo root at `./plugins/things-app`, and its bundled MCP server lives directly under that child repo's top-level `mcp/` directory.
 - `cardhop-app` packages from its child-repo root at `./plugins/cardhop-app`, and its bundled MCP server lives directly under that child repo's top-level `mcp/` directory.
 

--- a/docs/maintainers/plugin-packaging-strategy.md
+++ b/docs/maintainers/plugin-packaging-strategy.md
@@ -36,7 +36,7 @@ The current direction is:
 5. keep root `socket` docs aligned with child packaging moves and coordinated release-prep changes instead of treating the marketplace file as the only source of truth
 6. keep the maintained version-bearing manifests aligned on one shared semantic version through the root release-version workflow instead of hand-editing scattered files
 
-Recent monorepo-owned examples follow that rule directly: `things-app` and `cardhop-app` both package from their child-repo roots while keeping bundled MCP server code under each child repo's top-level `mcp/` directory.
+Recent monorepo-owned examples follow that rule directly: `things-app` and `cardhop-app` both package from their child-repo roots while keeping bundled MCP server code under each child repo's top-level `mcp/` directory. `apple-dev-skills` follows the same child-root packaging rule while using a root `.mcp.json` to register Xcode's built-in `xcrun mcpbridge` server instead of bundling separate server code.
 
 Child-repo internal layout changes do not automatically imply root marketplace changes. If a child repo keeps the same packaged plugin root, keep the `socket` marketplace path stable and only update the root docs to explain the child's new internal layout. Recent example: `things-app` keeps its marketplace path at `./plugins/things-app` while its bundled MCP server lives at top-level `mcp/` inside that child repo.
 

--- a/plugins/SpeakSwiftlyServer/.codex-plugin/plugin.json
+++ b/plugins/SpeakSwiftlyServer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "speak-swiftly-server",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Repo-local Codex plugin for the SpeakSwiftlyServer MCP surface, focused operator skills, and shared local MCP configuration.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",
@@ -16,11 +16,13 @@
     "apple",
     "swift",
     "xcode",
+    "mcp",
     "swiftui",
     "ios",
     "macos"
   ],
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Apple Dev Skills",
     "shortDescription": "Apple, Swift, Xcode, SwiftUI, and DocC workflows for Codex.",

--- a/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
+++ b/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
@@ -94,7 +94,8 @@ require_contains "$audit_doc" "## Source-of-Truth Order"
 require_contains "$audit_doc" "## Audit Procedure"
 require_contains "$audit_doc" "## Local Discovery Smoke Test Flow"
 require_contains "$audit_doc" "## Reporting Shape"
-require_contains "$audit_doc" 'this repository'"'"'s shipped Apple plugin owns the end-user toolkit contract'
+require_contains "$audit_doc" '`productivity-skills` owns the reusable `maintain-project-repo` toolkit contract'
+require_contains "$audit_doc" 'this repository owns only the Apple-specific profile selection and Xcode MCP registration contract'
 require_contains "$audit_doc" 'Historical milestone planning decisions that no longer need standalone docs should live in `ROADMAP.md`'
 require_not_contains "$audit_doc" 'plugins/apple-dev-skills/'
 
@@ -112,9 +113,9 @@ execution_split_doc="docs/maintainers/execution-split-and-inference-plan.md"
 require_contains "$execution_split_doc" "## Target Skill Matrix"
 require_contains "$execution_split_doc" "## Guidance Preservation Contract"
 require_contains "$execution_split_doc" "## AGENTS Expansion Strategy"
-require_contains "$execution_split_doc" "## Repo-Maintenance Toolkit Direction"
+require_contains "$execution_split_doc" "## Repo-Maintenance Direction"
 require_contains "$execution_split_doc" "## Implementation Plan"
-require_contains "$execution_split_doc" 'the shipped plugin self-contained'
+require_contains "$execution_split_doc" '`productivity-skills/maintain-project-repo` as the canonical shipped repo-maintenance surface'
 require_contains "ROADMAP.md" "Completed Milestones 22 and 23"
 require_contains "ROADMAP.md" 'See `docs/maintainers/customization-consolidation-review.md`.'
 require_contains "ROADMAP.md" "Completed Milestones 30 through 36"
@@ -237,20 +238,23 @@ do
   require_not_contains "$file" 'plugins/apple-dev-skills/'
 done
 
-echo "Validating repo-maintenance toolkit asset copies..."
-toolkit_source_dir="./shared/repo-maintenance-toolkit/assets/repo-maintenance"
-toolkit_workflow_source="./shared/repo-maintenance-toolkit/assets/github/repo-maintenance-workflows/validate-repo-maintenance.yml"
-toolkit_installer_source="./shared/repo-maintenance-toolkit/scripts/install_repo_maintenance_toolkit.py"
+echo "Validating maintain-project-repo delegation..."
+[[ ! -e "./shared/repo-maintenance-toolkit" ]] || fail "Did not expect apple-dev-skills to retain shared/repo-maintenance-toolkit."
 for skill_dir in \
   "./skills/bootstrap-swift-package" \
   "./skills/bootstrap-xcode-app-project" \
   "./skills/sync-swift-package-guidance" \
   "./skills/sync-xcode-project-guidance"
 do
-  cmp -s "$skill_dir/scripts/install_repo_maintenance_toolkit.py" "$toolkit_installer_source" || fail "Repo-maintenance toolkit installer drift detected in $skill_dir"
-  diff -qr "$toolkit_source_dir" "$skill_dir/assets/repo-maintenance" >/dev/null || fail "Repo-maintenance toolkit asset drift detected in $skill_dir/assets/repo-maintenance"
-  cmp -s "$toolkit_workflow_source" "$skill_dir/assets/github/repo-maintenance-workflows/validate-repo-maintenance.yml" || fail "Repo-maintenance workflow asset drift detected in $skill_dir"
+  [[ ! -e "$skill_dir/scripts/install_repo_maintenance_toolkit.py" ]] || fail "Did not expect legacy toolkit installer in $skill_dir"
+  [[ ! -e "$skill_dir/assets/repo-maintenance" ]] || fail "Did not expect vendored repo-maintenance assets in $skill_dir"
+  [[ ! -e "$skill_dir/assets/github/repo-maintenance-workflows" ]] || fail "Did not expect vendored repo-maintenance workflow assets in $skill_dir"
+  require_contains "$skill_dir/SKILL.md" 'maintain-project-repo'
 done
+require_contains "./skills/bootstrap-swift-package/scripts/bootstrap_swift_package.sh" 'productivity-skills/skills/maintain-project-repo/scripts/run_workflow.py'
+require_contains "./skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py" 'productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py'
+require_contains "./skills/sync-swift-package-guidance/scripts/sync_swift_package_guidance.py" 'productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py'
+require_contains "./skills/sync-xcode-project-guidance/scripts/sync_xcode_project_guidance.py" 'productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py'
 
 echo "Validating preserved guidance in AGENTS assets..."
 package_agents_assets=(

--- a/plugins/apple-dev-skills/.mcp.json
+++ b/plugins/apple-dev-skills/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "xcode": {
+      "command": "xcrun",
+      "args": [
+        "mcpbridge"
+      ],
+      "note": "Registers Xcode's built-in MCP bridge for external Codex sessions. Users still need Xcode installed, Xcode > Settings > Intelligence > Model Context Protocol enabled, and an open project in Xcode for the bridge to provide project-specific tools."
+    }
+  }
+}

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -45,6 +45,8 @@ Use this repository's skills when the work is about:
 - Apple-project guidance sync
 - Apple-platform documentation routing
 
+When installed as a Codex plugin, this repository also registers Xcode's built-in MCP bridge through `xcrun mcpbridge`. Users still need to allow external agents in Xcode's Intelligence settings and keep the relevant project open in Xcode before external Codex sessions can use Xcode-provided tools.
+
 Use [`CONTRIBUTING.md`](./CONTRIBUTING.md) for maintainer workflow details, and use [`ROADMAP.md`](./ROADMAP.md) for planned and completed milestone-level work.
 
 ## Development
@@ -59,7 +61,7 @@ uv sync --dev
 
 ### Workflow
 
-Treat root [`skills/`](./skills/) as the canonical authored surface. Keep shared reusable assets in [`shared/`](./shared/), maintainer docs in [`docs/`](./docs/), and install metadata in [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) and [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json).
+Treat root [`skills/`](./skills/) as the canonical authored surface. Keep shared reusable assets in [`shared/`](./shared/), maintainer docs in [`docs/`](./docs/), and install metadata in [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json), [`.mcp.json`](./.mcp.json), and [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json).
 
 Keep the repo honest about its Apple docs-first policy. When a skill changes, update the relevant tests and maintainer guidance in the same pass rather than letting the packaging or guidance drift. Use [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the normal contributor workflow and review expectations.
 
@@ -78,6 +80,7 @@ uv run pytest
 .
 ├── .codex-plugin/
 ├── .claude-plugin/
+├── .mcp.json
 ├── AGENTS.md
 ├── CONTRIBUTING.md
 ├── README.md

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -359,6 +359,7 @@ Completed Milestone 40 by shipping `swiftui-app-architecture-workflow`, groundin
 
 ## History
 
+- Registered Xcode's built-in MCP bridge through the Codex plugin manifest so installed `apple-dev-skills` plugins expose the Xcode-owned MCP path without bundling a separate server package.
 - Clarified the Apple `maintain-project-repo` branch-protection contract so generated and synced repos require the `validate` Actions check context instead of the workflow-title display string.
 - Completed Milestones 1 through 17 by establishing the repository, shipping the core Apple skill bundle, improving portability and customization guidance, adding bootstrap and repo-sync workflows, extracting Apple docs exploration into its own skill, and cleaning up the install surface around the top-level export model.
 - Completed Milestones 19 and 20 by shipping `format-swift-sources` and `structure-swift-sources` as distinct cleanup workflows with clear boundaries.

--- a/plugins/apple-dev-skills/docs/maintainers/reality-audit.md
+++ b/plugins/apple-dev-skills/docs/maintainers/reality-audit.md
@@ -17,6 +17,11 @@ Root `skills/` is the canonical workflow-authoring surface.
 2.5. Shared repo-maintenance behavior from `productivity-skills/skills/maintain-project-repo/`
    - `productivity-skills` owns the reusable `maintain-project-repo` toolkit contract
    - this repository's Apple bootstrap and guidance-sync flows call that sibling skill with the `swift-package` or `xcode-app` profile
+   - this repository owns only the Apple-specific profile selection and Xcode MCP registration contract
+2.6. Packaged plugin metadata under `.codex-plugin/plugin.json` and `.mcp.json`
+   - `.codex-plugin/plugin.json` is the Codex plugin entrypoint
+   - `.mcp.json` registers Xcode's built-in `xcrun mcpbridge` server for external Codex sessions
+   - the Xcode MCP server remains Xcode-owned; this repo does not bundle a separate Xcode MCP server package
 3. Repository validation rules in `.github/scripts/validate_repo_docs.sh`
 4. Root maintainer and discoverability docs
    - `README.md`
@@ -44,6 +49,7 @@ Deprecated compatibility skills that remain on disk do not count as part of the 
 4. Run `bash .github/scripts/validate_repo_docs.sh` and treat failures as documentation-contract drift unless code assets prove otherwise.
    - for repo-maintenance drift inside this repo, compare Apple behavior against `productivity-skills/skills/maintain-project-repo/`
    - when intentionally syncing ideas from another repo, reconcile them into `maintain-project-repo` first, then keep this repo limited to Apple guidance and profile selection
+   - for Xcode MCP drift, compare the plugin metadata against Apple's documented `codex mcp add xcode -- xcrun mcpbridge` setup
 5. Run `uv run --group dev pytest` and treat failures as runtime drift.
 6. Reconcile root docs to the tested, shipped state instead of preserving stale historical wording.
 7. Update `ROADMAP.md` in the same change when milestone or status text is no longer truthful.
@@ -63,6 +69,7 @@ Use this flow when validating the current top-level export surface and local dis
 - Root docs should say plainly that `productivity-skills` remains the default baseline layer for general repo-doc and maintenance work, while this repo is the Apple-specific specialization layer.
 - Root docs must describe the same active skill surface.
 - Root docs must describe the current top-level export shape without treating deleted nested packaging experiments as active.
+- Codex plugin docs must describe Xcode MCP registration as Xcode-owned `xcrun mcpbridge` wiring, not as a bundled third-party server package.
 - Maintainer-doc links in root docs must resolve on disk.
 - Validation rules must check the canonical maintainer-doc paths, not legacy locations.
 - Historical notes may mention retired or deprecated skills only in migration context.

--- a/plugins/apple-dev-skills/docs/maintainers/workflow-atlas.md
+++ b/plugins/apple-dev-skills/docs/maintainers/workflow-atlas.md
@@ -134,7 +134,7 @@ flowchart TD
 - User-visible response:
   - The user sees direct progress inside one of the active top-level skills, or a direct recommendation to switch to another skill.
 - Interaction style:
-- The repo-level UX is a bundle of fifteen active skills exported from the top-level `skills/` surface.
+- The repo-level UX is a bundle of sixteen active skills exported from the top-level `skills/` surface.
 
 ## `xcode-build-run-workflow`
 

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.0.4"
+version = "6.0.5"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/mcp-tool-matrix.md
+++ b/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/mcp-tool-matrix.md
@@ -1,5 +1,7 @@
 # MCP Tool Matrix
 
+These are Xcode-owned MCP tools exposed through `xcrun mcpbridge` after external-agent access is enabled in Xcode. Do not substitute a bundled or third-party Xcode MCP server when following this matrix.
+
 ## Workspace and session
 
 - `XcodeListWindows`

--- a/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/mcp-tool-matrix.md
+++ b/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/mcp-tool-matrix.md
@@ -1,5 +1,7 @@
 # MCP Tool Matrix
 
+These are Xcode-owned MCP tools exposed through `xcrun mcpbridge` after external-agent access is enabled in Xcode. Do not substitute a bundled or third-party Xcode MCP server when following this matrix.
+
 ## Workspace and session
 
 - `XcodeListWindows`

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/mcp-tool-matrix.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/mcp-tool-matrix.md
@@ -1,5 +1,7 @@
 # MCP Tool Matrix
 
+These are Xcode-owned MCP tools exposed through `xcrun mcpbridge` after external-agent access is enabled in Xcode. Do not substitute a bundled or third-party Xcode MCP server when following this matrix.
+
 ## Workspace and session
 
 - `XcodeListWindows`

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.0.4"
+version = "6.0.5"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.0.4"
+version = "6.0.5"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.0.4"
+version = "6.0.5"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.0.4"
+version = "6.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/scripts/validate_socket_metadata.py
+++ b/scripts/validate_socket_metadata.py
@@ -88,6 +88,33 @@ def validate_plugin_entry(entry: object, seen_names: set[str]) -> None:
             f"`{manifest_name}` instead."
         )
 
+    mcp_servers_path = plugin_manifest.get("mcpServers")
+    if mcp_servers_path is not None:
+        if not isinstance(mcp_servers_path, str) or not mcp_servers_path.startswith("./"):
+            fail(
+                f"Packaged plugin manifest for `{name}` must use a repo-relative `./...` "
+                f"`mcpServers` path, but found `{mcp_servers_path}`."
+            )
+        mcp_config_path = (plugin_root / mcp_servers_path).resolve()
+        try:
+            mcp_config_path.relative_to(plugin_root)
+        except ValueError:
+            fail(
+                f"Packaged plugin manifest for `{name}` points `mcpServers` outside its "
+                f"plugin root: {mcp_servers_path}"
+            )
+        if not mcp_config_path.is_file():
+            fail(
+                f"Packaged plugin manifest for `{name}` points at missing MCP server "
+                f"configuration: {mcp_config_path.relative_to(REPO_ROOT)}."
+            )
+        mcp_config = load_json(mcp_config_path)
+        if not isinstance(mcp_config, dict):
+            fail(
+                f"MCP server configuration for `{name}` must decode to a JSON object: "
+                f"{mcp_config_path.relative_to(REPO_ROOT)}"
+            )
+
 
 def main() -> None:
     print("Validating root marketplace presence...")

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.0.4"
+version = "6.0.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- register Xcode's built-in MCP bridge in apple-dev-skills via .mcp.json and the plugin manifest
- align Apple guidance and validators around Xcode-owned mcpbridge plus productivity-skills maintain-project-repo ownership
- bump maintained socket version surfaces to 6.0.5 for release

## Verification
- bash .github/scripts/validate_repo_docs.sh in plugins/apple-dev-skills
- uv run pytest in plugins/apple-dev-skills
- uv run scripts/validate_socket_metadata.py
- scripts/release.sh inventory
- git diff --check

Reference: https://developer.apple.com/documentation/xcode/giving-external-agents-access-to-xcode