### PR TITLE
release: tolerate annotated release tags

### DIFF
--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release.sh
@@ -139,7 +139,8 @@ create_release_tag() {
   tag_sha="$(git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
 
   if [ -n "$tag_sha" ]; then
-    [ "$tag_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
+    tag_commit_sha="$(git -C "$REPO_ROOT" rev-list -n 1 "$RELEASE_TAG")"
+    [ "$tag_commit_sha" = "$head_sha" ] || die "Tag $RELEASE_TAG already exists and does not point at HEAD."
     log "Tag $RELEASE_TAG already points at HEAD."
     return 0
   fi

--- a/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
+++ b/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
@@ -111,6 +111,7 @@ class RepoMaintenanceToolkitWorkflowTests(unittest.TestCase):
         self.assertIn("REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS", release_script)
         self.assertIn("push_release_branch", release_script)
         self.assertIn("push_release_tag", release_script)
+        self.assertIn('rev-list -n 1 "$RELEASE_TAG"', release_script)
         self.assertIn('gh pr checks "$pr_number" --watch', release_script)
         self.assertIn('select(.state == "COMMENTED")', release_script)
         self.assertIn("valid concerns in code, or add out-of-scope concerns to ROADMAP.md", release_script)


### PR DESCRIPTION
## Summary

- Compare existing release tags by their resolved commit instead of the annotated tag object SHA.
- Keeps resumed standard release runs from rejecting an annotated tag that already points at the intended release commit.
- Adds maintain-project-repo workflow coverage so the generated toolkit keeps this behavior.

## Related socket issues

- Follow-up to #19, which fixed waiting for initial PR checks before release CI watching.
- Follow-up to #20, which fixed the release comment gate for approval-only reviews.
- No currently open socket issue exists for this annotated-tag resume bug, so this PR does not include a `Closes #...` trailer.

## Verification

- `uv run pytest skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py`
- `uv run scripts/validate_socket_metadata.py`
- `git diff --check`