### PR TITLE
plugin: add project API maintenance skill

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,6 +78,7 @@ No active backlog candidates are currently tracked here. Add new candidates only
 ## History
 
 - Completed the subtree workflow and release-discipline milestones by adding the root marketplace audit pass, the public child plugin removal checklist, and a tighter roadmap state that no longer carries stale backlog items as active work.
+- Prepared the `v6.1.0` minor release by adding the `maintain-project-api` productivity skill and keeping the monorepo-owned child docs, tests, and shared version surfaces aligned.
 - Added explicit `standard` and `subtrees` release-mode guidance, including the pull-only `SpeakSwiftlyServer` rule for `socket` subtree sync.
 - Published `apple-dev-skills` `v6.0.11` after adding direct regression coverage for SwiftPM-generated `.swiftpm/xcode/package.xcworkspace` classification and synced the released child state back into `socket`.
 - Prepared the shared `v6.0.11` patch release after fixing `productivity-skills:maintain-project-repo` release-helper regressions for initial PR check discovery and approval-only review handling.

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.0.15"
+version = "6.1.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.0.15"
+version = "6.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/README.md
+++ b/plugins/productivity-skills/README.md
@@ -78,6 +78,7 @@ See [LICENSE](./LICENSE).
 - `explain-code-slice`
 - `maintain-project-agents`
 - `maintain-project-accessibility`
+- `maintain-project-api`
 - `maintain-project-contributing`
 - `maintain-project-readme`
 - `maintain-project-repo`

--- a/plugins/productivity-skills/ROADMAP.md
+++ b/plugins/productivity-skills/ROADMAP.md
@@ -27,7 +27,7 @@
 - Milestone 14: Claude Code optimization pass - Planned
 - Milestone 22: Accessibility maintenance baseline - Planned
 - Milestone 23: Security and support maintenance baseline - Planned
-- Milestone 24: API maintenance baseline - In Progress
+- Milestone 24: API maintenance baseline - Completed
 
 ## Milestone 14: Claude Code optimization pass
 
@@ -110,25 +110,27 @@ Planned
 
 ### Status
 
-In Progress
+Completed
 
 ### Scope
 
-- [ ] Add a new `maintain-project-api` baseline skill for canonical `API.md` maintenance.
-- [ ] Define `API.md` as the repo-local API contract document for surface area, access, request and response shapes, errors, compatibility, local verification, and ownership.
-- [ ] Keep the skill aligned with the existing docs-maintenance family so API references can be audited and normalized with deterministic `check-only` and bounded `apply` workflow modes.
+- [x] Add a new `maintain-project-api` baseline skill for canonical `API.md` maintenance.
+- [x] Define `API.md` as the repo-local API contract document for surface area, access, request and response shapes, errors, compatibility, local verification, and ownership.
+- [x] Keep the skill aligned with the existing docs-maintenance family so API references can be audited and normalized with deterministic `check-only` and bounded `apply` workflow modes.
 
 ### Tickets
 
-- [ ] Draft and ship the `maintain-project-api` skill surface with template, config, script, references, and tests.
-- [ ] Define and validate the canonical `API.md` schema, including surface, auth, schemas, errors, versioning, verification, and support ownership sections.
-- [ ] Add claim-integrity guardrails so the workflow does not invent endpoints, schemas, credentials, permissions, version guarantees, or support paths.
-- [ ] Update repo-level maintainer docs and active-skill inventory once the new skill is implemented.
+- [x] Draft and ship the `maintain-project-api` skill surface with template, config, script, references, and tests.
+- [x] Define and validate the canonical `API.md` schema, including surface, auth, schemas, errors, versioning, verification, and support ownership sections.
+- [x] Add claim-integrity guardrails so the workflow does not invent endpoints, schemas, credentials, permissions, version guarantees, or support paths.
+- [x] Update repo-level maintainer docs and active-skill inventory once the new skill is implemented.
 
 ### Exit Criteria
 
-- [ ] The repository ships a working `maintain-project-api` skill with deterministic `check-only` and bounded `apply` behavior.
-- [ ] The canonical `API.md` contract is documented, test-covered, and grounded in the baseline maintainers' workflow family.
+- [x] The repository ships a working `maintain-project-api` skill with deterministic `check-only` and bounded `apply` behavior.
+- [x] The canonical `API.md` contract is documented, test-covered, and grounded in the baseline maintainers' workflow family.
+
+Completed Milestone 24 by adding `maintain-project-api` as a template-backed `API.md` maintenance workflow with check/apply modes, schema references, OpenAI metadata, and regression coverage for clean missing-file creation.
 
 ## Backlog Candidates
 
@@ -138,6 +140,7 @@ In Progress
 ## History
 
 - Fixed `maintain-project-repo` standard release handling so new release PRs wait for initial GitHub checks before watching CI, approval-only reviews no longer count as unresolved review comments, and release tags are created only after CI and the review-comment gate pass.
+- Added `maintain-project-api` as the baseline `API.md` maintenance skill for API surface, access, schema, error, compatibility, verification, and support ownership docs.
 - Clarified that the managed repo-maintenance workflow exposes `validate` as the branch-protection check context, avoiding blocked PRs caused by requiring the workflow-title display string instead.
 - Completed Milestones 0 through 11 by refactoring the naming and structure, splitting README and roadmap maintenance into dedicated skills, restoring `explain-code-slice`, and aligning the repository around the current plugin-ready packaging model.
 - Completed Milestones 12 and 13 by moving the agent-stack maintainer bootstrap and guidance-sync workflows into `agent-plugin-skills`.

--- a/plugins/productivity-skills/ROADMAP.md
+++ b/plugins/productivity-skills/ROADMAP.md
@@ -8,6 +8,7 @@
 - [Milestone 14: Claude Code optimization pass](#milestone-14-claude-code-optimization-pass)
 - [Milestone 22: Accessibility maintenance baseline](#milestone-22-accessibility-maintenance-baseline)
 - [Milestone 23: Security and support maintenance baseline](#milestone-23-security-and-support-maintenance-baseline)
+- [Milestone 24: API maintenance baseline](#milestone-24-api-maintenance-baseline)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -26,6 +27,7 @@
 - Milestone 14: Claude Code optimization pass - Planned
 - Milestone 22: Accessibility maintenance baseline - Planned
 - Milestone 23: Security and support maintenance baseline - Planned
+- Milestone 24: API maintenance baseline - In Progress
 
 ## Milestone 14: Claude Code optimization pass
 
@@ -103,6 +105,30 @@ Planned
 - [ ] The repository ships a working `maintain-project-security` skill with deterministic `check-only` and bounded `apply` behavior.
 - [ ] The repository ships a working `maintain-project-support` skill with deterministic `check-only` and bounded `apply` behavior.
 - [ ] The canonical `SECURITY.md` and `SUPPORT.md` contracts are documented, test-covered, and grounded in the baseline maintainers' workflow family.
+
+## Milestone 24: API maintenance baseline
+
+### Status
+
+In Progress
+
+### Scope
+
+- [ ] Add a new `maintain-project-api` baseline skill for canonical `API.md` maintenance.
+- [ ] Define `API.md` as the repo-local API contract document for surface area, access, request and response shapes, errors, compatibility, local verification, and ownership.
+- [ ] Keep the skill aligned with the existing docs-maintenance family so API references can be audited and normalized with deterministic `check-only` and bounded `apply` workflow modes.
+
+### Tickets
+
+- [ ] Draft and ship the `maintain-project-api` skill surface with template, config, script, references, and tests.
+- [ ] Define and validate the canonical `API.md` schema, including surface, auth, schemas, errors, versioning, verification, and support ownership sections.
+- [ ] Add claim-integrity guardrails so the workflow does not invent endpoints, schemas, credentials, permissions, version guarantees, or support paths.
+- [ ] Update repo-level maintainer docs and active-skill inventory once the new skill is implemented.
+
+### Exit Criteria
+
+- [ ] The repository ships a working `maintain-project-api` skill with deterministic `check-only` and bounded `apply` behavior.
+- [ ] The canonical `API.md` contract is documented, test-covered, and grounded in the baseline maintainers' workflow family.
 
 ## Backlog Candidates
 

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
 testpaths = [
   "skills/maintain-project-agents/tests",
   "skills/maintain-project-accessibility/tests",
+  "skills/maintain-project-api/tests",
   "skills/maintain-project-readme/tests",
   "skills/maintain-project-contributing/tests",
   "skills/maintain-project-roadmap/tests",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/skills/maintain-project-api/SKILL.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: maintain-project-api
+description: Maintain canonical API.md files through deterministic audit and bounded apply modes. Use when a project API reference needs auditing, normalization, or bounded fixes for API surface, authentication, request and response schemas, errors, versioning, compatibility, local verification, or support guidance. This is the default baseline API.md workflow for most repos unless a narrower plugin owns that repo shape.
+---
+
+# Maintain Project API
+
+Maintain canonical `API.md` files through one deterministic API-reference workflow.
+
+This skill is the default baseline path for `API.md` maintenance across most repositories. Reach for a narrower plugin only when the target repo has a specialized shape that deserves its own maintainer contract, such as a skills-export or plugin-export repository.
+
+## Inputs
+
+- Required: `--project-root <path>`
+- Required: `--run-mode <check-only|apply>`
+- Optional: `--api-path <path>`
+- Optional: `--config <path>`
+
+## Workflow
+
+1. Validate the project root and resolve the target `API.md`.
+2. Load the canonical API-reference schema from `config/api-customization.template.yaml`, then merge any explicit override or project-local customization file.
+3. In `check-only`, audit the required section schema, required subsection schema, required table of contents, placeholder content, and verification-command formatting.
+4. In `apply`, keep edits bounded to the target `API.md` while creating a missing file from the bundled template and normalizing the document to the canonical structure.
+5. Re-run the same audit to confirm post-fix status.
+
+## Canonical Base Contract
+
+The source of truth for the base API-reference contract lives in:
+
+- `config/api-customization.template.yaml`
+- `assets/API.template.md`
+
+The base contract requires:
+
+- a top-level title and short summary
+- a required `## Table of Contents`
+- canonical top-level sections for overview, API surface, authentication and access, requests and responses, errors, versioning and compatibility, local development and verification, and support ownership
+- required subsection structure for the sections that need stable consumer-facing detail
+
+## Writing Expectations
+
+- `Overview > Who This API Is For` should name the real consumers: humans, services, tools, packages, apps, or maintainers.
+- `Overview > Stability Status` should say whether the API is stable, experimental, internal, deprecated, or otherwise constrained.
+- `API Surface` should list concrete entry points and the protocol, transport, runtime, package interface, or file format used to reach each one.
+- `Authentication and Access` should describe credentials and permissions without inventing secrets, scopes, roles, or access paths.
+- `Requests and Responses` should document grounded request inputs, response outputs, and data models.
+- `Errors` should make failures actionable by documenting the error shape and common failure modes with likely causes or next checks.
+- `Versioning and Compatibility` should make the supported compatibility window and breaking-change handling explicit.
+- `Local Development and Verification > Verification` should prefer fenced commands or reproducible call examples with language info strings.
+- `Support and Ownership` should name only grounded teams, maintainers, issue trackers, services, or escalation paths.
+
+## Output Contract
+
+- Return Markdown plus JSON with:
+  - `run_context`
+  - `schema_contract`
+  - `schema_violations`
+  - `command_integrity_issues`
+  - `content_quality_issues`
+  - `fixes_applied`
+  - `post_fix_status`
+  - `errors`
+- If there are no issues and no errors, output exactly `No findings.`
+
+## Guardrails
+
+- Never auto-commit, auto-push, or open a PR.
+- Never invent commands, endpoints, protocols, schemas, environment variables, credentials, permissions, version guarantees, support paths, or compatibility promises that are not grounded in the repo.
+- Never edit files other than the target `API.md`.
+- Keep `API.md` as the canonical API-reference filename for this skill.
+- Treat this skill as a hard-enforced base template. Downstream plugins may specialize the schema, but the base skill should not do repo-profile inference.
+
+## References
+
+- `agents/openai.yaml`
+- `references/section-schema.md`
+- `references/output-contract.md`
+- `references/fix-policies.md`
+- `references/style-rules.md`
+- `references/api-customization.md`
+- `references/api-config-schema.md`
+- `references/project-api-maintenance-automation-prompts.md`

--- a/plugins/productivity-skills/skills/maintain-project-api/agents/openai.yaml
+++ b/plugins/productivity-skills/skills/maintain-project-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maintain Project API"
+  short_description: "Audit and apply bounded fixes to canonical API.md files."
+  default_prompt: "Use $maintain-project-api for an ordinary software-project API.md. Load the template-backed API-reference schema first, enforce the required table of contents and canonical section structure, return audit findings in check-only mode, and in apply mode keep edits bounded to grounded API surface, request, response, error, versioning, verification, and support guidance only."

--- a/plugins/productivity-skills/skills/maintain-project-api/assets/API.template.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/assets/API.template.md
@@ -1,0 +1,83 @@
+# API Reference for {{PROJECT_NAME}}
+
+Use this reference to understand the public API surface, how to call it, what it returns, and how to verify behavior locally.
+
+## Table of Contents
+
+## Overview
+
+### Who This API Is For
+
+Explain which humans, services, tools, packages, or apps are expected to consume this API.
+
+### Stability Status
+
+State whether the API is stable, experimental, internal, deprecated, or otherwise constrained.
+
+## API Surface
+
+### Entry Points
+
+List the public routes, commands, functions, resources, files, modules, or other callable entry points that belong in this API contract.
+
+### Protocols and Transports
+
+Document the concrete protocol, transport, runtime, package interface, or file format used by each entry point.
+
+## Authentication and Access
+
+### Credentials
+
+Document the tokens, secrets, sessions, certificates, local permissions, or unauthenticated access model needed to call the API.
+
+### Permissions
+
+Document the scopes, roles, local capabilities, repository permissions, or service privileges required for successful calls.
+
+## Requests and Responses
+
+### Request Shape
+
+Describe the required request fields, parameters, headers, body structure, input files, command arguments, or function inputs.
+
+### Response Shape
+
+Describe the returned fields, status values, output files, generated artifacts, events, or function return values.
+
+### Data Models
+
+Define the important payload objects, records, enums, resource identifiers, schemas, and persistence-backed structures that API consumers need to understand.
+
+## Errors
+
+### Error Shape
+
+Document the structured error format, exit-code behavior, thrown error types, HTTP status mapping, log surface, or diagnostic output API consumers will see.
+
+### Common Failure Modes
+
+Call out the common, actionable failure modes and the most likely cause or next diagnostic step for each one.
+
+## Versioning and Compatibility
+
+### Supported Versions
+
+State the supported API versions, package versions, protocol versions, endpoint revisions, or documented compatibility window.
+
+### Breaking Changes
+
+Explain how breaking changes are announced, documented, migrated, or intentionally not supported.
+
+## Local Development and Verification
+
+### Runtime Configuration
+
+Document the concrete local config files, environment variables, feature flags, local services, fixtures, or seed data needed to exercise the API.
+
+### Verification
+
+Prefer grounded commands or reproducible call examples with fenced code blocks and language info strings when examples help API consumers verify behavior.
+
+## Support and Ownership
+
+Name the team, maintainer, service, issue tracker, or documented escalation path that API consumers should use when the API contract is unclear or broken.

--- a/plugins/productivity-skills/skills/maintain-project-api/config/api-customization.template.yaml
+++ b/plugins/productivity-skills/skills/maintain-project-api/config/api-customization.template.yaml
@@ -1,0 +1,154 @@
+schemaVersion: 1
+isCustomized: false
+profile: base
+settings:
+  preservePreamble: true
+  allowAdditionalSections: true
+  requiredSections:
+    - Overview
+    - API Surface
+    - Authentication and Access
+    - Requests and Responses
+    - Errors
+    - Versioning and Compatibility
+    - Local Development and Verification
+    - Support and Ownership
+  sectionOrder:
+    - Overview
+    - API Surface
+    - Authentication and Access
+    - Requests and Responses
+    - Errors
+    - Versioning and Compatibility
+    - Local Development and Verification
+    - Support and Ownership
+  requiredSubsections:
+    Overview:
+      - Who This API Is For
+      - Stability Status
+    API Surface:
+      - Entry Points
+      - Protocols and Transports
+    Authentication and Access:
+      - Credentials
+      - Permissions
+    Requests and Responses:
+      - Request Shape
+      - Response Shape
+      - Data Models
+    Errors:
+      - Error Shape
+      - Common Failure Modes
+    Versioning and Compatibility:
+      - Supported Versions
+      - Breaking Changes
+    Local Development and Verification:
+      - Runtime Configuration
+      - Verification
+  sectionAliases:
+    API Surface:
+      - Endpoints
+      - Public API
+      - Interface
+    Authentication and Access:
+      - Authentication
+      - Authorization
+      - Access
+    Requests and Responses:
+      - Payloads
+      - Schemas
+      - Request and Response Shapes
+    Errors:
+      - Error Handling
+    Versioning and Compatibility:
+      - Compatibility
+      - Versioning
+    Local Development and Verification:
+      - Local Setup
+      - Development
+      - Verification
+    Support and Ownership:
+      - Support
+      - Ownership
+  subsectionAliases:
+    Overview/Who This API Is For:
+      - Audience
+      - Consumers
+    Overview/Stability Status:
+      - Stability
+      - Status
+    API Surface/Entry Points:
+      - Routes
+      - Endpoints
+    API Surface/Protocols and Transports:
+      - Protocols
+      - Transports
+    Authentication and Access/Credentials:
+      - Authentication
+      - Secrets
+    Authentication and Access/Permissions:
+      - Authorization
+      - Scopes
+    Requests and Responses/Request Shape:
+      - Requests
+      - Request Format
+    Requests and Responses/Response Shape:
+      - Responses
+      - Response Format
+    Requests and Responses/Data Models:
+      - Schemas
+      - Models
+    Errors/Error Shape:
+      - Error Format
+    Errors/Common Failure Modes:
+      - Failure Modes
+      - Common Errors
+    Versioning and Compatibility/Supported Versions:
+      - Versions
+      - Supported API Versions
+    Versioning and Compatibility/Breaking Changes:
+      - Compatibility Notes
+      - Migration Notes
+    Local Development and Verification/Runtime Configuration:
+      - Runtime Config
+      - Configuration
+    Local Development and Verification/Verification:
+      - Validation
+  sectionTemplates:
+    Support and Ownership: |
+      Name the team, maintainer, service, issue tracker, or documented escalation path that API consumers should use when the API contract is unclear or broken.
+  subsectionTemplates:
+    Overview/Who This API Is For: |
+      Explain which humans, services, tools, packages, or apps are expected to consume this API.
+    Overview/Stability Status: |
+      State whether the API is stable, experimental, internal, deprecated, or otherwise constrained.
+    API Surface/Entry Points: |
+      List the public routes, commands, functions, resources, files, modules, or other callable entry points that belong in this API contract.
+    API Surface/Protocols and Transports: |
+      Document the concrete protocol, transport, runtime, package interface, or file format used by each entry point.
+    Authentication and Access/Credentials: |
+      Document the tokens, secrets, sessions, certificates, local permissions, or unauthenticated access model needed to call the API.
+    Authentication and Access/Permissions: |
+      Document the scopes, roles, local capabilities, repository permissions, or service privileges required for successful calls.
+    Requests and Responses/Request Shape: |
+      Describe the required request fields, parameters, headers, body structure, input files, command arguments, or function inputs.
+    Requests and Responses/Response Shape: |
+      Describe the returned fields, status values, output files, generated artifacts, events, or function return values.
+    Requests and Responses/Data Models: |
+      Define the important payload objects, records, enums, resource identifiers, schemas, and persistence-backed structures that API consumers need to understand.
+    Errors/Error Shape: |
+      Document the structured error format, exit-code behavior, thrown error types, HTTP status mapping, log surface, or diagnostic output API consumers will see.
+    Errors/Common Failure Modes: |
+      Call out the common, actionable failure modes and the most likely cause or next diagnostic step for each one.
+    Versioning and Compatibility/Supported Versions: |
+      State the supported API versions, package versions, protocol versions, endpoint revisions, or documented compatibility window.
+    Versioning and Compatibility/Breaking Changes: |
+      Explain how breaking changes are announced, documented, migrated, or intentionally not supported.
+    Local Development and Verification/Runtime Configuration: |
+      Document the concrete local config files, environment variables, feature flags, local services, fixtures, or seed data needed to exercise the API.
+    Local Development and Verification/Verification: |
+      ```bash
+      # Replace this with the grounded validation commands for the project.
+      ```
+
+      Prefer grounded commands or reproducible call examples with fenced code blocks and language info strings when examples help API consumers verify behavior.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/api-config-schema.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/api-config-schema.md
@@ -1,0 +1,28 @@
+# API Config Schema
+
+The API-reference configuration file is YAML and uses this top-level shape:
+
+- `schemaVersion`
+- `isCustomized`
+- `profile`
+- `settings`
+
+The `settings` map supports:
+
+- `preservePreamble`
+- `allowAdditionalSections`
+- `requiredSections`
+- `sectionOrder`
+- `requiredSubsections`
+- `sectionAliases`
+- `subsectionAliases`
+- `sectionTemplates`
+- `subsectionTemplates`
+
+Practical rules:
+
+- `requiredSections` defines the canonical top-level sections, excluding the title, summary, and `Table of Contents`.
+- `sectionOrder` defines the enforced top-level ordering.
+- `requiredSubsections` defines required `###` headings under specific `##` sections.
+- `sectionAliases` and `subsectionAliases` allow bounded migration from older heading names into canonical names.
+- `sectionTemplates` and `subsectionTemplates` provide the base scaffolding used during apply mode when content is missing.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/api-customization.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/api-customization.md
@@ -1,0 +1,19 @@
+# API Customization
+
+The base API-reference contract is defined in `../config/api-customization.template.yaml`.
+
+Downstream specializations may customize:
+
+- canonical section order
+- required sections
+- required subsection structure
+- section and subsection aliases
+- section and subsection scaffold text
+
+The base skill always requires:
+
+- a top-level title and short summary
+- a `Table of Contents`
+- deterministic normalization to the configured schema
+
+Use a project-local `config/api-customization.yaml` or `--config <path>` override when a downstream plugin needs a narrower or expanded API reference structure.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/fix-policies.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/fix-policies.md
@@ -1,0 +1,8 @@
+# Fix Policies
+
+- Keep edits bounded to the target `API.md`.
+- Preserve existing section bodies whenever they already satisfy the schema.
+- Create a missing `API.md` from the bundled template.
+- Normalize canonical headings and subsection headings to the configured names and order.
+- Add missing sections or subsections from the configured templates instead of inventing repo-fiction.
+- Do not synthesize endpoints, field names, schemas, environment variable names, service names, credential names, permissions, version guarantees, support paths, or compatibility promises.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/output-contract.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/output-contract.md
@@ -1,0 +1,16 @@
+# Output Contract
+
+Return Markdown plus JSON with:
+
+- `run_context`
+- `schema_contract`
+- `schema_violations`
+- `command_integrity_issues`
+- `content_quality_issues`
+- `fixes_applied`
+- `post_fix_status`
+- `errors`
+
+Clean-run rule:
+
+- Output exactly `No findings.` only when there are no remaining issues and no errors.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/project-api-maintenance-automation-prompts.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/project-api-maintenance-automation-prompts.md
@@ -1,0 +1,18 @@
+# Automation Prompts
+
+Use these prompts when validating or applying the skill through automation.
+
+## Check-only
+
+- Audit `API.md` for the canonical section order.
+- Confirm the required table of contents is present and matches the canonical top-level headings.
+- Confirm sections with required subsections contain the configured `###` headings.
+- Flag placeholder content and malformed or weak verification command blocks.
+
+## Apply
+
+- Create a missing `API.md` from the bundled template.
+- Normalize `API.md` to the canonical section order.
+- Preserve existing API reference guidance where it already matches the schema.
+- Add missing sections or subsections from the configured templates only.
+- Keep all edits bounded to `API.md`.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/section-schema.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/section-schema.md
@@ -1,0 +1,52 @@
+# Section Schema
+
+The canonical base `API.md` structure is defined by:
+
+- `../config/api-customization.template.yaml`
+- `../assets/API.template.md`
+
+Base top-level shape:
+
+1. top-level title
+2. short API-consumer-facing summary
+3. `## Table of Contents`
+4. `## Overview`
+5. `## API Surface`
+6. `## Authentication and Access`
+7. `## Requests and Responses`
+8. `## Errors`
+9. `## Versioning and Compatibility`
+10. `## Local Development and Verification`
+11. `## Support and Ownership`
+
+Required subsection shape:
+
+- `Overview`
+  - `Who This API Is For`
+  - `Stability Status`
+- `API Surface`
+  - `Entry Points`
+  - `Protocols and Transports`
+- `Authentication and Access`
+  - `Credentials`
+  - `Permissions`
+- `Requests and Responses`
+  - `Request Shape`
+  - `Response Shape`
+  - `Data Models`
+- `Errors`
+  - `Error Shape`
+  - `Common Failure Modes`
+- `Versioning and Compatibility`
+  - `Supported Versions`
+  - `Breaking Changes`
+- `Local Development and Verification`
+  - `Runtime Configuration`
+  - `Verification`
+
+Schema expectations:
+
+- Use `##` headings for top-level sections.
+- Use `###` headings for required subsections.
+- Always include a top-level `Table of Contents`.
+- Preserve additional repo-specific sections when present, but keep canonical sections in canonical order.

--- a/plugins/productivity-skills/skills/maintain-project-api/references/style-rules.md
+++ b/plugins/productivity-skills/skills/maintain-project-api/references/style-rules.md
@@ -1,0 +1,10 @@
+# Style Rules
+
+- Keep API reference guidance direct, concrete, and repo-grounded.
+- Favor short explanatory paragraphs plus small bullet lists when they improve scanability.
+- Treat `API.md` as a public-interface contract, not as a product overview, implementation narrative, or contributor guide.
+- Keep `API Surface` concrete enough that a consumer can find the callable entry points without reverse-engineering the repo.
+- Keep `Requests and Responses` grounded in real fields, arguments, files, commands, return values, or generated artifacts.
+- Keep `Errors` actionable: explain what the caller sees and the most likely next diagnostic step.
+- Keep `Local Development and Verification` operational and practical, with reproducible commands or call examples when they are known.
+- Prefer fenced code blocks with language info strings when showing verification commands or API call examples.

--- a/plugins/productivity-skills/skills/maintain-project-api/scripts/maintain_project_api.py
+++ b/plugins/productivity-skills/skills/maintain-project-api/scripts/maintain_project_api.py
@@ -625,18 +625,15 @@ def apply_fixes(
     api_text: str,
     config: Dict[str, object],
 ) -> Tuple[str, List[Dict[str, str]]]:
+    fixes: List[Dict[str, str]] = []
     if not api_text.strip():
-        bootstrap = render_template_bootstrap(project_root)
-        write_text(api_path, bootstrap)
-        return (
-            bootstrap,
-            [
-                {
-                    "action": "create-api-from-template",
-                    "file": str(api_path),
-                    "reason": "Created a missing API.md from the bundled canonical template.",
-                }
-            ],
+        api_text = render_template_bootstrap(project_root)
+        fixes.append(
+            {
+                "action": "create-api-from-template",
+                "file": str(api_path),
+                "reason": "Created a missing API.md from the bundled canonical template.",
+            }
         )
 
     settings = config_settings(config)
@@ -676,13 +673,14 @@ def apply_fixes(
     for heading, body in rendered_sections:
         parts.extend(["", f"## {heading}", "", body.strip()])
     document = "\n".join(parts).strip() + "\n"
-    return normalize_whitespace(document), [
+    fixes.append(
         {
             "action": "normalize-api-structure",
             "file": str(api_path),
             "reason": "Normalized API.md to the canonical template-backed section schema.",
         }
-    ]
+    )
+    return normalize_whitespace(document), fixes
 
 
 def format_report(report: Dict[str, object]) -> str:

--- a/plugins/productivity-skills/skills/maintain-project-api/scripts/maintain_project_api.py
+++ b/plugins/productivity-skills/skills/maintain-project-api/scripts/maintain_project_api.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "PyYAML>=6.0.2,<7",
+# ]
+# ///
+"""Audit and apply bounded API.md maintenance from a hard-enforced schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import yaml
+
+H2_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+H3_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+SHELL_FENCE_RE = re.compile(r"```([^\n`]*)\n(.*?)```", re.DOTALL)
+PLACEHOLDER_PATTERNS = [
+    re.compile(r"\bTODO\b", re.IGNORECASE),
+    re.compile(r"\bTBD\b", re.IGNORECASE),
+    re.compile(r"<[^>]+>"),
+]
+
+
+@dataclass
+class Issue:
+    issue_id: str
+    category: str
+    severity: str
+    file: str
+    evidence: str
+    recommended_fix: str
+    auto_fixable: bool
+    fixed: bool = False
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "issue_id": self.issue_id,
+            "category": self.category,
+            "severity": self.severity,
+            "file": self.file,
+            "evidence": self.evidence,
+            "recommended_fix": self.recommended_fix,
+            "auto_fixable": self.auto_fixable,
+            "fixed": self.fixed,
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit and optionally apply bounded API.md maintenance from a hard-enforced schema."
+    )
+    parser.add_argument("--project-root", required=True, help="Absolute project root path")
+    parser.add_argument("--api-path", help="Optional API path override")
+    parser.add_argument("--run-mode", required=True, choices=["check-only", "apply"], help="Execution mode")
+    parser.add_argument("--config", help="Optional API config override")
+    parser.add_argument("--json-out", help="Write JSON report path")
+    parser.add_argument("--md-out", help="Write markdown report path")
+    parser.add_argument("--print-json", action="store_true", help="Print JSON report")
+    parser.add_argument("--print-md", action="store_true", help="Print markdown report")
+    parser.add_argument("--fail-on-issues", action="store_true", help="Exit non-zero when unresolved issues remain")
+    return parser.parse_args()
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def normalize_whitespace(text: str) -> str:
+    return text.strip() + "\n"
+
+
+def slugify_heading(heading: str) -> str:
+    slug = heading.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug)
+    return slug
+
+
+def split_sections(text: str) -> Tuple[str, List[Tuple[str, str]]]:
+    matches = list(H2_RE.finditer(text))
+    if not matches:
+        return text.strip(), []
+
+    preamble = text[: matches[0].start()].rstrip()
+    sections: List[Tuple[str, str]] = []
+    for idx, match in enumerate(matches):
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+        sections.append((match.group(1).strip(), text[start:end].strip("\n")))
+    return preamble, sections
+
+
+def split_subsections(body: str) -> Tuple[str, List[Tuple[str, str]]]:
+    matches = list(H3_RE.finditer(body))
+    if not matches:
+        return body.strip(), []
+
+    preamble = body[: matches[0].start()].strip()
+    subsections: List[Tuple[str, str]] = []
+    for idx, match in enumerate(matches):
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(body)
+        subsections.append((match.group(1).strip(), body[start:end].strip("\n")))
+    return preamble, subsections
+
+
+def section_map(sections: Sequence[Tuple[str, str]]) -> Dict[str, str]:
+    return {heading: body for heading, body in sections}
+
+
+def parse_title_and_summary(preamble: str) -> Tuple[Optional[str], Optional[str], List[str]]:
+    lines = [line.rstrip() for line in preamble.splitlines()]
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    extras: List[str] = []
+    title_index: Optional[int] = None
+    summary_index: Optional[int] = None
+
+    for idx, line in enumerate(lines):
+        if line.startswith("# "):
+            title = line[2:].strip()
+            title_index = idx
+            break
+
+    if title_index is None:
+        return None, None, lines
+
+    for idx in range(title_index + 1, len(lines)):
+        if lines[idx].strip():
+            summary = lines[idx].strip()
+            summary_index = idx
+            break
+
+    for idx, line in enumerate(lines):
+        if idx in {title_index, summary_index}:
+            continue
+        extras.append(line)
+
+    return title, summary, extras
+
+
+def collapse_blank_lines(lines: Sequence[str]) -> List[str]:
+    collapsed: List[str] = []
+    previous_blank = False
+    for line in lines:
+        blank = line.strip() == ""
+        if blank and previous_blank:
+            continue
+        collapsed.append(line)
+        previous_blank = blank
+    while collapsed and collapsed[0].strip() == "":
+        collapsed.pop(0)
+    while collapsed and collapsed[-1].strip() == "":
+        collapsed.pop()
+    return collapsed
+
+
+def normalize_preamble(preamble: str, project_name: str, preserve_preamble: bool) -> str:
+    title, summary, extras = parse_title_and_summary(preamble)
+    normalized_title = title or f"API Reference for {project_name}"
+    normalized_summary = (
+        summary
+        or "Use this reference to understand the public API surface, how to call it, what it returns, and how to verify behavior locally."
+    )
+    lines = [f"# {normalized_title}", "", normalized_summary]
+    if preserve_preamble:
+        extra_lines = collapse_blank_lines(extras)
+        if extra_lines:
+            lines.extend(["", *extra_lines])
+    return "\n".join(lines).strip()
+
+
+def read_yaml(path: Path) -> Dict[str, object]:
+    data = yaml.safe_load(read_text(path))
+    return data if isinstance(data, dict) else {}
+
+
+def deep_merge(base: Dict[str, object], override: Dict[str, object]) -> Dict[str, object]:
+    merged: Dict[str, object] = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = deep_merge(merged[key], value)  # type: ignore[arg-type]
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_config(project_root: Path, config_override: Optional[str]) -> Dict[str, object]:
+    default_path = Path(__file__).resolve().parents[1] / "config" / "api-customization.template.yaml"
+    default_config = read_yaml(default_path)
+    loaded_path = default_path
+
+    if config_override:
+        override_path = Path(config_override).expanduser().resolve()
+        merged = deep_merge(default_config, read_yaml(override_path))
+        merged["isCustomized"] = True
+        merged["configPath"] = str(override_path)
+        merged["defaultConfigPath"] = str(default_path)
+        return merged
+
+    project_config = project_root / "config" / "api-customization.yaml"
+    if project_config.is_file():
+        loaded_path = project_config
+        merged = deep_merge(default_config, read_yaml(project_config))
+        merged["isCustomized"] = True
+    else:
+        merged = dict(default_config)
+        merged["isCustomized"] = bool(default_config.get("isCustomized", False))
+
+    merged["configPath"] = str(loaded_path)
+    merged["defaultConfigPath"] = str(default_path)
+    return merged
+
+
+def config_settings(config: Dict[str, object]) -> Dict[str, object]:
+    settings = config.get("settings", {})
+    return settings if isinstance(settings, dict) else {}
+
+
+def required_sections(settings: Dict[str, object]) -> List[str]:
+    values = settings.get("requiredSections", [])
+    return [str(item) for item in values] if isinstance(values, list) else []
+
+
+def canonical_order(settings: Dict[str, object]) -> List[str]:
+    values = settings.get("sectionOrder", [])
+    return [str(item) for item in values] if isinstance(values, list) else []
+
+
+def required_subsections(settings: Dict[str, object]) -> Dict[str, List[str]]:
+    raw = settings.get("requiredSubsections", {})
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): [str(item) for item in value]
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
+
+
+def section_aliases(settings: Dict[str, object]) -> Dict[str, List[str]]:
+    raw = settings.get("sectionAliases", {})
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): [str(item) for item in value]
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
+
+
+def subsection_aliases(settings: Dict[str, object]) -> Dict[str, List[str]]:
+    raw = settings.get("subsectionAliases", {})
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key): [str(item) for item in value]
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
+
+
+def section_templates(settings: Dict[str, object]) -> Dict[str, str]:
+    raw = settings.get("sectionTemplates", {})
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value).strip() for key, value in raw.items()}
+
+
+def subsection_templates(settings: Dict[str, object]) -> Dict[str, str]:
+    raw = settings.get("subsectionTemplates", {})
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value).strip() for key, value in raw.items()}
+
+
+def build_toc(headings: Sequence[str]) -> str:
+    return "\n".join(f"- [{heading}](#{slugify_heading(heading)})" for heading in headings)
+
+
+def toc_entries(body: str) -> List[str]:
+    entries: List[str] = []
+    for line in body.splitlines():
+        match = re.match(r"^\s*-\s+\[(.+?)\]\(#(.+?)\)\s*$", line.strip())
+        if match:
+            entries.append(match.group(1).strip())
+    return entries
+
+
+def section_alias_lookup(settings: Dict[str, object]) -> Dict[str, str]:
+    reverse: Dict[str, str] = {}
+    for canonical, aliases in section_aliases(settings).items():
+        for alias in aliases:
+            reverse[alias] = canonical
+    return reverse
+
+
+def subsection_alias_lookup(settings: Dict[str, object]) -> Dict[Tuple[str, str], str]:
+    reverse: Dict[Tuple[str, str], str] = {}
+    for canonical_path, aliases in subsection_aliases(settings).items():
+        if "/" not in canonical_path:
+            continue
+        parent, canonical_name = canonical_path.split("/", 1)
+        for alias in aliases:
+            reverse[(parent, alias)] = canonical_name
+    return reverse
+
+
+def render_template_bootstrap(project_root: Path) -> str:
+    template_path = Path(__file__).resolve().parents[1] / "assets" / "API.template.md"
+    template = read_text(template_path)
+    return normalize_whitespace(template.replace("{{PROJECT_NAME}}", project_root.name))
+
+
+def render_section_body(heading: str, existing_body: str, settings: Dict[str, object]) -> str:
+    required_children = required_subsections(settings).get(heading, [])
+    section_template_map = section_templates(settings)
+    subsection_template_map = subsection_templates(settings)
+    subsection_alias_map = subsection_alias_lookup(settings)
+
+    if not required_children:
+        return existing_body.strip() or section_template_map.get(heading, "")
+
+    preamble, subsections = split_subsections(existing_body)
+    subsection_lookup: Dict[str, str] = {}
+    extra_subsections: List[Tuple[str, str]] = []
+    for name, body in subsections:
+        canonical_name = subsection_alias_map.get((heading, name), name)
+        if canonical_name in required_children and canonical_name not in subsection_lookup:
+            subsection_lookup[canonical_name] = body
+        else:
+            extra_subsections.append((name, body))
+
+    lines: List[str] = []
+    if preamble.strip():
+        lines.extend([preamble.strip(), ""])
+
+    for idx, child in enumerate(required_children):
+        child_body = subsection_lookup.get(child, "").strip() or subsection_template_map.get(f"{heading}/{child}", "")
+        lines.extend([f"### {child}", "", child_body.strip()])
+        if idx < len(required_children) - 1 or extra_subsections:
+            lines.append("")
+
+    for idx, (name, body) in enumerate(extra_subsections):
+        lines.extend([f"### {name}", "", body.strip()])
+        if idx < len(extra_subsections) - 1:
+            lines.append("")
+
+    rendered = "\n".join(lines).strip()
+    return rendered or section_template_map.get(heading, "")
+
+
+def validate_schema(
+    api_path: Path,
+    api_text: str,
+    config: Dict[str, object],
+) -> Tuple[List[Issue], List[Issue], List[Issue], List[Tuple[str, str]]]:
+    settings = config_settings(config)
+    required = required_sections(settings)
+    order = canonical_order(settings)
+    subsection_map = required_subsections(settings)
+    section_alias_map = section_alias_lookup(settings)
+
+    schema_issues: List[Issue] = []
+    command_issues: List[Issue] = []
+    content_issues: List[Issue] = []
+
+    preamble, sections = split_sections(api_text)
+    lookup = section_map(sections)
+    title, summary, _extras = parse_title_and_summary(preamble)
+
+    if not title:
+        schema_issues.append(
+            Issue(
+                issue_id="missing-title",
+                category="schema",
+                severity="high",
+                file=str(api_path),
+                evidence="API.md is missing a top-level '# API Reference for <project>' title.",
+                recommended_fix="Add a clear top-level API title.",
+                auto_fixable=True,
+            )
+        )
+    if not summary:
+        schema_issues.append(
+            Issue(
+                issue_id="missing-summary",
+                category="schema",
+                severity="medium",
+                file=str(api_path),
+                evidence="API.md is missing a short API consumer-facing summary beneath the title.",
+                recommended_fix="Add a short summary sentence beneath the top-level title.",
+                auto_fixable=True,
+            )
+        )
+
+    if "Table of Contents" not in lookup:
+        schema_issues.append(
+            Issue(
+                issue_id="missing-table-of-contents",
+                category="schema",
+                severity="medium",
+                file=str(api_path),
+                evidence="API.md is missing the required '## Table of Contents' section.",
+                recommended_fix="Add a table of contents that mirrors the canonical top-level headings.",
+                auto_fixable=True,
+            )
+        )
+
+    observed_headings = [heading for heading, _body in sections]
+    canonical_positions = {heading: idx for idx, heading in enumerate(observed_headings)}
+    for heading in required:
+        if heading in lookup:
+            continue
+        alias_found = next(
+            (alias for alias, canonical in section_alias_map.items() if canonical == heading and alias in lookup),
+            None,
+        )
+        if alias_found:
+            schema_issues.append(
+                Issue(
+                    issue_id=f"non-canonical-heading-{slugify_heading(heading)}",
+                    category="schema",
+                    severity="medium",
+                    file=str(api_path),
+                    evidence=f"API.md uses alias heading '## {alias_found}' where the canonical schema expects '## {heading}'.",
+                    recommended_fix=f"Rename '## {alias_found}' to '## {heading}'.",
+                    auto_fixable=True,
+                )
+            )
+        else:
+            schema_issues.append(
+                Issue(
+                    issue_id=f"missing-section-{slugify_heading(heading)}",
+                    category="schema",
+                    severity="high",
+                    file=str(api_path),
+                    evidence=f"API.md is missing required section '## {heading}'.",
+                    recommended_fix=f"Add the required '## {heading}' section.",
+                    auto_fixable=True,
+                )
+            )
+
+    order_positions: List[int] = []
+    for heading in order:
+        if heading in canonical_positions:
+            order_positions.append(canonical_positions[heading])
+            continue
+        alias_found = next(
+            (alias for alias, canonical in section_alias_map.items() if canonical == heading and alias in canonical_positions),
+            None,
+        )
+        if alias_found:
+            order_positions.append(canonical_positions[alias_found])
+    if order_positions and order_positions != sorted(order_positions):
+        schema_issues.append(
+            Issue(
+                issue_id="canonical-section-order",
+                category="schema",
+                severity="medium",
+                file=str(api_path),
+                evidence="Canonical API sections are not in the configured order.",
+                recommended_fix="Normalize the top-level sections into canonical order.",
+                auto_fixable=True,
+            )
+        )
+
+    subsection_alias_map = subsection_alias_lookup(settings)
+    for parent, children in subsection_map.items():
+        body = lookup.get(parent, "")
+        if not body:
+            alias_parent = next(
+                (alias for alias, canonical in section_alias_map.items() if canonical == parent and alias in lookup),
+                None,
+            )
+            body = lookup.get(alias_parent, "") if alias_parent else ""
+        if not body:
+            continue
+        _preamble, subsections = split_subsections(body)
+        found = {
+            subsection_alias_map.get((parent, name), name): subsection_body
+            for name, subsection_body in subsections
+        }
+        for child in children:
+            if child not in found:
+                schema_issues.append(
+                    Issue(
+                        issue_id=f"missing-subsection-{slugify_heading(parent)}-{slugify_heading(child)}",
+                        category="schema",
+                        severity="high",
+                        file=str(api_path),
+                        evidence=f"Section '## {parent}' is missing required subsection '### {child}'.",
+                        recommended_fix=f"Add the required subsection '### {child}' under '## {parent}'.",
+                        auto_fixable=True,
+                    )
+                )
+
+    if "Table of Contents" in lookup:
+        expected_toc = [heading for heading in order if heading in required or heading in lookup]
+        actual_toc = toc_entries(lookup["Table of Contents"])
+        if actual_toc != expected_toc:
+            schema_issues.append(
+                Issue(
+                    issue_id="stale-table-of-contents",
+                    category="schema",
+                    severity="low",
+                    file=str(api_path),
+                    evidence="Table of contents entries do not match the canonical top-level section headings in order.",
+                    recommended_fix="Regenerate the table of contents from the canonical section list.",
+                    auto_fixable=True,
+                )
+            )
+
+    for heading in required:
+        body = lookup.get(heading)
+        if not body:
+            continue
+        if not body.strip():
+            schema_issues.append(
+                Issue(
+                    issue_id=f"empty-section-{slugify_heading(heading)}",
+                    category="schema",
+                    severity="medium",
+                    file=str(api_path),
+                    evidence=f"Section '## {heading}' is present but empty.",
+                    recommended_fix=f"Add grounded content to '## {heading}'.",
+                    auto_fixable=True,
+                )
+            )
+        if any(pattern.search(body) for pattern in PLACEHOLDER_PATTERNS):
+            content_issues.append(
+                Issue(
+                    issue_id=f"placeholder-content-{slugify_heading(heading)}",
+                    category="content-quality",
+                    severity="medium",
+                    file=str(api_path),
+                    evidence=f"Section '## {heading}' contains placeholder-style content.",
+                    recommended_fix="Replace placeholder content with repo-grounded API consumer guidance.",
+                    auto_fixable=False,
+                )
+            )
+
+    verification_body = lookup.get("Local Development and Verification", "")
+    _preamble, dev_subsections = split_subsections(verification_body)
+    verification_lookup = {name: body for name, body in dev_subsections}
+    verification_text = verification_lookup.get("Verification", "").strip()
+    if verification_text:
+        shell_blocks = list(SHELL_FENCE_RE.finditer(verification_text))
+        if shell_blocks:
+            for match in shell_blocks:
+                info = match.group(1).strip()
+                block = match.group(2).strip()
+                if not info:
+                    command_issues.append(
+                        Issue(
+                            issue_id=f"missing-code-fence-info-string-{match.start()}",
+                            category="command-integrity",
+                            severity="low",
+                            file=str(api_path),
+                            evidence="Verification uses a fenced code block without a language info string.",
+                            recommended_fix="Use fenced code blocks with an info string such as ```bash for verification commands.",
+                            auto_fixable=False,
+                        )
+                    )
+                if not block:
+                    command_issues.append(
+                        Issue(
+                            issue_id=f"empty-shell-block-{match.start()}",
+                            category="command-integrity",
+                            severity="medium",
+                            file=str(api_path),
+                            evidence="Verification contains an empty fenced code block.",
+                            recommended_fix="Remove the empty block or replace it with grounded validation commands.",
+                            auto_fixable=True,
+                        )
+                    )
+                if any(pattern.search(block) for pattern in PLACEHOLDER_PATTERNS):
+                    command_issues.append(
+                        Issue(
+                            issue_id=f"placeholder-command-block-{match.start()}",
+                            category="command-integrity",
+                            severity="high",
+                            file=str(api_path),
+                            evidence="Verification contains a placeholder command block.",
+                            recommended_fix="Replace the placeholder command block with grounded validation commands or prose.",
+                            auto_fixable=False,
+                        )
+                    )
+        elif len(verification_text.split()) < 6:
+            content_issues.append(
+                Issue(
+                    issue_id="thin-verification-guidance",
+                    category="content-quality",
+                    severity="medium",
+                    file=str(api_path),
+                    evidence="Local Development and Verification > Verification is too thin to help API consumers verify behavior.",
+                    recommended_fix="Add grounded validation guidance, preferably with fenced code blocks and language info strings.",
+                    auto_fixable=False,
+                )
+            )
+
+    return schema_issues, command_issues, content_issues, sections
+
+
+def apply_fixes(
+    project_root: Path,
+    api_path: Path,
+    api_text: str,
+    config: Dict[str, object],
+) -> Tuple[str, List[Dict[str, str]]]:
+    if not api_text.strip():
+        bootstrap = render_template_bootstrap(project_root)
+        write_text(api_path, bootstrap)
+        return (
+            bootstrap,
+            [
+                {
+                    "action": "create-api-from-template",
+                    "file": str(api_path),
+                    "reason": "Created a missing API.md from the bundled canonical template.",
+                }
+            ],
+        )
+
+    settings = config_settings(config)
+    required = required_sections(settings)
+    order = canonical_order(settings)
+    preserve_preamble = bool(settings.get("preservePreamble", True))
+    allow_additional = bool(settings.get("allowAdditionalSections", True))
+    section_alias_map = section_alias_lookup(settings)
+
+    preamble, sections = split_sections(api_text)
+    normalized_preamble = normalize_preamble(preamble, project_root.name, preserve_preamble)
+
+    canonical_lookup: Dict[str, str] = {}
+    extra_sections: List[Tuple[str, str]] = []
+    for heading, body in sections:
+        if heading == "Table of Contents":
+            continue
+        canonical_heading = section_alias_map.get(heading, heading)
+        if canonical_heading in order or canonical_heading in required:
+            canonical_lookup[canonical_heading] = body
+        elif allow_additional:
+            extra_sections.append((heading, body))
+
+    canonical_sections: List[Tuple[str, str]] = []
+    for heading in order:
+        body = render_section_body(heading, canonical_lookup.get(heading, ""), settings).strip()
+        canonical_sections.append((heading, body))
+
+    headings_for_toc = [heading for heading, _body in canonical_sections]
+    if allow_additional:
+        headings_for_toc.extend(heading for heading, _body in extra_sections)
+    rendered_sections = [("Table of Contents", build_toc(headings_for_toc).strip()), *canonical_sections]
+    if allow_additional:
+        rendered_sections.extend(extra_sections)
+
+    parts = [normalized_preamble]
+    for heading, body in rendered_sections:
+        parts.extend(["", f"## {heading}", "", body.strip()])
+    document = "\n".join(parts).strip() + "\n"
+    return normalize_whitespace(document), [
+        {
+            "action": "normalize-api-structure",
+            "file": str(api_path),
+            "reason": "Normalized API.md to the canonical template-backed section schema.",
+        }
+    ]
+
+
+def format_report(report: Dict[str, object]) -> str:
+    total_issues = (
+        len(report["schema_violations"])
+        + len(report["command_integrity_issues"])
+        + len(report["content_quality_issues"])
+    )
+    if total_issues == 0 and not report["errors"]:
+        return "No findings."
+
+    lines = [
+        "# API.md Maintenance Report",
+        "",
+        f"- Target: `{report['run_context']['api_path']}`",
+        f"- Mode: `{report['run_context']['run_mode']}`",
+        f"- Config: `{report['schema_contract']['config_path']}`",
+    ]
+
+    for key, title in (
+        ("schema_violations", "Schema Violations"),
+        ("command_integrity_issues", "Command Integrity Issues"),
+        ("content_quality_issues", "Content Quality Issues"),
+        ("fixes_applied", "Fixes Applied"),
+        ("errors", "Errors"),
+    ):
+        items = report[key]
+        if not items:
+            continue
+        lines.extend(["", f"## {title}"])
+        for item in items:
+            evidence = item.get("evidence") or item.get("reason") or item.get("message")
+            lines.append(f"- {item.get('issue_id', item.get('action', 'item'))}: {evidence}")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def run_maintenance(args: argparse.Namespace) -> Tuple[Dict[str, object], str]:
+    project_root = Path(args.project_root).expanduser().resolve()
+    if not project_root.is_dir():
+        raise ValueError(f"Project root does not exist or is not a directory: {project_root}")
+
+    api_path = (
+        Path(args.api_path).expanduser().resolve()
+        if args.api_path
+        else project_root / "API.md"
+    )
+    config = load_config(project_root, args.config)
+
+    errors: List[str] = []
+    fixes_applied: List[Dict[str, str]] = []
+    existing_text = read_text(api_path) if api_path.is_file() else ""
+
+    if args.run_mode == "apply":
+        new_text, applied = apply_fixes(project_root, api_path, existing_text, config)
+        if not api_path.parent.exists():
+            api_path.parent.mkdir(parents=True, exist_ok=True)
+        if normalize_whitespace(existing_text) != new_text:
+            write_text(api_path, new_text)
+            fixes_applied.extend(applied)
+            existing_text = new_text
+
+    if existing_text:
+        schema_issues, command_issues, content_issues, _sections = validate_schema(
+            api_path, existing_text, config
+        )
+    else:
+        schema_issues = [
+            Issue(
+                issue_id="missing-api-file",
+                category="schema",
+                severity="high",
+                file=str(api_path),
+                evidence="API.md does not exist.",
+                recommended_fix="Create the canonical API.md file from the bundled template.",
+                auto_fixable=True,
+            )
+        ]
+        command_issues = []
+        content_issues = []
+
+    report = {
+        "run_context": {
+            "project_root": str(project_root),
+            "api_path": str(api_path),
+            "run_mode": args.run_mode,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "schema_contract": {
+            "config_path": config.get("configPath"),
+            "default_config_path": config.get("defaultConfigPath"),
+            "required_table_of_contents": True,
+            "required_sections": required_sections(config_settings(config)),
+            "section_order": canonical_order(config_settings(config)),
+            "required_subsections": required_subsections(config_settings(config)),
+        },
+        "schema_violations": [issue.to_dict() for issue in schema_issues],
+        "command_integrity_issues": [issue.to_dict() for issue in command_issues],
+        "content_quality_issues": [issue.to_dict() for issue in content_issues],
+        "fixes_applied": fixes_applied,
+        "post_fix_status": {
+            "remaining_issue_count": len(schema_issues) + len(command_issues) + len(content_issues),
+            "is_clean": not schema_issues and not command_issues and not content_issues and not errors,
+        },
+        "errors": errors,
+    }
+    markdown = format_report(report)
+    return report, markdown
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report, markdown = run_maintenance(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.md_out:
+        Path(args.md_out).write_text(markdown, encoding="utf-8")
+    if args.print_json:
+        print(json.dumps(report, indent=2))
+    if args.print_md:
+        print(markdown, end="")
+
+    has_issues = (
+        bool(report["schema_violations"])
+        or bool(report["command_integrity_issues"])
+        or bool(report["content_quality_issues"])
+        or bool(report["errors"])
+    )
+    if args.fail_on_issues and has_issues:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/productivity-skills/skills/maintain-project-api/tests/test_maintain_project_api.py
+++ b/plugins/productivity-skills/skills/maintain-project-api/tests/test_maintain_project_api.py
@@ -151,10 +151,13 @@ def test_apply_creates_api_from_template_when_missing(tmp_path: Path) -> None:
     assert report["fixes_applied"]
     assert "# API Reference for" in created
     assert "## Table of Contents" in created
+    assert "- [Overview](#overview)" in created
     assert "## API Surface" in created
     assert "## Local Development and Verification" in created
     assert "### Runtime Configuration" in created
     assert "### Verification" in created
+    assert report["schema_violations"] == []
+    assert report["post_fix_status"]["is_clean"] is True
 
 
 def test_apply_normalizes_structure_and_aliases(tmp_path: Path) -> None:

--- a/plugins/productivity-skills/skills/maintain-project-api/tests/test_maintain_project_api.py
+++ b/plugins/productivity-skills/skills/maintain-project-api/tests/test_maintain_project_api.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "maintain_project_api.py"
+SPEC = importlib.util.spec_from_file_location("maintain_project_api", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules["maintain_project_api"] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def run(project_root: Path, run_mode: str = "check-only", api_path: Path | None = None):
+    args = argparse.Namespace(
+        project_root=str(project_root),
+        api_path=str(api_path) if api_path else None,
+        run_mode=run_mode,
+        config=None,
+        json_out=None,
+        md_out=None,
+        print_json=False,
+        print_md=False,
+        fail_on_issues=False,
+    )
+    return MODULE.run_maintenance(args)
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+VALID_API = """
+# API Reference for demo-project
+
+Use this reference to understand the public API surface, how to call it, what it returns, and how to verify behavior locally.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [API Surface](#api-surface)
+- [Authentication and Access](#authentication-and-access)
+- [Requests and Responses](#requests-and-responses)
+- [Errors](#errors)
+- [Versioning and Compatibility](#versioning-and-compatibility)
+- [Local Development and Verification](#local-development-and-verification)
+- [Support and Ownership](#support-and-ownership)
+
+## Overview
+
+### Who This API Is For
+
+This API is for local tools and maintainers that need to inspect demo-project state from automated checks.
+
+### Stability Status
+
+The API is stable for documented fields and experimental for any field explicitly marked internal.
+
+## API Surface
+
+### Entry Points
+
+The public entry point is `GET /v1/status`.
+
+### Protocols and Transports
+
+The API is exposed over local HTTP and returns JSON.
+
+## Authentication and Access
+
+### Credentials
+
+Local development calls do not require credentials.
+
+### Permissions
+
+The caller must be able to reach the local development server.
+
+## Requests and Responses
+
+### Request Shape
+
+`GET /v1/status` accepts no request body.
+
+### Response Shape
+
+The response contains a `status` string and an `updatedAt` timestamp.
+
+### Data Models
+
+`status` is one of `ok`, `degraded`, or `offline`.
+
+## Errors
+
+### Error Shape
+
+Errors return a JSON object with `code`, `message`, and `requestId`.
+
+### Common Failure Modes
+
+Connection failures usually mean the local server is not running.
+
+## Versioning and Compatibility
+
+### Supported Versions
+
+The documented surface covers version `v1`.
+
+### Breaking Changes
+
+Breaking changes require an explicit migration note in this file.
+
+## Local Development and Verification
+
+### Runtime Configuration
+
+The local API uses the default development server configuration.
+
+### Verification
+
+```bash
+uv run pytest
+```
+
+## Support and Ownership
+
+Open an issue in this repository when the documented contract does not match the implementation.
+""".strip()
+
+
+def test_valid_api_file_has_no_findings(tmp_path: Path) -> None:
+    write(tmp_path / "API.md", VALID_API)
+
+    report, markdown = run(tmp_path)
+
+    assert report["schema_violations"] == []
+    assert report["command_integrity_issues"] == []
+    assert report["content_quality_issues"] == []
+    assert report["errors"] == []
+    assert markdown == "No findings."
+
+
+def test_apply_creates_api_from_template_when_missing(tmp_path: Path) -> None:
+    report, _markdown = run(tmp_path, run_mode="apply")
+    created = (tmp_path / "API.md").read_text(encoding="utf-8")
+
+    assert report["fixes_applied"]
+    assert "# API Reference for" in created
+    assert "## Table of Contents" in created
+    assert "## API Surface" in created
+    assert "## Local Development and Verification" in created
+    assert "### Runtime Configuration" in created
+    assert "### Verification" in created
+
+
+def test_apply_normalizes_structure_and_aliases(tmp_path: Path) -> None:
+    write(
+        tmp_path / "API.md",
+        """
+# API Reference for demo-project
+
+Short reference.
+
+## Overview
+
+### Audience
+
+This API is for local tools.
+
+### Status
+
+Stable for documented fields.
+
+## Endpoints
+
+### Routes
+
+`GET /v1/status`
+
+### Protocols
+
+Local HTTP.
+
+## Authentication
+
+### Secrets
+
+No token is required.
+
+### Scopes
+
+Local network access is required.
+
+## Schemas
+
+### Requests
+
+No body is required.
+
+### Responses
+
+JSON is returned.
+
+### Models
+
+The response has a `status` field.
+
+## Error Handling
+
+### Error Format
+
+Errors are JSON objects.
+
+### Failure Modes
+
+The server may be offline.
+
+## Compatibility
+
+### Versions
+
+Version `v1` is supported.
+
+### Migration Notes
+
+Breaking changes are documented here.
+
+## Local Setup
+
+### Runtime Config
+
+Use the development server defaults.
+
+### Validation
+
+```bash
+pnpm test
+```
+
+## Support
+
+Open an issue.
+""".strip(),
+    )
+
+    report, _markdown = run(tmp_path, run_mode="apply")
+    updated = (tmp_path / "API.md").read_text(encoding="utf-8")
+
+    assert report["fixes_applied"]
+    assert "## Table of Contents" in updated
+    assert "## API Surface" in updated
+    assert "## Endpoints" not in updated
+    assert "## Authentication and Access" in updated
+    assert "## Local Setup" not in updated
+    assert "### Audience" not in updated
+    assert "### Who This API Is For" in updated
+    assert "### Runtime Configuration" in updated
+    assert report["schema_violations"] == []
+
+
+def test_check_only_flags_missing_table_of_contents(tmp_path: Path) -> None:
+    write(
+        tmp_path / "API.md",
+        VALID_API.replace(
+            """## Table of Contents
+
+- [Overview](#overview)
+- [API Surface](#api-surface)
+- [Authentication and Access](#authentication-and-access)
+- [Requests and Responses](#requests-and-responses)
+- [Errors](#errors)
+- [Versioning and Compatibility](#versioning-and-compatibility)
+- [Local Development and Verification](#local-development-and-verification)
+- [Support and Ownership](#support-and-ownership)
+
+""",
+            "",
+        ),
+    )
+
+    report, _markdown = run(tmp_path, run_mode="check-only")
+
+    issue_ids = {issue["issue_id"] for issue in report["schema_violations"]}
+    assert "missing-table-of-contents" in issue_ids
+
+
+def test_check_only_flags_verification_fence_without_info_string(tmp_path: Path) -> None:
+    write(
+        tmp_path / "API.md",
+        VALID_API.replace("```bash\nuv run pytest\n```", "```\nuv run pytest\n```"),
+    )
+
+    report, _markdown = run(tmp_path, run_mode="check-only")
+
+    issue_ids = {issue["issue_id"] for issue in report["command_integrity_issues"]}
+    assert any(issue_id.startswith("missing-code-fence-info-string-") for issue_id in issue_ids)

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.0.15"
+version = "6.1.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.0.15"
+version = "6.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.0.15"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.0.15",
+  "version": "6.1.0",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.0.15"
+version = "6.1.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Adds a new `maintain-project-api` productivity skill for canonical `API.md` maintenance.
- Includes the template, config schema, bounded apply/check script, references, OpenAI metadata, and tests.
- Wires the new skill into the active inventory, roadmap, and pytest testpaths.

## Verification

- `uv run pytest skills/maintain-project-api/tests`
- `uv run pytest`
- `uv run scripts/validate_socket_metadata.py`
