### PR TITLE
Document Apple companion install paths

### DIFF
--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -26,7 +26,7 @@
   "interface": {
     "displayName": "Apple Dev Skills",
     "shortDescription": "Apple, Swift, Xcode, SwiftUI, and DocC workflows for Codex.",
-    "longDescription": "Bundle Apple-platform development skills for Swift, SwiftUI architecture, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling.",
+    "longDescription": "Bundle Apple-platform development skills for Swift, SwiftUI architecture, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling. Most workflows work standalone; bootstrap and guidance-sync workflows that install or refresh repo-maintenance files require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -38,7 +38,7 @@
       "Explore the relevant Apple docs first, then explain the right SwiftUI or Xcode path for this repository.",
       "Help me build, test, or debug this Swift or Xcode project using the repo's Apple workflows.",
       "Write or review DocC symbol comments, articles, extension files, and landing-page structure for this Swift repository.",
-      "Sync the Apple project guidance in this repo without hand-editing Xcode project files."
+      "Sync the Apple project guidance in this repo without hand-editing Xcode project files, using Productivity Skills when repo-maintenance files must be installed or refreshed."
     ],
     "brandColor": "#0A84FF"
   }

--- a/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
+++ b/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
@@ -43,6 +43,8 @@ echo "Validating local discovery mirrors..."
 echo "Validating root README contract..."
 require_contains "README.md" 'Treat `productivity-skills` as the default baseline layer for general repo-doc and maintenance work'
 require_contains "README.md" 'This repository is the canonical source of truth for Gale'"'"'s Apple, Swift, and Xcode workflow skills.'
+require_contains "README.md" 'Most Apple Dev Skills workflows are useful as a standalone plugin.'
+require_contains "README.md" 'The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale'"'"'s plugin superproject and marketplace catalog.'
 require_contains "README.md" 'Treat root [`skills/`](./skills/) as the canonical authored surface.'
 require_contains "README.md" 'Keep shared reusable assets in [`shared/`](./shared/)'
 require_contains "README.md" 'Run the repository test suite for skill and metadata changes:'
@@ -61,6 +63,7 @@ require_contains "CONTRIBUTING.md" 'uv run pytest'
 echo "Validating AGENTS contract..."
 require_contains "AGENTS.md" 'This repository is the canonical home for Gale'"'"'s Apple, Swift, and Xcode workflow skills.'
 require_contains "AGENTS.md" 'Treat `productivity-skills` as the default baseline maintainer layer'
+require_contains "AGENTS.md" 'Preserve standalone-install guidance for public users who install only `apple-dev-skills`'
 require_contains "AGENTS.md" 'Root `skills/` is the canonical authored and exported surface.'
 require_contains "AGENTS.md" 'Keep shared reusable assets in [`shared/`](./shared/) and maintainer tests in [`tests/`](./tests/).'
 require_contains "AGENTS.md" 'require reading the relevant Apple documentation before proposing implementation changes.'
@@ -95,6 +98,7 @@ require_contains "$audit_doc" "## Audit Procedure"
 require_contains "$audit_doc" "## Local Discovery Smoke Test Flow"
 require_contains "$audit_doc" "## Reporting Shape"
 require_contains "$audit_doc" '`productivity-skills` owns the reusable `maintain-project-repo` toolkit contract'
+require_contains "$audit_doc" 'standalone `apple-dev-skills` installs from installs that also include the `productivity-skills` companion plugin'
 require_contains "$audit_doc" 'this repository owns only the Apple-specific profile selection and Xcode MCP registration contract'
 require_contains "$audit_doc" 'Historical milestone planning decisions that no longer need standalone docs should live in `ROADMAP.md`'
 require_not_contains "$audit_doc" 'plugins/apple-dev-skills/'
@@ -116,6 +120,7 @@ require_contains "$execution_split_doc" "## AGENTS Expansion Strategy"
 require_contains "$execution_split_doc" "## Repo-Maintenance Direction"
 require_contains "$execution_split_doc" "## Implementation Plan"
 require_contains "$execution_split_doc" '`productivity-skills/maintain-project-repo` as the canonical shipped repo-maintenance surface'
+require_contains "$execution_split_doc" 'Users who install only `apple-dev-skills` still get the Apple-only workflows'
 require_contains "ROADMAP.md" "Completed Milestones 22 and 23"
 require_contains "ROADMAP.md" 'See `docs/maintainers/customization-consolidation-review.md`.'
 require_contains "ROADMAP.md" "Completed Milestones 30 through 36"
@@ -250,6 +255,8 @@ do
   [[ ! -e "$skill_dir/assets/repo-maintenance" ]] || fail "Did not expect vendored repo-maintenance assets in $skill_dir"
   [[ ! -e "$skill_dir/assets/github/repo-maintenance-workflows" ]] || fail "Did not expect vendored repo-maintenance workflow assets in $skill_dir"
   require_contains "$skill_dir/SKILL.md" 'maintain-project-repo'
+  require_contains "$skill_dir/SKILL.md" 'Companion Plugin Requirement'
+  require_contains "$skill_dir/SKILL.md" 'https://github.com/gaelic-ghost/socket'
 done
 require_contains "./skills/bootstrap-swift-package/scripts/bootstrap_swift_package.sh" 'productivity-skills/skills/maintain-project-repo/scripts/run_workflow.py'
 require_contains "./skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py" 'productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py'

--- a/plugins/apple-dev-skills/AGENTS.md
+++ b/plugins/apple-dev-skills/AGENTS.md
@@ -8,6 +8,7 @@ Use this file for durable repo-local guidance that Codex should follow before ch
 
 - This repository is the canonical home for Gale's Apple, Swift, and Xcode workflow skills.
 - Treat `productivity-skills` as the default baseline maintainer layer for general repo docs and maintenance work; this repo is the narrower specialist layer when Apple-specific behavior should change the workflow.
+- Preserve standalone-install guidance for public users who install only `apple-dev-skills`, and make the `productivity-skills` companion requirement explicit only for workflows that install or refresh `maintain-project-repo`.
 - Root `skills/` is the canonical authored and exported surface.
 - Keep shared reusable assets in [`shared/`](./shared/) and maintainer tests in [`tests/`](./tests/).
 

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -47,6 +47,14 @@ Use this repository's skills when the work is about:
 
 When installed as a Codex plugin, this repository also registers Xcode's built-in MCP bridge through `xcrun mcpbridge`. Users still need to allow external agents in Xcode's Intelligence settings and keep the relevant project open in Xcode before external Codex sessions can use Xcode-provided tools.
 
+### Companion Plugin Requirements
+
+Most Apple Dev Skills workflows are useful as a standalone plugin. The bootstrap and repo-guidance sync workflows that install or refresh `scripts/repo-maintenance/` also need the companion [`productivity-skills`](https://github.com/gaelic-ghost/productivity-skills) plugin installed alongside this plugin, because `productivity-skills` owns the reusable `maintain-project-repo` implementation while Apple Dev Skills chooses the Apple-specific `swift-package` or `xcode-app` profile.
+
+If an agent has only `apple-dev-skills` installed, it can still use the documentation lookup, SwiftUI architecture, Xcode build/run/test, DocC, formatting, source-structure, and accessibility workflows. It should install `productivity-skills` before running `bootstrap-swift-package`, `bootstrap-xcode-app-project`, `sync-swift-package-guidance`, or `sync-xcode-project-guidance` in mutating mode.
+
+The [`socket`](https://github.com/gaelic-ghost/socket) repository is Gale's plugin superproject and marketplace catalog. Installing from the socket marketplace is useful when you want Apple Dev Skills and its companion plugins available together without wiring each plugin one by one; standalone installs remain supported for Apple-only workflows that do not call `maintain-project-repo`.
+
 Use [`CONTRIBUTING.md`](./CONTRIBUTING.md) for maintainer workflow details, and use [`ROADMAP.md`](./ROADMAP.md) for planned and completed milestone-level work.
 
 ## Development

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -29,6 +29,7 @@
 - Keep root `skills/` as the canonical authored and exported surface.
 - Keep Apple documentation requirements explicit and enforceable in the skill guidance.
 - Keep plugin packaging thin and secondary to the workflow-authoring surface.
+- Keep standalone install behavior honest: Apple-only workflows should remain usable from `apple-dev-skills` alone, while repo-maintenance bootstrap and sync workflows should name their `productivity-skills` companion requirement and the optional `socket` marketplace path.
 - Expand the repo deliberately instead of adding loosely related helper features ad hoc.
 
 ## Milestone Progress

--- a/plugins/apple-dev-skills/docs/maintainers/execution-split-and-inference-plan.md
+++ b/plugins/apple-dev-skills/docs/maintainers/execution-split-and-inference-plan.md
@@ -98,7 +98,7 @@ Planned profile shape:
 - `xcode-app`
 - optional later `swift-mixed-root`
 
-The socket plugin ships `productivity-skills` and `apple-dev-skills` together, so Apple workflows can call the sibling `maintain-project-repo` skill instead of vendoring another toolkit source.
+The `socket` marketplace lists `productivity-skills` and `apple-dev-skills` together, so users who install that catalog get the sibling `maintain-project-repo` skill without wiring each plugin one by one. Users who install only `apple-dev-skills` still get the Apple-only workflows, but mutating bootstrap and guidance-sync workflows must explain that repo-maintenance install or refresh requires the `productivity-skills` companion plugin.
 
 Current Apple-side integration status:
 

--- a/plugins/apple-dev-skills/docs/maintainers/reality-audit.md
+++ b/plugins/apple-dev-skills/docs/maintainers/reality-audit.md
@@ -67,6 +67,7 @@ Use this flow when validating the current top-level export surface and local dis
 ## Durable Review Criteria
 
 - Root docs should say plainly that `productivity-skills` remains the default baseline layer for general repo-doc and maintenance work, while this repo is the Apple-specific specialization layer.
+- Root docs should distinguish standalone `apple-dev-skills` installs from installs that also include the `productivity-skills` companion plugin or the `socket` marketplace catalog.
 - Root docs must describe the same active skill surface.
 - Root docs must describe the current top-level export shape without treating deleted nested packaging experiments as active.
 - Codex plugin docs must describe Xcode MCP registration as Xcode-owned `xcrun mcpbridge` wiring, not as a bundled third-party server package.

--- a/plugins/apple-dev-skills/docs/maintainers/workflow-atlas.md
+++ b/plugins/apple-dev-skills/docs/maintainers/workflow-atlas.md
@@ -87,6 +87,7 @@ flowchart TD
 - End-user `AGENTS.md` guidance is recommended from each skill's local snippet copy, not from a router.
 - The active skill surface now uses the intended install-facing names directly.
 - The reusable repo-maintenance implementation now lives in `productivity-skills/maintain-project-repo`; Apple bootstrap and sync skills call that sibling skill with the `swift-package` or `xcode-app` profile.
+- Standalone `apple-dev-skills` installs remain useful for Apple-only workflows, but mutating bootstrap and guidance-sync workflows must tell users when they need the `productivity-skills` companion plugin or the `socket` marketplace catalog.
 - The canonical shipped repo-maintenance contract stays profile-aware and gives downstream repos `scripts/repo-maintenance/config/profile.env` while Apple workflows choose either the `swift-package` or `xcode-app` profile explicitly.
 - The managed workflow's protected-branch check context is `validate`; GitHub exposes the job check run by that context, not by the display-style workflow title plus job string `Validate Repo Maintenance / validate`.
 - The Swift package side of the execution split is now in place, with build-run and testing split into separate primary skills while `swift-package-workflow` remains only as a legacy compatibility-routing surface.
@@ -114,6 +115,7 @@ flowchart TD
 
 - Treat `productivity-skills` as the baseline maintainer layer for general repo-doc and maintenance work.
 - Use `apple-dev-skills` when Swift, Xcode, Apple docs requirements, or Apple-platform repo shape should materially change the workflow.
+- Keep public install guidance explicit about the two valid shapes: standalone `apple-dev-skills` for Apple-only workflows, or `apple-dev-skills` plus `productivity-skills` for repo-maintenance bootstrap and sync workflows. The `socket` marketplace is the convenient catalog when users want those companion plugins together.
 - The repository currently exports only from top-level `skills/`.
 - If this repository later grows top-level `mcps/` or `apps/`, those directories are valid export surfaces too.
 - The repository must not reintroduce a nested packaged plugin tree or any other second export surface under `plugins/`.

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.1.0"
+version = "6.1.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/SKILL.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/SKILL.md
@@ -9,6 +9,10 @@ description: Bootstrap new Swift Package Manager repositories with consistent de
 
 Create a new Swift package repository with one top-level entry point, a simplicity-first Swift baseline, and a local-first maintainer surface. `scripts/run_workflow.py` is the runtime wrapper, and `scripts/bootstrap_swift_package.sh` is the deterministic implementation core for scaffold creation, testing-mode selection, validation, and `maintain-project-repo` installation with the `swift-package` profile.
 
+## Companion Plugin Requirement
+
+This skill can be discovered from a standalone `apple-dev-skills` install, but its mutating bootstrap path installs repo-maintenance files through the companion [`productivity-skills`](https://github.com/gaelic-ghost/productivity-skills) plugin. If the companion `maintain-project-repo` runner is missing, tell the user to install `productivity-skills` alongside `apple-dev-skills` or install the [`socket`](https://github.com/gaelic-ghost/socket) marketplace, which is useful when they want Gale's Apple and general maintainer plugins available together.
+
 ## When To Use
 
 - Use this skill for new Swift package scaffolding.

--- a/plugins/apple-dev-skills/skills/bootstrap-swift-package/scripts/bootstrap_swift_package.sh
+++ b/plugins/apple-dev-skills/skills/bootstrap-swift-package/scripts/bootstrap_swift_package.sh
@@ -75,6 +75,7 @@ swift_minor_version=""
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 agents_template="$script_dir/../assets/AGENTS.md"
 maintain_project_repo_runner="$script_dir/../../../../productivity-skills/skills/maintain-project-repo/scripts/run_workflow.py"
+maintain_project_repo_missing_message="Validation failed: bootstrap-swift-package needs productivity-skills/maintain-project-repo to install repo-maintenance files, but the runner was missing at $maintain_project_repo_runner. Install the productivity-skills plugin alongside apple-dev-skills, or install the socket marketplace from https://github.com/gaelic-ghost/socket so both companion plugins are available, then rerun this workflow."
 
 is_ignorable_directory_entry() {
   local entry_name="$1"
@@ -479,7 +480,7 @@ mkdir -p "$target_dir"
   if [[ -x "$maintain_project_repo_runner" ]]; then
     "$maintain_project_repo_runner" --repo-root "$target_dir" --operation install --profile swift-package >/dev/null
   else
-    failed "Validation failed: maintain-project-repo runner missing at $maintain_project_repo_runner. Ensure productivity-skills ships alongside apple-dev-skills before rerunning."
+    failed "$maintain_project_repo_missing_message"
   fi
 
   ensure_test_target "$testing_mode" "$name"

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/SKILL.md
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/SKILL.md
@@ -9,6 +9,10 @@ description: Bootstrap a new native Apple app project for macOS, iOS, or iPadOS 
 
 Create a new native Apple app repository from nothing to a usable baseline on disk. The first implementation prioritizes a deterministic `XcodeGen` path for SwiftUI app projects and a guarded planning path for the standard Xcode-created-project flow. `scripts/run_workflow.py` is the runtime entrypoint, and `scripts/bootstrap_xcode_app_project.py` is the current implementation core for XcodeGen-backed scaffold creation plus `maintain-project-repo` installation with the `xcode-app` profile.
 
+## Companion Plugin Requirement
+
+This skill can be discovered from a standalone `apple-dev-skills` install, but its mutating bootstrap path installs repo-maintenance files through the companion [`productivity-skills`](https://github.com/gaelic-ghost/productivity-skills) plugin. If the companion `maintain-project-repo` runner is missing, tell the user to install `productivity-skills` alongside `apple-dev-skills` or install the [`socket`](https://github.com/gaelic-ghost/socket) marketplace, which is useful when they want Gale's Apple and general maintainer plugins available together.
+
 ## When To Use
 
 - Use this skill when the user wants to start, begin, create, or bootstrap a new macOS, iOS, or iPadOS app project on macOS.

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py
@@ -122,7 +122,11 @@ def maintain_project_repo_runner() -> Path:
     runner = plugins_root / "productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py"
     if not runner.is_file():
         raise RuntimeError(
-            f"Expected maintain-project-repo runner at {runner}, but it was missing."
+            "bootstrap-xcode-app-project needs productivity-skills/maintain-project-repo "
+            f"to install repo-maintenance files, but the runner was missing at {runner}. "
+            "Install the productivity-skills plugin alongside apple-dev-skills, or install "
+            "the socket marketplace from https://github.com/gaelic-ghost/socket so both "
+            "companion plugins are available, then rerun this workflow."
         )
     return runner
 
@@ -207,7 +211,7 @@ def main() -> int:
             "normalized_inputs": normalized_inputs,
             "validation_result": "failed (maintain-project-repo install)",
             "stderr": str(exc),
-            "next_step": "Ensure productivity-skills ships alongside apple-dev-skills, then rerun the workflow.",
+            "next_step": "Install the productivity-skills companion plugin or the socket marketplace, then rerun bootstrap-xcode-app-project.",
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 1

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/SKILL.md
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/SKILL.md
@@ -9,6 +9,10 @@ description: Sync repo guidance for an existing Swift Package Manager repository
 
 Bring an existing Swift package repository up to the expected guidance baseline without stretching the package bootstrap skill into an ongoing repo-guidance surface. This skill owns deterministic `AGENTS.md` creation or bounded section append behavior for existing SwiftPM repos and runs `maintain-project-repo` with the `swift-package` profile alongside that guidance. `scripts/run_workflow.py` is the runtime entrypoint, and `scripts/sync_swift_package_guidance.py` applies the current sync behavior.
 
+## Companion Plugin Requirement
+
+This skill can be discovered from a standalone `apple-dev-skills` install, but its mutating guidance-sync path refreshes repo-maintenance files through the companion [`productivity-skills`](https://github.com/gaelic-ghost/productivity-skills) plugin. If the companion `maintain-project-repo` runner is missing, tell the user to install `productivity-skills` alongside `apple-dev-skills` or install the [`socket`](https://github.com/gaelic-ghost/socket) marketplace, which is useful when they want Gale's Apple and general maintainer plugins available together.
+
 ## When To Use
 
 - Use this skill when an existing Swift package repo needs `AGENTS.md` added, refreshed, or merged with the current SwiftPM workflow baseline.

--- a/plugins/apple-dev-skills/skills/sync-swift-package-guidance/scripts/sync_swift_package_guidance.py
+++ b/plugins/apple-dev-skills/skills/sync-swift-package-guidance/scripts/sync_swift_package_guidance.py
@@ -73,7 +73,11 @@ def maintain_project_repo_runner() -> Path:
     runner = plugins_root / "productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py"
     if not runner.is_file():
         raise RuntimeError(
-            f"Expected maintain-project-repo runner at {runner}, but it was missing."
+            "sync-swift-package-guidance needs productivity-skills/maintain-project-repo "
+            f"to refresh repo-maintenance files, but the runner was missing at {runner}. "
+            "Install the productivity-skills plugin alongside apple-dev-skills, or install "
+            "the socket marketplace from https://github.com/gaelic-ghost/socket so both "
+            "companion plugins are available, then rerun this workflow."
         )
     return runner
 
@@ -207,7 +211,7 @@ def main() -> int:
             "validation_result": validation_result,
             "actions": actions,
             "stderr": str(exc),
-            "next_step": "Ensure productivity-skills ships alongside apple-dev-skills, then rerun the workflow.",
+            "next_step": "Install the productivity-skills companion plugin or the socket marketplace, then rerun sync-swift-package-guidance.",
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 1

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/SKILL.md
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/SKILL.md
@@ -9,6 +9,10 @@ description: Sync repo guidance for an existing native Apple app repository mana
 
 Bring an existing Xcode app repository up to the expected guidance baseline without overloading the main Xcode execution skill. This skill owns repo-guidance alignment for existing Apple app repos, including deterministic `AGENTS.md` creation or bounded section append behavior, and runs `maintain-project-repo` with the `xcode-app` profile alongside that guidance. `scripts/run_workflow.py` is the runtime entrypoint, and `scripts/sync_xcode_project_guidance.py` applies the current sync behavior.
 
+## Companion Plugin Requirement
+
+This skill can be discovered from a standalone `apple-dev-skills` install, but its mutating guidance-sync path refreshes repo-maintenance files through the companion [`productivity-skills`](https://github.com/gaelic-ghost/productivity-skills) plugin. If the companion `maintain-project-repo` runner is missing, tell the user to install `productivity-skills` alongside `apple-dev-skills` or install the [`socket`](https://github.com/gaelic-ghost/socket) marketplace, which is useful when they want Gale's Apple and general maintainer plugins available together.
+
 ## When To Use
 
 - Use this skill when an existing macOS, iOS, or iPadOS app repo needs `AGENTS.md` added, refreshed, or merged with the current Xcode workflow baseline.

--- a/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/scripts/sync_xcode_project_guidance.py
+++ b/plugins/apple-dev-skills/skills/sync-xcode-project-guidance/scripts/sync_xcode_project_guidance.py
@@ -52,7 +52,11 @@ def maintain_project_repo_runner() -> Path:
     runner = plugins_root / "productivity-skills" / "skills" / "maintain-project-repo" / "scripts" / "run_workflow.py"
     if not runner.is_file():
         raise RuntimeError(
-            f"Expected maintain-project-repo runner at {runner}, but it was missing."
+            "sync-xcode-project-guidance needs productivity-skills/maintain-project-repo "
+            f"to refresh repo-maintenance files, but the runner was missing at {runner}. "
+            "Install the productivity-skills plugin alongside apple-dev-skills, or install "
+            "the socket marketplace from https://github.com/gaelic-ghost/socket so both "
+            "companion plugins are available, then rerun this workflow."
         )
     return runner
 
@@ -171,7 +175,7 @@ def main() -> int:
             "validation_result": validation_result,
             "actions": actions,
             "stderr": str(exc),
-            "next_step": "Ensure productivity-skills ships alongside apple-dev-skills, then rerun the workflow.",
+            "next_step": "Install the productivity-skills companion plugin or the socket marketplace, then rerun sync-xcode-project-guidance.",
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 1

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.1.0"
+version = "6.1.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.1.0"
+version = "6.1.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.1.0"
+version = "6.1.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.1.0"
+version = "6.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.1.0"
+version = "6.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- document standalone apple-dev-skills behavior versus the productivity-skills companion requirement
- add socket marketplace guidance for users who want companion plugins installed together
- improve missing maintain-project-repo failure messages in Apple bootstrap and guidance-sync workflows
- bump maintained version surfaces to 6.1.1 for the patch release

## Subtree accounting
- apple-dev-skills: pushed out to gaelic-ghost/apple-dev-skills main and released as v6.1.1
- SpeakSwiftlyServer: not touched

## Verification
- bash .github/scripts/validate_repo_docs.sh
- uv run pytest in plugins/apple-dev-skills
- uv run scripts/validate_socket_metadata.py
- git diff --check