### PR TITLE
docs: tighten Swift public API guidance

### DIFF
--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/AGENTS.md
+++ b/plugins/apple-dev-skills/AGENTS.md
@@ -41,6 +41,9 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 - If no relevant Apple documentation can be found, say that explicitly before proceeding.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer framework-provided behavior over custom boilerplate. Do not add extra wrappers, coordinators, custom codable glue, or renaming layers unless a concrete constraint requires them or they make the final code clearly easier to understand.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default. Prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Preserve source-of-truth names when the meaning has not changed, and avoid automatic case-conversion strategies unless the project explicitly wants them.
 - Keep `explore-apple-swift-docs` as the canonical docs-routing surface instead of re-embedding broad docs-source selection logic into execution skills.
 - For SwiftPM guidance, edit `Package.swift` intentionally and keep it readable. Agents may modify it when package structure, targets, products, or dependencies need to change, should keep dependency provenance concise but fetchable from real remote repositories or package registries, should not commit machine-local dependency paths, and should try to keep package graph updates consolidated in one change when possible.

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -359,6 +359,7 @@ Completed Milestone 40 by shipping `swiftui-app-architecture-workflow`, groundin
 
 ## History
 
+- Tightened the Swift public API guidance across shared snippets, skill-local snippet copies, and generated `AGENTS.md` templates so public call sites default to streamlined typed APIs, optional defaulted parameters over overloads, request/options structs at four or more public parameters, and enum-backed choice modeling.
 - Registered Xcode's built-in MCP bridge through the Codex plugin manifest so installed `apple-dev-skills` plugins expose the Xcode-owned MCP path without bundling a separate server package.
 - Clarified the Apple `maintain-project-repo` branch-protection contract so generated and synced repos require the `validate` Actions check context instead of the workflow-title display string.
 - Completed Milestones 1 through 17 by establishing the repository, shipping the core Apple skill bundle, improving portability and customization guidance, adding bootstrap and repo-sync workflows, extracting Apple docs exploration into its own skill, and cleaning up the install surface around the top-level export model.

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.0.13"
+version = "6.0.14"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/shared/agents-snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/shared/agents-snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/shared/agents-snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/shared/agents-snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/apple-ui-accessibility-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/apple-ui-accessibility-workflow/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/assets/AGENTS.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/assets/AGENTS.md
@@ -33,6 +33,10 @@
 - Prefer the simplest correct Swift that is easiest to read, reason about, and maintain.
 - Treat idiomatic Swift and Cocoa-style naming conventions as tools in service of readability, not goals by themselves.
 - Prefer explicit, consistent, and unambiguous names.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact and concise code; use shorthand syntax and trailing-closure syntax when readability improves.
 - Do not add boilerplate, helper types, or extra layers just to make code look more architectural or more "Swifty".
 - Strongly prefer synthesized, implicit, and framework-provided behavior over handwritten setup code.

--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/references/snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/references/snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/assets/AGENTS.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/assets/AGENTS.md
@@ -12,6 +12,9 @@
 - Prefer Dash or local Apple docs first, then official Apple docs when local docs are insufficient.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer synthesized and framework-provided behavior over extra wrappers and boilerplate.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Keep data flow straight and dependency direction unidirectional.
 - Treat the `.xcworkspace` or `.xcodeproj` as the source of truth for app integration, schemes, and build settings.
 - Prefer Xcode-aware tooling or `xcodebuild` over ad hoc filesystem assumptions when project structure or target membership is involved.

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/explore-apple-swift-docs/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/explore-apple-swift-docs/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/explore-apple-swift-docs/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/explore-apple-swift-docs/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/format-swift-sources/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/format-swift-sources/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/swift-package-build-run-workflow/references/snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/skills/swift-package-build-run-workflow/references/snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/swift-package-testing-workflow/references/snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/skills/swift-package-testing-workflow/references/snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/swift-package-workflow/references/snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/skills/swift-package-workflow/references/snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/swiftui-app-architecture-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/swiftui-app-architecture-workflow/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/AGENTS.md
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/AGENTS.md
@@ -15,6 +15,9 @@
 - Prefer Dash or local Swift docs first, then official Swift or Apple docs when local docs are insufficient.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer synthesized and framework-provided behavior over extra wrappers and boilerplate.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Keep data flow straight and dependency direction unidirectional.
 - Treat `Package.swift` as the source of truth for package structure, targets, products, and dependencies.
 - Prefer `swift package` subcommands for structural package edits before manually editing `Package.swift`.

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/append-section.md
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/assets/append-section.md
@@ -13,6 +13,9 @@
 - Prefer Dash or local Swift docs first, then official Swift or Apple docs when local docs are insufficient.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer synthesized and framework-provided behavior over extra wrappers and boilerplate.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Keep data flow straight and dependency direction unidirectional.
 - Treat `Package.swift` as the source of truth for package structure, targets, products, and dependencies.
 - Prefer `swift package` subcommands for structural package edits before manually editing `Package.swift`.

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/references/snippets/apple-swift-package-core.md
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/references/snippets/apple-swift-package-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/AGENTS.md
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/AGENTS.md
@@ -14,6 +14,9 @@
 - Prefer Dash or local Apple docs first, then official Apple docs when local docs are insufficient.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer synthesized and framework-provided behavior over extra wrappers and boilerplate.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Keep data flow straight and dependency direction unidirectional.
 - Treat the `.xcworkspace` or `.xcodeproj` as the source of truth for app integration, schemes, and build settings.
 - Prefer Xcode-aware tooling or `xcodebuild` over ad hoc filesystem assumptions when project structure or target membership is involved.

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/append-section.md
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/assets/append-section.md
@@ -12,6 +12,9 @@
 - Prefer Dash or local Apple docs first, then official Apple docs when local docs are insufficient.
 - Prefer the simplest correct Swift that is easiest to read and reason about.
 - Prefer synthesized and framework-provided behavior over extra wrappers and boilerplate.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; prefer optional parameters with explicit default values over additional methods or overloads when the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Keep data flow straight and dependency direction unidirectional.
 - Treat the `.xcworkspace` or `.xcodeproj` as the source of truth for app integration, schemes, and build settings.
 - Prefer Xcode-aware tooling or `xcodebuild` over ad hoc filesystem assumptions when project structure or target membership is involved.

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-app-project-workflow/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-build-run-workflow/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/snippets/apple-swift-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/snippets/apple-swift-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want cross-project Swi
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/snippets/apple-xcode-project-core.md
@@ -28,6 +28,10 @@ Use this snippet in repository `AGENTS.md` files when you want baseline standard
 - Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
 - This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
 - Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
 - Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
 - Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
 - When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.0.13"
+version = "6.0.14"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.0.13"
+version = "6.0.14"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.0.13"
+version = "6.0.14"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.0.13"
+version = "6.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.0.13"
+version = "6.0.14"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- tighten apple-dev-skills public Swift API guidance around compact typed APIs, defaulted optional parameters, request/options structs, and enum-backed choices
- carry the guidance through shared snippets, skill-local snippet copies, full AGENTS templates, and append-section sync assets
- bump maintained socket version surfaces to 6.0.14

## Verification
- bash .github/scripts/validate_repo_docs.sh (plugins/apple-dev-skills)
- uv run pytest (plugins/apple-dev-skills, 130 passed)
- uv run scripts/validate_socket_metadata.py
- scripts/release.sh inventory