### PR TITLE
Release v6.4.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -29,6 +29,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "swiftasb-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/swiftasb-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "dotnet-skills",
       "source": {
         "source": "local",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -47,7 +47,7 @@
         "path": "./plugins/dotnet-skills"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
@@ -96,7 +96,7 @@
         "path": "./plugins/rust-skills"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
@@ -132,7 +132,7 @@
         "path": "./plugins/spotify"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
@@ -144,7 +144,7 @@
         "path": "./plugins/web-dev-skills"
       },
       "policy": {
-        "installation": "AVAILABLE",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"

--- a/README.md
+++ b/README.md
@@ -217,20 +217,20 @@ Treat `socket` as the canonical home for the monorepo-owned child directories an
 
 The repo-root marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json).
 
-That marketplace points at the actual plugin root each child repository treats as installable today:
+That marketplace points at the plugin root for each cataloged child repository. Entries with real shipped skills, MCP servers, hooks, or apps are installable. Placeholder entries stay visible as planned surfaces but use `policy.installation: NOT_AVAILABLE` until they ship actual content:
 
-- `./plugins/agent-plugin-skills`
-- `./plugins/apple-dev-skills`
-- `./plugins/cardhop-app`
-- `./plugins/dotnet-skills`
-- `./plugins/productivity-skills`
-- `gaelic-ghost/SpeakSwiftlyServer` for `speak-swiftly`, displayed as `Speak Swiftly`
-- `./plugins/python-skills`
-- `./plugins/rust-skills`
-- `./plugins/spotify`
-- `./plugins/swiftasb-skills`
-- `./plugins/things-app`
-- `./plugins/web-dev-skills`
+- Installable: `./plugins/agent-plugin-skills`
+- Installable: `./plugins/apple-dev-skills`
+- Installable: `./plugins/cardhop-app`
+- Installable: `./plugins/productivity-skills`
+- Installable: `gaelic-ghost/SpeakSwiftlyServer` for `speak-swiftly`, displayed as `Speak Swiftly`
+- Installable: `./plugins/python-skills`
+- Installable: `./plugins/swiftasb-skills`
+- Installable: `./plugins/things-app`
+- Not available yet: `./plugins/dotnet-skills`
+- Not available yet: `./plugins/rust-skills`
+- Not available yet: `./plugins/spotify`
+- Not available yet: `./plugins/web-dev-skills`
 
 For `things-app`, that marketplace path stays `./plugins/things-app` because the installable plugin root is the child repo root even though the bundled server now lives at top-level `mcp/` inside that child repo.
 
@@ -247,7 +247,7 @@ codex plugin marketplace add gaelic-ghost/socket
 codex plugin marketplace upgrade socket
 ```
 
-Use the `socket` marketplace when you want one catalog for Gale's plugin set. From that marketplace, users can install or enable individual entries such as `apple-dev-skills`, `productivity-skills`, `agent-plugin-skills`, `python-skills`, `things-app`, and the other listed child plugins. This is especially useful for workflows that need companion skills, such as Apple bootstrap or guidance-sync workflows that rely on both `apple-dev-skills` and `productivity-skills`.
+Use the `socket` marketplace when you want one catalog for Gale's plugin set. From that marketplace, users can install or enable individual available entries such as `apple-dev-skills`, `productivity-skills`, `agent-plugin-skills`, `python-skills`, `swiftasb-skills`, `things-app`, and `cardhop-app`. This is especially useful for workflows that need companion skills, such as Apple bootstrap or guidance-sync workflows that rely on both `apple-dev-skills` and `productivity-skills`.
 
 When both the Socket marketplace and the standalone SpeakSwiftlyServer marketplace are configured, prefer enabling `speak-swiftly` from the Socket catalog and disabling duplicate standalone enablement. The Speak Swiftly doctor should detect duplicate installs or enablement and offer a repair path that keeps the Socket entry active.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Treat `socket` as the canonical home for the monorepo-owned child directories an
 - `python-skills` is monorepo-owned here with no separate upstream GitHub release target.
 - Child repos may expose plugin packaging from their own repo roots whether they are monorepo-owned here or still preserve subtree sync.
 - `apple-dev-skills` packages from its child-repo root at `./plugins/apple-dev-skills`, and its Codex plugin manifest registers Xcode's built-in MCP bridge through a root `.mcp.json`.
-- `swiftasb-skills` packages from its child-repo root at `./plugins/swiftasb-skills`, and ships companion guidance for explaining SwiftASB plus building SwiftUI-facing integrations on top of the SwiftASB package.
+- `swiftasb-skills` packages from its child-repo root at `./plugins/swiftasb-skills`, and ships companion guidance for explaining SwiftASB, choosing integration shapes, diagnosing integration failures, and building SwiftUI, AppKit, and Swift package integrations on top of the SwiftASB package.
 - `apple-dev-skills` and `SpeakSwiftlyServer` also carry their own repo-local `.agents/plugins/marketplace.json` files so Codex can track either child repository as a Git-backed standalone marketplace without cloning `socket`.
 - `SpeakSwiftlyServer` owns the canonical `speak-swiftly` plugin payload. The Socket marketplace exposes that payload by Git-backed reference so users can enable `Speak Swiftly` from the Socket catalog without `socket` carrying a second copied plugin directory.
 - `things-app` packages from its child-repo root at `./plugins/things-app`, and its bundled MCP server lives directly under that child repo's top-level `mcp/` directory.

--- a/README.md
+++ b/README.md
@@ -201,12 +201,13 @@ The root superproject docs are:
 
 Treat `socket` as the canonical home for the monorepo-owned child directories and as the subtree host for the remaining imported child repos.
 
-- `agent-plugin-skills`, `cardhop-app`, `dotnet-skills`, `productivity-skills`, `rust-skills`, `spotify`, `things-app`, and `web-dev-skills` are monorepo-owned here.
+- `agent-plugin-skills`, `cardhop-app`, `dotnet-skills`, `productivity-skills`, `rust-skills`, `spotify`, `swiftasb-skills`, `things-app`, and `web-dev-skills` are monorepo-owned here.
 - `apple-dev-skills` and `SpeakSwiftlyServer` preserve explicit subtree sync paths.
 - `SpeakSwiftlyServer` may be synchronized into `socket` by subtree pull after standalone source or release work lands, but routine Speak Swiftly plugin payload edits do not need a subtree pull because the Socket catalog installs from the Git-backed standalone repository.
 - `python-skills` is monorepo-owned here with no separate upstream GitHub release target.
 - Child repos may expose plugin packaging from their own repo roots whether they are monorepo-owned here or still preserve subtree sync.
 - `apple-dev-skills` packages from its child-repo root at `./plugins/apple-dev-skills`, and its Codex plugin manifest registers Xcode's built-in MCP bridge through a root `.mcp.json`.
+- `swiftasb-skills` packages from its child-repo root at `./plugins/swiftasb-skills`, and ships companion guidance for explaining SwiftASB plus building SwiftUI-facing integrations on top of the SwiftASB package.
 - `apple-dev-skills` and `SpeakSwiftlyServer` also carry their own repo-local `.agents/plugins/marketplace.json` files so Codex can track either child repository as a Git-backed standalone marketplace without cloning `socket`.
 - `SpeakSwiftlyServer` owns the canonical `speak-swiftly` plugin payload. The Socket marketplace exposes that payload by Git-backed reference so users can enable `Speak Swiftly` from the Socket catalog without `socket` carrying a second copied plugin directory.
 - `things-app` packages from its child-repo root at `./plugins/things-app`, and its bundled MCP server lives directly under that child repo's top-level `mcp/` directory.
@@ -227,6 +228,7 @@ That marketplace points at the actual plugin root each child repository treats a
 - `./plugins/python-skills`
 - `./plugins/rust-skills`
 - `./plugins/spotify`
+- `./plugins/swiftasb-skills`
 - `./plugins/things-app`
 - `./plugins/web-dev-skills`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 - Milestone 2: subtree workflow hardening - Completed
 - Milestone 3: release and sync discipline - Completed
 - Milestone 4: Speak Swiftly plugin catalog split - In Progress
-- Milestone 5: SwiftASB skills plugin - Planned
+- Milestone 5: SwiftASB skills plugin - In Progress
 
 ## Milestone 2: subtree workflow hardening
 
@@ -117,28 +117,28 @@ Verified against `gaelic-ghost/SpeakSwiftlyServer` `v4.5.0`: the released reposi
 
 ### Status
 
-Planned
+In Progress
 
 ### Scope
 
-- [ ] Add a Socket-hosted `swiftasb-skills` child plugin that helps agents explain SwiftASB, choose an integration shape, and build SwiftUI, AppKit, and Swift package surfaces on top of SwiftASB.
+- [x] Add a Socket-hosted `swiftasb-skills` child plugin that helps agents explain SwiftASB, choose an integration shape, and build SwiftUI, AppKit, and Swift package surfaces on top of SwiftASB.
 - [ ] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle an MCP server, duplicate SwiftASB source, or copy generated schema files into `socket`.
 - [ ] Keep Apple framework workflow rules delegated to `apple-dev-skills`, with this plugin focused on SwiftASB-specific explanation, decision support, integration, and troubleshooting.
 - [ ] Keep the detailed implementation plan in [`docs/maintainers/swiftasb-skills-plugin-plan.md`](./docs/maintainers/swiftasb-skills-plugin-plan.md).
 
 ### Tickets
 
-- [ ] Create `plugins/swiftasb-skills/` with its own `.codex-plugin/plugin.json` and authored `skills/` source.
-- [ ] Add first-slice skills for explaining SwiftASB, choosing an integration shape, and building a SwiftUI app on top of SwiftASB.
+- [x] Create `plugins/swiftasb-skills/` with its own `.codex-plugin/plugin.json` and authored `skills/` source.
+- [x] Add first-slice skills for explaining SwiftASB, choosing an integration shape, and building a SwiftUI app on top of SwiftASB.
 - [ ] Add later-slice skills for AppKit apps, Swift package authors, and integration diagnostics after the first slice proves useful.
-- [ ] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
-- [ ] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
+- [x] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
+- [x] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
 - [ ] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` and any child-plugin checks added by the new plugin.
 
 ### Exit Criteria
 
-- [ ] The Socket marketplace exposes `swiftasb-skills` as an installable child plugin.
-- [ ] The new skills can help an agent explain SwiftASB to a user before implementation, including when SwiftASB is not the right fit.
+- [x] The Socket marketplace exposes `swiftasb-skills` as an installable child plugin.
+- [x] The new skills can help an agent explain SwiftASB to a user before implementation, including when SwiftASB is not the right fit.
 - [ ] The new skills guide SwiftUI, AppKit, and Swift package integrations without duplicating broad Apple framework guidance that belongs to `apple-dev-skills`.
 - [ ] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,7 +130,8 @@ In Progress
 
 - [x] Create `plugins/swiftasb-skills/` with its own `.codex-plugin/plugin.json` and authored `skills/` source.
 - [x] Add first-slice skills for explaining SwiftASB, choosing an integration shape, and building a SwiftUI app on top of SwiftASB.
-- [ ] Add later-slice skills for AppKit apps and Swift package authors after the first slice proves useful.
+- [ ] Add `swiftasb:build-appkit-app` for AppKit apps after the first slice proves useful.
+- [ ] Add `swiftasb:build-swift-package` for Swift package authors after the first slice proves useful.
 - [x] Add an integration diagnostics skill for runtime discovery, app-server startup, threads, turns, approvals, diagnostics, MCP status, history reads, and live-test isolation.
 - [x] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
 - [x] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
@@ -145,7 +146,8 @@ In Progress
 
 ## Backlog Candidates
 
-No active backlog candidates are currently tracked here. Add new candidates only when they represent real future work that is not already covered by the maintainer docs or milestone history.
+- [ ] [#35](https://github.com/gaelic-ghost/socket/issues/35) / [#37](https://github.com/gaelic-ghost/socket/issues/37): Harden release and PR scripts around delayed GitHub state. Fold the duplicate timing reports into one implementation pass that reviews CI check registration, PR comment/review reads, remote branch/tag visibility, GitHub release visibility, timeout configuration, logs, and tests across `socket` and the reusable `maintain-project-repo` release assets.
+- [ ] [#31](https://github.com/gaelic-ghost/socket/issues/31): Review the remaining subtree plugin strategy after the Git-backed marketplace shift. Decide whether `apple-dev-skills` and `SpeakSwiftlyServer` still need subtree mirrors, what `socket` should own long term, how versioning should work if more children become standalone-only, and what validation proves the chosen install model.
 
 ## History
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,9 +122,9 @@ In Progress
 ### Scope
 
 - [x] Add a Socket-hosted `swiftasb-skills` child plugin that helps agents explain SwiftASB, choose an integration shape, and build SwiftUI, AppKit, and Swift package surfaces on top of SwiftASB.
-- [ ] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle an MCP server, duplicate SwiftASB source, or copy generated schema files into `socket`.
-- [ ] Keep Apple framework workflow rules delegated to `apple-dev-skills`, with this plugin focused on SwiftASB-specific explanation, decision support, integration, and troubleshooting.
-- [ ] Keep the detailed implementation plan in [`docs/maintainers/swiftasb-skills-plugin-plan.md`](./docs/maintainers/swiftasb-skills-plugin-plan.md).
+- [x] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle an MCP server, duplicate SwiftASB source, or copy generated schema files into `socket`.
+- [x] Keep Apple framework workflow rules delegated to `apple-dev-skills`, with this plugin focused on SwiftASB-specific explanation, decision support, integration, and troubleshooting.
+- [x] Keep the detailed implementation plan in [`docs/maintainers/swiftasb-skills-plugin-plan.md`](./docs/maintainers/swiftasb-skills-plugin-plan.md).
 
 ### Tickets
 
@@ -133,14 +133,14 @@ In Progress
 - [ ] Add later-slice skills for AppKit apps, Swift package authors, and integration diagnostics after the first slice proves useful.
 - [x] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
 - [x] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
-- [ ] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` and any child-plugin checks added by the new plugin.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` and any child-plugin checks added by the new plugin.
 
 ### Exit Criteria
 
 - [x] The Socket marketplace exposes `swiftasb-skills` as an installable child plugin.
 - [x] The new skills can help an agent explain SwiftASB to a user before implementation, including when SwiftASB is not the right fit.
 - [ ] The new skills guide SwiftUI, AppKit, and Swift package integrations without duplicating broad Apple framework guidance that belongs to `apple-dev-skills`.
-- [ ] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
+- [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 
 ## Backlog Candidates
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,7 +146,7 @@ In Progress
 
 ## Backlog Candidates
 
-- [ ] [#35](https://github.com/gaelic-ghost/socket/issues/35) / [#37](https://github.com/gaelic-ghost/socket/issues/37): Harden release and PR scripts around delayed GitHub state. Fold the duplicate timing reports into one implementation pass that reviews CI check registration, PR comment/review reads, remote branch/tag visibility, GitHub release visibility, timeout configuration, logs, and tests across `socket` and the reusable `maintain-project-repo` release assets.
+- [x] [#35](https://github.com/gaelic-ghost/socket/issues/35) / [#37](https://github.com/gaelic-ghost/socket/issues/37): Harden release and PR scripts around delayed GitHub state. Fold the duplicate timing reports into one implementation pass that reviews CI check registration, PR comment/review reads, remote branch/tag visibility, GitHub release visibility, timeout configuration, logs, and tests across `socket` and the reusable `maintain-project-repo` release assets.
 
 ## History
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,6 @@ In Progress
 ## Backlog Candidates
 
 - [ ] [#35](https://github.com/gaelic-ghost/socket/issues/35) / [#37](https://github.com/gaelic-ghost/socket/issues/37): Harden release and PR scripts around delayed GitHub state. Fold the duplicate timing reports into one implementation pass that reviews CI check registration, PR comment/review reads, remote branch/tag visibility, GitHub release visibility, timeout configuration, logs, and tests across `socket` and the reusable `maintain-project-repo` release assets.
-- [ ] [#31](https://github.com/gaelic-ghost/socket/issues/31): Review the remaining subtree plugin strategy after the Git-backed marketplace shift. Decide whether `apple-dev-skills` and `SpeakSwiftlyServer` still need subtree mirrors, what `socket` should own long term, how versioning should work if more children become standalone-only, and what validation proves the chosen install model.
 
 ## History
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,7 +130,8 @@ In Progress
 
 - [x] Create `plugins/swiftasb-skills/` with its own `.codex-plugin/plugin.json` and authored `skills/` source.
 - [x] Add first-slice skills for explaining SwiftASB, choosing an integration shape, and building a SwiftUI app on top of SwiftASB.
-- [ ] Add later-slice skills for AppKit apps, Swift package authors, and integration diagnostics after the first slice proves useful.
+- [ ] Add later-slice skills for AppKit apps and Swift package authors after the first slice proves useful.
+- [x] Add an integration diagnostics skill for runtime discovery, app-server startup, threads, turns, approvals, diagnostics, MCP status, history reads, and live-test isolation.
 - [x] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
 - [x] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` and any child-plugin checks added by the new plugin.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@
 - [Milestone 2: subtree workflow hardening](#milestone-2-subtree-workflow-hardening)
 - [Milestone 3: release and sync discipline](#milestone-3-release-and-sync-discipline)
 - [Milestone 4: Speak Swiftly plugin catalog split](#milestone-4-speak-swiftly-plugin-catalog-split)
+- [Milestone 5: SwiftASB skills plugin](#milestone-5-swiftasb-skills-plugin)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -26,7 +27,8 @@
 
 - Milestone 2: subtree workflow hardening - Completed
 - Milestone 3: release and sync discipline - Completed
-- Milestone 4: Speak Swiftly plugin catalog split - Planned
+- Milestone 4: Speak Swiftly plugin catalog split - In Progress
+- Milestone 5: SwiftASB skills plugin - Planned
 
 ## Milestone 2: subtree workflow hardening
 
@@ -111,12 +113,42 @@ In Progress
 
 Verified against `gaelic-ghost/SpeakSwiftlyServer` `v4.5.0`: the released repository root plugin manifest declares `name: speak-swiftly`, version `2.2.0`, `interface.displayName: Speak Swiftly`, `mcpServers: ./.mcp.json`, `hooks: ./hooks/hooks.json`, and `skills: ./skills/`; its standalone marketplace entry also exposes `speak-swiftly` from `./`. Local checkout install/remove tests for both repositories passed with temporary `CODEX_HOME` directories, leaving the test marketplaces removed. The Git-backed standalone SpeakSwiftlyServer marketplace add/upgrade test passed from isolated state. After PR #36 merged, the Git-backed Socket marketplace add/upgrade test passed from isolated state at Socket revision `5bc1e94`, and the cached Socket catalog exposed `speak-swiftly` from `https://github.com/gaelic-ghost/SpeakSwiftlyServer.git` with `ref: main`.
 
+## Milestone 5: SwiftASB skills plugin
+
+### Status
+
+Planned
+
+### Scope
+
+- [ ] Add a Socket-hosted `swiftasb-skills` child plugin that helps agents explain SwiftASB, choose an integration shape, and build SwiftUI, AppKit, and Swift package surfaces on top of SwiftASB.
+- [ ] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle an MCP server, duplicate SwiftASB source, or copy generated schema files into `socket`.
+- [ ] Keep Apple framework workflow rules delegated to `apple-dev-skills`, with this plugin focused on SwiftASB-specific explanation, decision support, integration, and troubleshooting.
+- [ ] Keep the detailed implementation plan in [`docs/maintainers/swiftasb-skills-plugin-plan.md`](./docs/maintainers/swiftasb-skills-plugin-plan.md).
+
+### Tickets
+
+- [ ] Create `plugins/swiftasb-skills/` with its own `.codex-plugin/plugin.json` and authored `skills/` source.
+- [ ] Add first-slice skills for explaining SwiftASB, choosing an integration shape, and building a SwiftUI app on top of SwiftASB.
+- [ ] Add later-slice skills for AppKit apps, Swift package authors, and integration diagnostics after the first slice proves useful.
+- [ ] Wire `swiftasb-skills` into the root Socket marketplace as a normal local child plugin.
+- [ ] Update root README and maintainer docs so users understand the split between the SwiftASB package source of truth and the Socket-hosted Codex guidance plugin.
+- [ ] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` and any child-plugin checks added by the new plugin.
+
+### Exit Criteria
+
+- [ ] The Socket marketplace exposes `swiftasb-skills` as an installable child plugin.
+- [ ] The new skills can help an agent explain SwiftASB to a user before implementation, including when SwiftASB is not the right fit.
+- [ ] The new skills guide SwiftUI, AppKit, and Swift package integrations without duplicating broad Apple framework guidance that belongs to `apple-dev-skills`.
+- [ ] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
+
 ## Backlog Candidates
 
 No active backlog candidates are currently tracked here. Add new candidates only when they represent real future work that is not already covered by the maintainer docs or milestone history.
 
 ## History
 
+- Planned a `swiftasb-skills` child plugin to help agents explain SwiftASB and build SwiftUI, AppKit, and Swift package integrations from a Socket-visible guidance surface.
 - Added root `docs/media` screenshot assets and README media guidance so the Codex plugin-directory catalog surface is visible without weakening text-first documentation.
 - Planned the `Speak Swiftly` plugin catalog split so the Socket marketplace can expose the canonical `SpeakSwiftlyServer` plugin payload by Git-backed reference instead of carrying a second copied plugin directory.
 - Added coordinated OpenAI Codex Hooks guidance across `agent-plugin-skills` and `productivity-skills`, with future `maintain-project-hooks` work tracked in the productivity roadmap.

--- a/docs/maintainers/swiftasb-skills-plugin-plan.md
+++ b/docs/maintainers/swiftasb-skills-plugin-plan.md
@@ -147,12 +147,12 @@ This skill should cover:
 
 The first slice should be intentionally small:
 
-- [ ] Create `plugins/swiftasb-skills/` with a plugin manifest.
-- [ ] Add `swiftasb:explain-swiftasb`.
-- [ ] Add `swiftasb:choose-integration-shape`.
-- [ ] Add `swiftasb:build-swiftui-app`.
-- [ ] Wire `swiftasb-skills` into `.agents/plugins/marketplace.json`.
-- [ ] Update `README.md` and `ROADMAP.md` so Socket documents the new child plugin surface.
+- [x] Create `plugins/swiftasb-skills/` with a plugin manifest.
+- [x] Add `swiftasb:explain-swiftasb`.
+- [x] Add `swiftasb:choose-integration-shape`.
+- [x] Add `swiftasb:build-swiftui-app`.
+- [x] Wire `swiftasb-skills` into `.agents/plugins/marketplace.json`.
+- [x] Update `README.md` and `ROADMAP.md` so Socket documents the new child plugin surface.
 - [ ] Run `uv run scripts/validate_socket_metadata.py`.
 - [ ] Run any child-plugin validation added by the new plugin.
 
@@ -171,8 +171,8 @@ After the first slice proves useful, add:
 
 The plugin is ready for first release when:
 
-- [ ] Socket exposes `swiftasb-skills` as an installable child plugin.
-- [ ] The skills consistently describe SwiftASB as a Swift-native app-server client rather than a general AI SDK or a raw protocol dump.
-- [ ] The guidance sends Apple framework questions through Apple Dev Skills instead of duplicating broad SwiftUI or AppKit rules.
-- [ ] The guidance points agents back to the SwiftASB package docs for source-of-truth API, licensing, release, and compatibility details.
+- [x] Socket exposes `swiftasb-skills` as an installable child plugin.
+- [x] The skills consistently describe SwiftASB as a Swift-native app-server client rather than a general AI SDK or a raw protocol dump.
+- [x] The guidance sends Apple framework questions through Apple Dev Skills instead of duplicating broad SwiftUI or AppKit rules.
+- [x] The guidance points agents back to the SwiftASB package docs for source-of-truth API, licensing, release, and compatibility details.
 - [ ] Root Socket docs, marketplace wiring, and validation all agree on the plugin's install surface.

--- a/docs/maintainers/swiftasb-skills-plugin-plan.md
+++ b/docs/maintainers/swiftasb-skills-plugin-plan.md
@@ -162,10 +162,10 @@ After the first slice proves useful, add:
 
 - [ ] `swiftasb:build-appkit-app`.
 - [ ] `swiftasb:build-swift-package`.
-- [ ] `swiftasb:diagnose-integration`.
+- [x] `swiftasb:diagnose-integration`.
 - [ ] Examples that show how agents should explain SwiftASB to users before implementation.
 - [ ] Install testing with a temporary `CODEX_HOME`.
-- [ ] A decision on whether SwiftASB itself should also carry a lightweight repo-local marketplace for standalone plugin installation.
+- [x] Decide against a SwiftASB repo-local marketplace because SwiftASB is expected to be consumed as a Swift package dependency inside other apps, command-line tools, and packages; Codex-visible guidance belongs in the Socket-hosted companion plugin.
 
 ## Definition Of Done
 

--- a/docs/maintainers/swiftasb-skills-plugin-plan.md
+++ b/docs/maintainers/swiftasb-skills-plugin-plan.md
@@ -1,0 +1,178 @@
+# SwiftASB Skills Plugin Plan
+
+This plan records the first durable shape for a Socket-hosted SwiftASB companion plugin.
+
+The plugin's job is to help agents build SwiftUI apps, AppKit apps, command-line tools, helper utilities, and Swift packages on top of SwiftASB, then explain the tradeoffs clearly enough that users can decide whether SwiftASB belongs in their project. It should teach the SwiftASB integration surface without turning the SwiftASB package repository into the only Codex-visible guidance source.
+
+## Intent
+
+The SwiftASB skills plugin should help agents do three things:
+
+- explain SwiftASB in plain language for app builders and package authors
+- choose the right integration shape for a user's app, tool, or package
+- implement SwiftASB-backed features while staying close to the real SwiftASB public API and Apple framework behavior
+
+This is a companion guidance plugin, not a runtime plugin. The first version should not bundle an MCP server, duplicate generated schema files, or copy SwiftASB source code into `socket`.
+
+## Packaging Direction
+
+Package the guidance as an independent child plugin under:
+
+```text
+plugins/swiftasb-skills/
+```
+
+The child plugin should own its Codex-facing guidance surface:
+
+- `.codex-plugin/plugin.json`
+- `skills/`
+- README or maintainer notes that explain the plugin's role
+- any validation scripts needed for the plugin's own authored guidance
+
+The root Socket marketplace should list the plugin as a normal local child entry when the plugin is ready to install:
+
+```json
+{
+  "name": "swiftasb-skills",
+  "source": {
+    "source": "local",
+    "path": "./plugins/swiftasb-skills"
+  },
+  "policy": {
+    "installation": "AVAILABLE",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Developer Tools"
+}
+```
+
+Keep the SwiftASB Swift package repository as the source of truth for the library, public API, generated wire types, release notes, licensing, live integration tests, and package-level documentation. Use this Socket plugin for Codex-visible agent workflows and user-facing decision support.
+
+## Relationship To Apple Dev Skills
+
+The SwiftASB plugin should rely on Apple Dev Skills for Apple framework rules and Xcode workflow selection.
+
+That means:
+
+- use Apple Dev Skills for SwiftUI, AppKit, SwiftPM, Xcode, DocC, build, and test workflow rules
+- use SwiftASB skills for the SwiftASB-specific decision, integration, explanation, and troubleshooting work
+- avoid duplicating broad SwiftUI or AppKit architecture guidance unless the guidance is specifically about using SwiftASB inside that framework-owned shape
+
+In practice, a SwiftUI task should first respect documented SwiftUI and Observation behavior, then apply SwiftASB's app-server, thread, turn, dashboard, minimap, and compatibility guidance inside that framework model.
+
+## Proposed Skill Inventory
+
+### `swiftasb:explain-swiftasb`
+
+Explain what SwiftASB does for a user in practical terms.
+
+This skill should cover:
+
+- the real problem SwiftASB solves
+- how it relates to the Codex app-server protocol
+- what app builders get from Swift-native types and observable companions
+- what SwiftASB does not provide
+- when a project should avoid SwiftASB
+- licensing and compatibility caveats that affect adoption decisions
+
+### `swiftasb:choose-integration-shape`
+
+Help an agent decide how SwiftASB should fit into a user's project before implementation starts.
+
+This skill should classify the project shape:
+
+- SwiftUI app
+- AppKit app
+- menu bar app
+- command-line tool
+- helper daemon or local service
+- package-only library
+- test or integration harness
+
+The output should recommend the SwiftASB entry points, user-visible behavior, state ownership, validation path, and documentation updates that fit that project shape.
+
+### `swiftasb:build-swiftui-app`
+
+Guide agents through SwiftUI-facing SwiftASB integration.
+
+This skill should emphasize:
+
+- framework-owned view and task behavior
+- observable companions for thread and turn state
+- user-visible progress, cancellation, and failure states
+- safe same-thread turn handling
+- clear boundaries between app UI state and SwiftASB client state
+- build and test checks appropriate for the app repository
+
+### `swiftasb:build-appkit-app`
+
+Guide agents through AppKit-facing SwiftASB integration.
+
+This skill should emphasize:
+
+- application and window ownership
+- object lifetime for clients, thread handles, and turn handles
+- menu or toolbar actions that start, cancel, resume, or inspect work
+- main-thread UI updates
+- logging and diagnostics that are useful to a Mac app maintainer
+- build and test checks appropriate for the app repository
+
+### `swiftasb:build-swift-package`
+
+Guide agents through package-author integration.
+
+This skill should help package authors:
+
+- expose SwiftASB-backed capabilities without leaking raw wire types as the default API
+- keep public APIs Swift-native and explainable
+- keep live Codex subprocess checks opt-in, timeout-bounded, and isolated
+- document compatibility expectations
+- add focused tests around the package's own behavior
+
+### `swiftasb:diagnose-integration`
+
+Help agents debug SwiftASB integration failures.
+
+This skill should cover:
+
+- Codex CLI discovery and diagnostics
+- app-server startup failures
+- schema or compatibility mismatch symptoms
+- same-thread concurrency rejection
+- turn timeout and cancellation behavior
+- thread history, compaction, and resume/fork surfaces where relevant
+- when to run live integration probes and how to keep them isolated
+
+## First Implementation Slice
+
+The first slice should be intentionally small:
+
+- [ ] Create `plugins/swiftasb-skills/` with a plugin manifest.
+- [ ] Add `swiftasb:explain-swiftasb`.
+- [ ] Add `swiftasb:choose-integration-shape`.
+- [ ] Add `swiftasb:build-swiftui-app`.
+- [ ] Wire `swiftasb-skills` into `.agents/plugins/marketplace.json`.
+- [ ] Update `README.md` and `ROADMAP.md` so Socket documents the new child plugin surface.
+- [ ] Run `uv run scripts/validate_socket_metadata.py`.
+- [ ] Run any child-plugin validation added by the new plugin.
+
+## Later Slices
+
+After the first slice proves useful, add:
+
+- [ ] `swiftasb:build-appkit-app`.
+- [ ] `swiftasb:build-swift-package`.
+- [ ] `swiftasb:diagnose-integration`.
+- [ ] Examples that show how agents should explain SwiftASB to users before implementation.
+- [ ] Install testing with a temporary `CODEX_HOME`.
+- [ ] A decision on whether SwiftASB itself should also carry a lightweight repo-local marketplace for standalone plugin installation.
+
+## Definition Of Done
+
+The plugin is ready for first release when:
+
+- [ ] Socket exposes `swiftasb-skills` as an installable child plugin.
+- [ ] The skills consistently describe SwiftASB as a Swift-native app-server client rather than a general AI SDK or a raw protocol dump.
+- [ ] The guidance sends Apple framework questions through Apple Dev Skills instead of duplicating broad SwiftUI or AppKit rules.
+- [ ] The guidance points agents back to the SwiftASB package docs for source-of-truth API, licensing, release, and compatibility details.
+- [ ] Root Socket docs, marketplace wiring, and validation all agree on the plugin's install surface.

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.3.4"
+version = "6.4.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.3.4"
+version = "6.4.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/config/release.env
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/config/release.env
@@ -1,3 +1,9 @@
 # Repo-maintenance release defaults.
 REPO_MAINTENANCE_DEFAULT_RELEASE_MODE=standard
 REPO_MAINTENANCE_RELEASE_BRANCH=main
+
+# GitHub can accept branch, tag, PR, check, review, and release mutations before
+# those surfaces are immediately readable. These defaults keep release scripts
+# explicit about intentional waits instead of failing on transient indexing gaps.
+REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120
+REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/lib/common.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/lib/common.sh
@@ -38,6 +38,104 @@ load_profile_env() {
   load_env_file "$REPO_MAINTENANCE_ROOT/config/profile.env"
 }
 
+positive_integer_or_default() {
+  value="$1"
+  default_value="$2"
+
+  case "$value" in
+    ''|*[!0-9]*)
+      printf '%s\n' "$default_value"
+      ;;
+    0)
+      printf '%s\n' "$default_value"
+      ;;
+    *)
+      printf '%s\n' "$value"
+      ;;
+  esac
+}
+
+github_wait_timeout() {
+  value="$1"
+  default_timeout="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS:-120}" 120)"
+  positive_integer_or_default "$value" "$default_timeout"
+}
+
+github_wait_poll_seconds() {
+  value="$1"
+  default_poll_seconds="$(positive_integer_or_default "${REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS:-5}" 5)"
+  positive_integer_or_default "$value" "$default_poll_seconds"
+}
+
+wait_for_remote_branch() {
+  branch_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_BRANCH_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_BRANCH_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote branch origin/$branch_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --heads origin "$branch_name" >/dev/null 2>&1; then
+      log "Remote branch origin/$branch_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote branch origin/$branch_name was not visible after ${timeout_seconds}s. Confirm the branch push succeeded and that the origin remote is reachable before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_remote_tag() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_REMOTE_TAG_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_REMOTE_TAG_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for remote tag $tag_name to become visible."
+
+  while :; do
+    if git -C "$REPO_ROOT" ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+      log "Remote tag $tag_name is visible."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "Remote tag $tag_name was not visible after ${timeout_seconds}s. Confirm the tag push succeeded and that GitHub has indexed the tag before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_github_release() {
+  tag_name="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_GH_RELEASE_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_GH_RELEASE_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub release $tag_name to become readable."
+
+  while :; do
+    if gh release view "$tag_name" >/dev/null 2>&1; then
+      log "GitHub release $tag_name is readable."
+      return 0
+    fi
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub release $tag_name was not readable after ${timeout_seconds}s. Confirm release creation succeeded and GitHub has indexed the release before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
 ensure_git_repo() {
   git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "maintain-project-repo must run inside a git worktree rooted at $REPO_ROOT."
 }

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release.sh
@@ -164,6 +164,7 @@ push_release_branch() {
 
   git -C "$REPO_ROOT" push -u origin "$branch_name"
   log "Pushed branch $branch_name."
+  wait_for_remote_branch "$branch_name"
 }
 
 push_release_tag() {
@@ -174,6 +175,7 @@ push_release_tag() {
 
   git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
   log "Pushed tag $RELEASE_TAG."
+  wait_for_remote_tag "$RELEASE_TAG"
 }
 
 create_or_update_pr() {
@@ -236,32 +238,17 @@ watch_ci() {
   log "CI is green for PR #$pr_number."
 }
 
-positive_integer_or_default() {
-  value="$1"
-  default_value="$2"
-
-  case "$value" in
-    ''|*[!0-9]*)
-      printf '%s\n' "$default_value"
-      ;;
-    0)
-      printf '%s\n' "$default_value"
-      ;;
-    *)
-      printf '%s\n' "$value"
-      ;;
-  esac
-}
-
 wait_for_initial_pr_checks() {
   pr_number="$1"
-  timeout_seconds="$(positive_integer_or_default "${REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS:-120}" 120)"
-  poll_seconds="$(positive_integer_or_default "${REPO_MAINTENANCE_INITIAL_CHECK_POLL_SECONDS:-5}" 5)"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_INITIAL_CHECK_POLL_SECONDS:-}")"
   elapsed_seconds="0"
+  last_state="no check data returned yet"
 
   log "Waiting up to ${timeout_seconds}s for GitHub to report initial checks on PR #$pr_number."
 
   while :; do
+    last_state="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'map(.name + ":" + .state) | join(", ")' 2>/dev/null || printf 'no checks reported')"
     check_count="$(gh pr checks "$pr_number" --json name,state,workflow --jq 'length' 2>/dev/null || printf '0')"
     case "$check_count" in
       ''|*[!0-9]*)
@@ -275,7 +262,36 @@ wait_for_initial_pr_checks() {
     fi
 
     if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
-      die "No checks were reported for PR #$pr_number after ${timeout_seconds}s. Confirm the GitHub Actions workflow triggers for the release branch, then rerun release.sh so it can watch CI."
+      die "No checks were reported for PR #$pr_number after ${timeout_seconds}s. Last observed state: $last_state. Confirm the GitHub Actions workflow triggers for the release branch, Actions is enabled, and the branch push succeeded before rerunning release.sh."
+    fi
+
+    sleep "$poll_seconds"
+    elapsed_seconds=$((elapsed_seconds + poll_seconds))
+  done
+}
+
+wait_for_pr_review_state() {
+  pr_number="$1"
+  timeout_seconds="$(github_wait_timeout "${REPO_MAINTENANCE_PR_REVIEW_TIMEOUT_SECONDS:-}")"
+  poll_seconds="$(github_wait_poll_seconds "${REPO_MAINTENANCE_PR_REVIEW_POLL_SECONDS:-}")"
+  elapsed_seconds="0"
+  last_state="PR review/comment state has not been read yet"
+
+  log "Waiting up to ${timeout_seconds}s for GitHub review/comment state on PR #$pr_number."
+
+  while :; do
+    last_state="$(gh pr view "$pr_number" --json reviewDecision,comments,reviews --jq '"reviewDecision=" + (.reviewDecision // "") + ", comments=" + ((.comments | length) | tostring) + ", reviews=" + ((.reviews | length) | tostring)' 2>/dev/null || printf 'GitHub did not return PR review/comment state')"
+    case "$last_state" in
+      "GitHub did not return PR review/comment state")
+        ;;
+      *)
+        log "GitHub review/comment state is readable for PR #$pr_number: $last_state."
+        return 0
+        ;;
+    esac
+
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
+      die "GitHub review/comment state for PR #$pr_number was not readable after ${timeout_seconds}s. Last observed state: $last_state. Confirm the PR exists and GitHub is returning review data before rerunning release.sh."
     fi
 
     sleep "$poll_seconds"
@@ -290,6 +306,8 @@ check_pr_comments() {
     log "Would check PR #$pr_number for comments and requested changes."
     return 0
   fi
+
+  wait_for_pr_review_state "$pr_number"
 
   review_decision="$(gh pr view "$pr_number" --json reviewDecision --jq '.reviewDecision // ""')"
   comment_count="$(gh pr view "$pr_number" --json comments,reviews --jq '([.comments[]?, (.reviews[]? | select(.state == "COMMENTED"))] | length)')"
@@ -352,6 +370,7 @@ create_github_release() {
 
   gh release create "$RELEASE_TAG" --verify-tag --generate-notes
   log "Created GitHub release $RELEASE_TAG."
+  wait_for_github_release "$RELEASE_TAG"
 }
 
 cleanup_merged_branches() {

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release/30-push-release.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release/30-push-release.sh
@@ -13,5 +13,7 @@ if [ "${REPO_MAINTENANCE_DRY_RUN:-false}" = "true" ]; then
 fi
 
 git -C "$REPO_ROOT" push -u origin "$branch_name"
+wait_for_remote_branch "$branch_name"
 git -C "$REPO_ROOT" push origin "$RELEASE_TAG"
+wait_for_remote_tag "$RELEASE_TAG"
 log "Pushed branch $branch_name and tag $RELEASE_TAG."

--- a/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release/40-github-release.sh
+++ b/plugins/productivity-skills/skills/maintain-project-repo/assets/repo-maintenance/release/40-github-release.sh
@@ -27,3 +27,4 @@ fi
 
 gh release create "$RELEASE_TAG" --verify-tag --generate-notes
 log "Created GitHub release $RELEASE_TAG."
+wait_for_github_release "$RELEASE_TAG"

--- a/plugins/productivity-skills/skills/maintain-project-repo/references/release-modes.md
+++ b/plugins/productivity-skills/skills/maintain-project-repo/references/release-modes.md
@@ -11,16 +11,21 @@ Run it from a feature branch or worktree. Do not run standard release mode from 
 - run the repo-specific version bump hook at `scripts/repo-maintenance/version-bump.sh`
 - commit the version bump as `release: bump versions for vX.Y.Z`
 - push the branch
+- wait for the pushed branch to become visible on the remote before creating or updating the PR
 - open or update a pull request against `main`
+- wait for GitHub to report initial PR checks before treating missing checks as a failure
 - watch CI
 - stop with a clear message if CI is not green so the maintainer can fix the branch, push, and rerun the same script
+- wait for PR review/comment state to be readable before making the review-comment gate decision
 - check PR review state and comments after CI is green
 - stop on requested changes or comments so the maintainer can address valid concerns, add out-of-scope concerns to `ROADMAP.md`, resolve the threads, push, and rerun the same script
 - merge the PR with a merge commit once CI is green and the comment pass is clear
 - fast-forward local `main` from `origin/main`
 - create the annotated release tag locally from the reviewed local `main`
 - push the tag
+- wait for the pushed tag to become visible on the remote before creating the GitHub release
 - create the GitHub release unless skipped
+- wait for the GitHub release object to become readable after creation
 - prune stale remote tracking refs and delete local branches already merged into `main` where safe
 
 Example:
@@ -31,6 +36,8 @@ bash scripts/repo-maintenance/release.sh --mode standard --version v1.2.0
 
 When a release intentionally has no repo version surfaces, pass `--skip-version-bump`. When the PR comment pass has already been handled and only historical comments remain visible through GitHub, rerun with `--review-comments-addressed`.
 
+GitHub visibility waits default to `REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120` and `REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5`. More specific overrides such as `REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS`, `REPO_MAINTENANCE_PR_REVIEW_TIMEOUT_SECONDS`, `REPO_MAINTENANCE_REMOTE_BRANCH_TIMEOUT_SECONDS`, `REPO_MAINTENANCE_REMOTE_TAG_TIMEOUT_SECONDS`, and `REPO_MAINTENANCE_GH_RELEASE_TIMEOUT_SECONDS` can narrow individual gates without editing the script. Timeout failures should name the delayed surface and the last observed state so maintainers can tell indexing lag apart from real CI, review, branch, tag, or release failures.
+
 ## `submodule`
 
 Use this mode when the current repository is checked out as a git submodule inside a larger parent repository:
@@ -40,7 +47,9 @@ Use this mode when the current repository is checked out as a git submodule insi
 - require an actual superproject relationship
 - create the release tag locally
 - push the branch and tag in the submodule repository
+- wait for the pushed branch and tag to become visible on the remote
 - create the GitHub release when `gh` is available
+- wait for the GitHub release object to become readable after creation
 - leave the parent-repo pointer update as a separate explicit follow-up step
 
 Example:

--- a/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
+++ b/plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py
@@ -108,6 +108,10 @@ class RepoMaintenanceToolkitWorkflowTests(unittest.TestCase):
         self.assertIn("Standard release mode must run from a release branch or worktree", release_script)
         self.assertIn("version-bump.sh", release_script)
         self.assertIn("wait_for_initial_pr_checks", release_script)
+        self.assertIn("wait_for_remote_branch", release_script)
+        self.assertIn("wait_for_remote_tag", release_script)
+        self.assertIn("wait_for_pr_review_state", release_script)
+        self.assertIn("wait_for_github_release", release_script)
         self.assertIn("REPO_MAINTENANCE_INITIAL_CHECK_TIMEOUT_SECONDS", release_script)
         self.assertIn("push_release_branch", release_script)
         self.assertIn("push_release_tag", release_script)
@@ -117,11 +121,45 @@ class RepoMaintenanceToolkitWorkflowTests(unittest.TestCase):
         self.assertIn("valid concerns in code, or add out-of-scope concerns to ROADMAP.md", release_script)
         self.assertIn('gh pr merge "$pr_number" --merge --delete-branch', release_script)
         self.assertIn('pull --ff-only origin "$base_branch"', release_script)
+        self.assertIn("Last observed state:", release_script)
         self.assertNotIn("release tag `$RELEASE_TAG` was created locally before this PR", release_script)
         standard_flow = release_script[release_script.index("run_standard_release()") :]
         self.assertLess(standard_flow.index("watch_ci \"$pr_number\""), standard_flow.index("create_release_tag"))
         self.assertLess(standard_flow.index("check_pr_comments \"$pr_number\""), standard_flow.index("create_release_tag"))
         self.assertLess(standard_flow.index("fast_forward_base_branch"), standard_flow.index("create_release_tag"))
+
+    def test_common_release_helpers_cover_delayed_github_state(self) -> None:
+        common_script = (ROOT / "skills/maintain-project-repo/assets/repo-maintenance/lib/common.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("wait_for_remote_branch", common_script)
+        self.assertIn("wait_for_remote_tag", common_script)
+        self.assertIn("wait_for_github_release", common_script)
+        self.assertIn("REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS", common_script)
+        self.assertIn("REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS", common_script)
+        self.assertIn("REPO_MAINTENANCE_REMOTE_BRANCH_TIMEOUT_SECONDS", common_script)
+        self.assertIn("REPO_MAINTENANCE_REMOTE_TAG_TIMEOUT_SECONDS", common_script)
+        self.assertIn("REPO_MAINTENANCE_GH_RELEASE_TIMEOUT_SECONDS", common_script)
+        self.assertIn("positive_integer_or_default", common_script)
+
+        push_step = (ROOT / "skills/maintain-project-repo/assets/repo-maintenance/release/30-push-release.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('wait_for_remote_branch "$branch_name"', push_step)
+        self.assertIn('wait_for_remote_tag "$RELEASE_TAG"', push_step)
+
+        release_step = (ROOT / "skills/maintain-project-repo/assets/repo-maintenance/release/40-github-release.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('wait_for_github_release "$RELEASE_TAG"', release_step)
+
+    def test_release_env_documents_github_wait_defaults(self) -> None:
+        release_env = (ROOT / "skills/maintain-project-repo/assets/repo-maintenance/config/release.env").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("REPO_MAINTENANCE_GH_WAIT_TIMEOUT_SECONDS=120", release_env)
+        self.assertIn("REPO_MAINTENANCE_GH_WAIT_POLL_SECONDS=5", release_env)
+        self.assertIn("transient indexing gaps", release_env)
 
     def test_refresh_preserves_repo_specific_extra_script(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.3.4"
+version = "6.4.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "swiftasb-skills",
+  "version": "6.3.4",
+  "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "homepage": "https://github.com/gaelic-ghost/socket/tree/main/plugins/swiftasb-skills",
+  "repository": "https://github.com/gaelic-ghost/socket",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "skills",
+    "swift",
+    "swiftui",
+    "appkit",
+    "swiftasb",
+    "app-server"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SwiftASB Skills",
+    "shortDescription": "SwiftASB explanation and integration workflows for Swift apps and packages.",
+    "longDescription": "Guide Codex agents through explaining SwiftASB, choosing the right integration shape, and building SwiftUI, AppKit, and Swift package surfaces on top of SwiftASB's Swift-native Codex app-server API.",
+    "developerName": "gaelic-ghost",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/swiftasb-skills",
+    "defaultPrompt": [
+      "Explain whether SwiftASB is the right fit for this Swift app before we start building.",
+      "Choose a SwiftASB integration shape for this SwiftUI or AppKit project.",
+      "Add a SwiftUI-facing SwiftASB client model using observable companions."
+    ],
+    "brandColor": "#F05138"
+  }
+}

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -34,7 +34,8 @@
     "defaultPrompt": [
       "Explain whether SwiftASB is the right fit for this Swift app before we start building.",
       "Choose a SwiftASB integration shape for this SwiftUI or AppKit project.",
-      "Add a SwiftUI-facing SwiftASB client model using observable companions."
+      "Add a SwiftUI-facing SwiftASB client model using observable companions.",
+      "Diagnose why this SwiftASB-backed app or test is failing."
     ],
     "brandColor": "#F05138"
   }

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/AGENTS.md
+++ b/plugins/swiftasb-skills/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+Use this file for durable guidance that applies inside the `swiftasb-skills` child plugin.
+
+## Repository Scope
+
+- `swiftasb-skills` is a Socket child plugin that ships Codex skills for explaining and integrating [SwiftASB](https://github.com/gaelic-ghost/SwiftASB).
+- Treat root [`skills/`](./skills/) as the authored skill source of truth.
+- Treat [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) as plugin packaging metadata.
+- Keep this plugin focused on SwiftASB-specific explanation, decision support, and integration workflows.
+
+## Source Of Truth
+
+- Use the current SwiftASB repository, README, DocC docs, release notes, and public Swift API as the source of truth for package behavior.
+- SwiftASB `v1.0.0` is the first supported public API baseline, but active development may move ahead of that release. Verify the local or GitHub package state before writing exact API guidance.
+- Do not copy SwiftASB source, generated wire models, or schema files into this plugin.
+- Do not describe generated `CodexWire...` models as the intended public integration surface. SwiftASB's public surface is the hand-owned Swift API.
+
+## Skill Boundaries
+
+- Use this plugin for SwiftASB-specific choices: whether to adopt SwiftASB, which SwiftASB owner should own the work, how to expose observable companions, and how to explain tradeoffs to a user.
+- Use `apple-dev-skills` for Apple framework behavior, SwiftUI/AppKit lifecycle rules, Xcode workflow selection, DocC, build, and test execution guidance.
+- When a task involves SwiftUI, AppKit, Observation, SwiftPM, or Xcode behavior, read the relevant Apple documentation before making framework claims.
+- Keep user-facing explanations plain and decision-oriented before moving into symbol names.
+
+## Validation
+
+For root Socket marketplace and packaging changes, run from the Socket root:
+
+```bash
+uv run scripts/validate_socket_metadata.py
+```
+
+When these skills are changed, also inspect the authored Markdown for stale SwiftASB symbol names and ensure links still point at the current source-of-truth docs.

--- a/plugins/swiftasb-skills/README.md
+++ b/plugins/swiftasb-skills/README.md
@@ -1,0 +1,92 @@
+# swiftasb-skills
+
+Codex skills for explaining [SwiftASB](https://github.com/gaelic-ghost/SwiftASB) and building Swift apps or packages on top of it.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Usage](#usage)
+- [Development](#development)
+- [Verification](#verification)
+- [Release Notes](#release-notes)
+- [License](#license)
+- [Active Skills](#active-skills)
+- [Packaging](#packaging)
+- [Repository Layout](#repository-layout)
+
+## Overview
+
+`swiftasb-skills` is the SwiftASB companion guidance plugin in Gale's skills ecosystem.
+
+### Status
+
+This directory is active as normal monorepo-owned content inside `socket` and ships the first SwiftASB workflow skills.
+
+### What This Project Is
+
+This plugin helps Codex agents explain SwiftASB, choose an integration shape, and implement SwiftUI-facing SwiftASB work. SwiftASB itself remains the source of truth for the Swift package, public API, DocC, release notes, generated wire maintenance, and licensing.
+
+### Motivation
+
+SwiftASB users need agents to make good adoption and integration decisions before code changes start. This plugin gives agents a Codex-visible workflow surface for that work without requiring SwiftPM dependency checkouts to act as plugin roots.
+
+## Usage
+
+Use `swiftasb-skills` when the work is specifically about:
+
+- explaining what SwiftASB does and whether it fits a user's Swift project
+- choosing between SwiftUI, AppKit, command-line, helper-service, or package-author integration shapes
+- building SwiftUI state around SwiftASB's `CodexAppServer`, `CodexThread`, `CodexTurnHandle`, and observable companions
+
+Use `apple-dev-skills` for Apple framework rules, Xcode workflow selection, SwiftUI/AppKit lifecycle behavior, DocC, build, and test execution.
+
+## Development
+
+Treat root [`skills/`](./skills/) as the source of truth for shipped workflow content. Treat [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) as install-surface metadata.
+
+Before changing exact SwiftASB API guidance, verify the current SwiftASB package state through the local checkout or [GitHub repository](https://github.com/gaelic-ghost/SwiftASB). The first supported public API baseline is `v1.0.0`, but the local package may be under active development.
+
+## Verification
+
+From the Socket root, run:
+
+```bash
+uv run scripts/validate_socket_metadata.py
+```
+
+Also review changed skills for stale SwiftASB symbol names and source-of-truth links.
+
+## Release Notes
+
+Use `socket` Git history and GitHub releases to track shipped changes for this directory.
+
+`swiftasb-skills` follows the shared `socket` semantic version. Version inventory and version bumps must run through the root [`scripts/release.sh`](../../scripts/release.sh) workflow.
+
+## License
+
+See [LICENSE](../../LICENSE) for the Socket superproject license. SwiftASB package licensing is documented in the [SwiftASB repository](https://github.com/gaelic-ghost/SwiftASB).
+
+## Active Skills
+
+- `explain-swiftasb`
+- `choose-integration-shape`
+- `build-swiftui-app`
+
+## Packaging
+
+This repository intentionally keeps authored content and plugin metadata separate.
+
+- root [`skills/`](./skills/) is the canonical authored workflow surface
+- [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) defines the Codex plugin metadata at the repo root
+- the Socket marketplace entry points at `./plugins/swiftasb-skills`
+
+## Repository Layout
+
+```text
+.
+├── .codex-plugin/
+│   └── plugin.json
+├── AGENTS.md
+├── README.md
+└── skills/
+```

--- a/plugins/swiftasb-skills/README.md
+++ b/plugins/swiftasb-skills/README.md
@@ -24,7 +24,7 @@ This directory is active as normal monorepo-owned content inside `socket` and sh
 
 ### What This Project Is
 
-This plugin helps Codex agents explain SwiftASB, choose an integration shape, implement SwiftUI-facing SwiftASB work, and diagnose integration failures. SwiftASB itself remains the source of truth for the Swift package, public API, DocC, release notes, generated wire maintenance, and licensing.
+This plugin helps Codex agents explain SwiftASB, choose an integration shape, implement SwiftUI-facing SwiftASB work, diagnose integration failures, and prepare later AppKit and package-author integrations. SwiftASB itself remains the source of truth for the Swift package, public API, DocC, release notes, generated wire maintenance, and licensing.
 
 ### Motivation
 

--- a/plugins/swiftasb-skills/README.md
+++ b/plugins/swiftasb-skills/README.md
@@ -24,7 +24,7 @@ This directory is active as normal monorepo-owned content inside `socket` and sh
 
 ### What This Project Is
 
-This plugin helps Codex agents explain SwiftASB, choose an integration shape, and implement SwiftUI-facing SwiftASB work. SwiftASB itself remains the source of truth for the Swift package, public API, DocC, release notes, generated wire maintenance, and licensing.
+This plugin helps Codex agents explain SwiftASB, choose an integration shape, implement SwiftUI-facing SwiftASB work, and diagnose integration failures. SwiftASB itself remains the source of truth for the Swift package, public API, DocC, release notes, generated wire maintenance, and licensing.
 
 ### Motivation
 
@@ -37,6 +37,7 @@ Use `swiftasb-skills` when the work is specifically about:
 - explaining what SwiftASB does and whether it fits a user's Swift project
 - choosing between SwiftUI, AppKit, command-line, helper-service, or package-author integration shapes
 - building SwiftUI state around SwiftASB's `CodexAppServer`, `CodexThread`, `CodexTurnHandle`, and observable companions
+- diagnosing SwiftASB integration failures across runtime discovery, app-server startup, threads, turns, approvals, diagnostics, MCP status, history reads, and live-test isolation
 
 Use `apple-dev-skills` for Apple framework rules, Xcode workflow selection, SwiftUI/AppKit lifecycle behavior, DocC, build, and test execution.
 
@@ -71,6 +72,7 @@ See [LICENSE](../../LICENSE) for the Socket superproject license. SwiftASB packa
 - `explain-swiftasb`
 - `choose-integration-shape`
 - `build-swiftui-app`
+- `diagnose-integration`
 
 ## Packaging
 

--- a/plugins/swiftasb-skills/skills/build-swiftui-app/SKILL.md
+++ b/plugins/swiftasb-skills/skills/build-swiftui-app/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: build-swiftui-app
+description: Build or refactor a SwiftUI app feature on top of SwiftASB using framework-owned SwiftUI state, SwiftASB thread and turn handles, observable companions, clear runtime diagnostics, and safe validation.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with SwiftASB v1.0.0 or newer, Swift 6, SwiftPM, SwiftUI, Observation, Xcode, and local Codex app-server integrations.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  package: SwiftASB
+  category: swiftasb-swiftui
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(xcodebuild:*)
+---
+
+# Build SwiftUI App With SwiftASB
+
+## Purpose
+
+Help a SwiftUI app use [SwiftASB](https://github.com/gaelic-ghost/SwiftASB) to start Codex work, show live progress, handle approvals or user input, and expose recent thread history without replaying raw app-server protocol payloads into app state.
+
+The real job is to connect SwiftUI views to SwiftASB's Swift-native handles and observable companions. SwiftUI owns view lifetime and rendering. SwiftASB owns the local Codex app-server process, thread and turn handles, typed events, request responses, diagnostics, and recent-history companions.
+
+## Required Documentation Gate
+
+Before implementing or proposing SwiftUI structure, read the relevant Apple documentation through Apple Dev Skills or official Apple docs.
+
+Minimum rules to rely on:
+
+- SwiftUI `@State` is view-managed storage, and SwiftUI updates dependent views when the value changes.
+- SwiftUI can store `@Observable` objects in `@State`; subviews update when they read changed observable properties.
+- SwiftUI app structure is built from an `App` whose body provides one or more `Scene` values.
+- Observation support should come from the `@Observable` macro rather than bare `Observable` protocol conformance.
+
+Authoritative docs:
+
+- [SwiftUI State](https://developer.apple.com/documentation/swiftui/state)
+- [SwiftUI App](https://developer.apple.com/documentation/swiftui/app)
+- [SwiftUI Scene](https://developer.apple.com/documentation/SwiftUI/Scene)
+- [Observation Observable macro](https://developer.apple.com/documentation/Observation/Observable%28%29)
+
+## When To Use
+
+- Use this skill when a SwiftUI app needs a SwiftASB-backed feature.
+- Use this skill after `swiftasb:choose-integration-shape` selects a SwiftUI app shape.
+- Use this skill when a SwiftUI app needs live Codex progress, approvals, diagnostics, recent turns, recent files, or recent commands.
+- Use this skill for refactors that move a SwiftUI app away from raw JSON-RPC or ad hoc event replay and toward SwiftASB companions.
+
+## Source Check
+
+Verify current SwiftASB docs and public API before editing:
+
+- [SwiftASB GitHub repository](https://github.com/gaelic-ghost/SwiftASB)
+- `Sources/SwiftASB/SwiftASB.docc/GettingStartedWithSwiftASB.md`
+- `Sources/SwiftASB/SwiftASB.docc/SwiftUIObservableCompanions.md`
+- `Sources/SwiftASB/SwiftASB.docc/HandlingTurnProgressAndApprovals.md`
+- `Sources/SwiftASB/Public/CodexAppServer.swift`
+- `Sources/SwiftASB/Public/CodexThread+Dashboard.swift`
+- `Sources/SwiftASB/Public/CodexTurnHandle.swift`
+
+As of SwiftASB `v1.0.0`, SwiftUI-facing integrations should prefer:
+
+- `CodexAppServer` for process startup, initialization, diagnostics, thread creation, and app-wide capability reads
+- `CodexThread` for conversation-scoped turn creation, request routing, thread actions, and local history
+- `CodexTurnHandle` for one active turn, including events, steering, interruption, request responses, and completion handoff
+- `CodexThread.makeDashboard()` for thread-level current state
+- `CodexTurnHandle.minimap` for active-turn current state
+- `CodexThread.makeRecentTurns(...)`, `makeRecentFiles(...)`, and `makeRecentCommands(...)` for local history views
+
+## Implementation Workflow
+
+1. Confirm the app's existing SwiftUI state pattern.
+2. Read Apple docs for the framework behavior the change relies on.
+3. Add SwiftASB as a package dependency only if it is not already present:
+   - package URL: `https://github.com/gaelic-ghost/SwiftASB`
+   - minimum version: `1.0.0`
+   - product: `SwiftASB`
+4. Choose the owner object:
+   - app-wide model owns `CodexAppServer`
+   - workspace, document, or conversation model owns `CodexThread`
+   - active-turn method or model owns `CodexTurnHandle`
+5. Start and initialize the app-server from an explicit async entrypoint.
+6. Create or resume a thread through `CodexAppServer`.
+7. Create observable companions from the thread and current turn.
+8. Render state from companions directly where possible.
+9. Route approval and elicitation responses through the owning `CodexTurnHandle` or `CodexThread`.
+10. Make startup, compatibility, turn, approval, cancellation, and shutdown errors human-readable.
+11. Validate with the repository's documented SwiftPM or Xcode path.
+
+## State Ownership Pattern
+
+Prefer one app-facing model that makes ownership visible:
+
+```swift
+import Observation
+import SwiftASB
+
+@MainActor
+@Observable
+final class CodexWorkspaceModel {
+    private let appServer = CodexAppServer()
+
+    var thread: CodexThread?
+    var dashboard: CodexThread.Dashboard?
+    var currentMinimap: CodexTurnHandle.Minimap?
+    var errorMessage: String?
+
+    func start(workspacePath: String) async {
+        do {
+            try await appServer.start()
+            _ = try await appServer.cliExecutableDiagnostics()
+            try await appServer.initialize(
+                .init(
+                    clientInfo: .init(
+                        name: "ExampleApp",
+                        title: "Example App",
+                        version: "1.0.0"
+                    )
+                )
+            )
+
+            let thread = try await appServer.startThread(
+                .init(currentDirectoryPath: workspacePath)
+            )
+            self.thread = thread
+            dashboard = await thread.makeDashboard()
+        } catch {
+            errorMessage = "SwiftASB could not start the local Codex runtime: \(error)"
+        }
+    }
+
+    func run(_ prompt: String) async {
+        guard let thread else {
+            errorMessage = "SwiftASB cannot start a turn before a thread exists."
+            return
+        }
+
+        do {
+            let turn = try await thread.startTextTurn(prompt)
+            currentMinimap = turn.minimap
+
+            for try await event in turn.events {
+                if case .completed = event {
+                    _ = try await turn.complete()
+                    currentMinimap = nil
+                    return
+                }
+            }
+        } catch {
+            errorMessage = "SwiftASB turn failed before completion: \(error)"
+        }
+    }
+
+    func stop() async {
+        await appServer.stop()
+    }
+}
+```
+
+Use this as a shape, not as a file to paste blindly. Match the app's real lifetime, error model, and UI needs.
+
+## UI Guidance
+
+- Show Codex runtime startup and compatibility failures before offering turn controls.
+- Disable same-thread turn controls while one turn is active, or create a separate thread when concurrent work is truly intended.
+- Use `dashboard` for thread-wide current activity.
+- Use `currentMinimap` for the active turn's command, file-edit, dynamic-tool, collab-tool, MCP, and compaction activity.
+- Use recent companions for inspector rails and completed history instead of building a second cache from raw events.
+- Keep approval and elicitation prompts user-facing and concrete: tell the user what command, file change, permission, or MCP action is being requested.
+- Keep cancellation visible and reversible where the app's product model allows it.
+
+## Validation
+
+Run the repository's documented validation path.
+
+For SwiftPM packages:
+
+```bash
+swift build
+swift test
+```
+
+For Xcode apps, use the repository's documented `xcodebuild` or Xcode MCP workflow. Do not assume SwiftPM validation is enough for an app project with Xcode-owned project settings.
+
+Live Codex integration tests should be opt-in, isolated in temporary workspaces, and bounded by hard timeouts.
+
+## Handoffs
+
+- Use `swiftasb:explain-swiftasb` when the user needs adoption tradeoffs before implementation.
+- Use `swiftasb:choose-integration-shape` when ownership or app shape is unclear.
+- Use `apple-dev-skills:explore-apple-swift-docs` for SwiftUI, Observation, SwiftPM, or AppKit documentation.
+- Use Apple build, test, or Xcode workflow skills for project execution and diagnostics.
+
+## Guardrails
+
+- Do not put raw generated `CodexWire...` models into SwiftUI view state.
+- Do not introduce a command bus or broad coordinator just to forward SwiftASB events; use local model methods and SwiftASB handles unless the app already has a real architecture surface for that job.
+- Do not start overlapping turns on the same thread; SwiftASB rejects that because the live app-server does not expose a reliable independent lifecycle for them.
+- Do not hide local Codex CLI discovery, compatibility, or startup failures behind generic "failed" messages.
+- Do not run multiple SwiftPM or Xcode build/test commands concurrently.

--- a/plugins/swiftasb-skills/skills/choose-integration-shape/SKILL.md
+++ b/plugins/swiftasb-skills/skills/choose-integration-shape/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: choose-integration-shape
+description: Choose the right SwiftASB integration shape for a SwiftUI app, AppKit app, command-line tool, helper service, package library, test harness, or mixed Swift project before implementation starts.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with SwiftASB v1.0.0 or newer, Swift 6, SwiftPM, SwiftUI, AppKit, and local Codex app-server integrations.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  package: SwiftASB
+  category: swiftasb-planning
+allowed-tools: Read Bash(rg:*) Bash(git:*)
+---
+
+# Choose SwiftASB Integration Shape
+
+## Purpose
+
+Pick the smallest correct way for a project to use [SwiftASB](https://github.com/gaelic-ghost/SwiftASB) before code changes begin.
+
+The practical decision is who owns the local Codex runtime, who owns each conversation thread, where active turn state is shown, and how much SwiftASB behavior should be exposed through the user's own app or package API.
+
+## When To Use
+
+- Use this skill when a user wants to build on SwiftASB but has not chosen the app or package architecture.
+- Use this skill before adding SwiftASB to a SwiftUI, AppKit, command-line, helper-service, or package-only project.
+- Use this skill when an existing project has mixed UI, package, and helper targets and needs a clear ownership decision.
+- Use this skill when the agent needs to explain the integration plan before editing code.
+
+## Source Check
+
+Verify current SwiftASB docs and public API before naming exact symbols:
+
+- [SwiftASB GitHub repository](https://github.com/gaelic-ghost/SwiftASB)
+- `README.md`
+- `Sources/SwiftASB/SwiftASB.docc/GettingStartedWithSwiftASB.md`
+- `Sources/SwiftASB/SwiftASB.docc/SwiftUIObservableCompanions.md`
+- `Sources/SwiftASB/Public/`
+
+For SwiftUI, AppKit, SwiftPM, or Xcode behavior, use Apple Dev Skills and Apple documentation first. SwiftASB chooses the Codex integration shape; Apple frameworks still own app lifecycle, view updates, window behavior, and project execution.
+
+## Classification Workflow
+
+1. Inspect the repository shape:
+   - SwiftPM package
+   - Xcode app project or workspace
+   - SwiftUI app
+   - AppKit app
+   - command-line executable
+   - helper daemon or local service
+   - tests or integration harness only
+2. Identify the user-visible job:
+   - chat or transcript UI
+   - workspace inspector
+   - command/file activity monitor
+   - approval and elicitation UI
+   - package API for other apps
+   - automation or one-shot task execution
+3. Choose the SwiftASB owner:
+   - app-wide model owns `CodexAppServer`
+   - document or workspace model owns `CodexThread`
+   - active task model owns `CodexTurnHandle`
+4. Choose the state surface:
+   - SwiftUI observable companions
+   - AppKit controller-owned models
+   - command-line event loop
+   - package API values and async streams
+   - test harness mocks or live opt-in probes
+5. Name validation:
+   - SwiftPM packages: `swift build` and `swift test`
+   - Xcode apps: repository-documented Xcode build and test path
+   - live Codex integration: opt-in flags, temporary workspaces, and hard timeouts only
+
+## Shape Recommendations
+
+### SwiftUI App
+
+Use an app or workspace model to own `CodexAppServer`, then create a `CodexThread` per conversation or workspace. Store SwiftASB observable companions in a view model instead of replaying raw events into unrelated state.
+
+Prefer:
+
+- `CodexThread.makeDashboard()` for thread-wide activity
+- `CodexTurnHandle.minimap` for active turn state
+- recent companions for inspector rails and completed history
+- explicit user-visible error strings for startup, compatibility, and turn failures
+
+Handoff: `swiftasb:build-swiftui-app`.
+
+### AppKit App
+
+Use an application, document, or window-controller-owned model to hold SwiftASB handles. Keep UI mutation on the main actor and make lifetime explicit so windows do not accidentally keep app-server work alive after close.
+
+Plan:
+
+- where `CodexAppServer` starts and stops
+- which window or document owns each `CodexThread`
+- how menu or toolbar actions start, steer, interrupt, or inspect turns
+- how streamed events reach AppKit views safely
+
+### Command-Line Tool
+
+Use `CodexAppServer` in a short-lived async main flow. Start, initialize, create or resume a thread, start a turn, stream terminal output or summary, and stop the app-server predictably.
+
+Avoid building SwiftUI observable companions unless the tool also feeds a UI.
+
+### Helper Service
+
+Use a long-lived owner for `CodexAppServer`, but keep thread ownership and cancellation explicit. Document how the service starts, stops, exposes status, and avoids overlapping same-thread turns.
+
+Treat service interruption, process cleanup, and logs as part of the product behavior.
+
+### Package Library
+
+Expose the package's own narrow API instead of re-exporting all SwiftASB types by default. Use SwiftASB internally unless the consumer genuinely needs direct `CodexAppServer`, `CodexThread`, or `CodexTurnHandle` access.
+
+Keep live Codex tests opt-in and timeout-bounded.
+
+### Test Harness
+
+Prefer mock or deterministic transport tests for package behavior. Use live Codex probes only when the test's purpose is runtime compatibility, and isolate them with temporary directories and environment flags.
+
+## Output Shape
+
+Return:
+
+1. `Chosen shape`: one of SwiftUI app, AppKit app, command-line tool, helper service, package library, test harness, or mixed.
+2. `SwiftASB owners`: who owns `CodexAppServer`, `CodexThread`, and `CodexTurnHandle`.
+3. `State surface`: observable companions, AppKit model, CLI stream, package API, or tests.
+4. `User-visible behavior`: progress, approvals, errors, diagnostics, history, and cancellation.
+5. `Validation path`: exact build/test family to run.
+6. `Next skill`: the next SwiftASB or Apple workflow skill.
+
+## Guardrails
+
+- Do not add a new manager or coordinator without naming the concrete ownership problem it solves.
+- Do not leak raw generated wire types into the user's public API unless the user explicitly asks for protocol-level work.
+- Do not hide same-thread overlap rejection; design the UI or API around one active turn per thread.
+- Do not run live Codex probes as ordinary unit tests.
+- Do not choose Apple framework architecture without reading the relevant Apple docs first.

--- a/plugins/swiftasb-skills/skills/diagnose-integration/SKILL.md
+++ b/plugins/swiftasb-skills/skills/diagnose-integration/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: diagnose-integration
+description: Diagnose SwiftASB integration failures across Codex CLI discovery, app-server startup, initialization, threads, turns, approvals, MCP status, diagnostics, history paging, and live-test isolation.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with SwiftASB v1.0.0 or newer, Swift 6, SwiftPM, SwiftUI, AppKit, CLI tools, package libraries, and local Codex app-server integrations.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  package: SwiftASB
+  category: swiftasb-diagnostics
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(xcodebuild:*)
+---
+
+# Diagnose SwiftASB Integration
+
+## Purpose
+
+Find the concrete failure point in a SwiftASB integration and explain it in terms the app maintainer can act on.
+
+The job is not just to say that "Codex failed." A useful diagnosis identifies which boundary failed: package dependency wiring, Codex CLI discovery, app-server process startup, initialization, thread creation, turn lifecycle, interactive request routing, MCP status, diagnostic stream handling, local history reads, or live-test isolation.
+
+## When To Use
+
+- Use this skill when a SwiftASB-backed app, CLI, helper service, package, or test harness fails.
+- Use this skill when logs mention `CodexAppServerError`, app-server transport failures, protocol failures, same-thread turn rejection, missing Codex CLI, MCP status issues, approval or elicitation problems, or history paging failures.
+- Use this skill before changing SwiftASB integration code when the failure boundary is still unclear.
+- Use this skill when deciding whether a failing check should be a normal unit test, an opt-in live Codex probe, or an app-level integration test.
+
+## Source Check
+
+Verify current SwiftASB docs and public API before naming exact symbols:
+
+- [SwiftASB GitHub repository](https://github.com/gaelic-ghost/SwiftASB)
+- `README.md`
+- `Sources/SwiftASB/SwiftASB.docc/GettingStartedWithSwiftASB.md`
+- `Sources/SwiftASB/SwiftASB.docc/HandlingTurnProgressAndApprovals.md`
+- `Sources/SwiftASB/SwiftASB.docc/ReadingDiagnosticsAndHistory.md`
+- `Sources/SwiftASB/SwiftASB.docc/AppWideCapabilities.md`
+- `Sources/SwiftASB/Public/CodexDiagnostics.swift`
+- `Sources/SwiftASB/Public/CodexErrors.swift`
+
+The current Codex app-server API includes lifecycle operations such as `thread/start`, `thread/resume`, `thread/fork`, `turn/start`, `turn/steer`, `turn/interrupt`, `model/list`, and `mcpServerStatus/list`, plus notifications for thread status, command output, MCP startup status, and skills/plugin state. Use the official [Codex app-server docs](https://developers.openai.com/codex/app-server#api-overview) when the diagnosis depends on upstream app-server behavior rather than SwiftASB's public wrapper.
+
+## Diagnostic Workflow
+
+1. Capture the exact symptom:
+   - thrown error text
+   - app logs
+   - failing test name
+   - user-visible behavior
+   - current branch and package version
+2. Classify the boundary:
+   - dependency wiring
+   - Codex CLI discovery
+   - app-server process startup
+   - initialization
+   - thread lifecycle
+   - turn lifecycle
+   - approval or elicitation response handling
+   - diagnostics stream
+   - app-wide model or MCP capability snapshots
+   - local history or remote turn paging
+   - test isolation
+3. Verify the smallest source-of-truth fact that can confirm or reject the classification.
+4. Recommend the narrowest fix and the exact validation command.
+5. If the failure is from active SwiftASB development, separate "consumer app bug" from "SwiftASB package issue" before editing either repo.
+
+## Boundary Checks
+
+### Dependency Wiring
+
+Check that the package dependency is real and remote-fetchable:
+
+```swift
+.package(url: "https://github.com/gaelic-ghost/SwiftASB", from: "1.0.0")
+```
+
+Then check the target that talks to Codex depends on:
+
+```swift
+.product(name: "SwiftASB", package: "SwiftASB")
+```
+
+Do not commit machine-local package paths such as `/Users/...`, `~/...`, or `../SwiftASB` into public projects.
+
+### Codex CLI Discovery
+
+SwiftASB expects a local Codex CLI runtime. A diagnosis should tell the maintainer which executable was attempted and whether SwiftASB reported it as supported.
+
+Use `CodexAppServer.cliExecutableDiagnostics()` after `start()` and before or after initialization when a UI or CLI needs to show:
+
+- resolved executable path
+- version string
+- support-window compatibility
+- likely runtime setup issue
+
+If the app requires a fixed binary, inspect whether it passes `CodexAppServer.Configuration.codexExecutableURL`.
+
+### App-Server Startup And Initialization
+
+The expected order is:
+
+1. create `CodexAppServer`
+2. call `start()`
+3. inspect `cliExecutableDiagnostics()` when needed
+4. call `initialize(_:)` once with client metadata
+5. create, resume, or fork a thread
+
+If initialization fails, separate process startup from protocol initialization. Startup failures are usually executable, environment, sandbox, or process problems. Initialization failures are usually protocol, compatibility, or malformed client metadata problems.
+
+### Thread Lifecycle
+
+Use `CodexAppServer` for app-wide stored-thread operations and thread creation. Use `CodexThread` for conversation-scoped actions.
+
+Check whether the app is:
+
+- starting an ephemeral thread when it expects stored history
+- resuming or forking the wrong thread id
+- using the wrong current working directory
+- expecting remote turn paging before history has materialized
+- treating thread status notifications as terminal turn completion
+
+### Turn Lifecycle
+
+Use `CodexThread.startTextTurn(...)` to create a `CodexTurnHandle`. Use that handle for active-turn events, steering, interruption, interactive responses, and completion handoff.
+
+If a turn does not behave as expected, check:
+
+- whether another turn is already active on the same thread
+- whether the app is consuming `turn.events`
+- whether terminal completion is being detected
+- whether `complete()` is called only after terminal state when a sealed local snapshot is needed
+- whether cancellation uses `interrupt()` rather than dropping the handle silently
+
+SwiftASB rejects overlapping turns on the same thread with `CodexAppServerError.invalidState` because the live app-server does not expose a reliable independent lifecycle for same-thread overlap.
+
+### Approvals And Elicitation
+
+Approval and elicitation requests are not diagnostics. They are server-originated requests that need typed responses.
+
+Use the same owner that received the request:
+
+- `CodexTurnHandle.respond(to:with:)` for active-turn requests
+- `CodexThread.respond(to:with:)` for thread-scoped requests
+
+If a request response fails, check that the response is sent through the matching thread or turn owner and that the app is not trying to answer a passive diagnostic event.
+
+### Diagnostics Stream
+
+`CodexAppServer.diagnosticEvents()` reports passive runtime diagnostics such as:
+
+- `warning`
+- `guardianWarning`
+- `modelRerouted`
+- `modelVerification`
+
+Diagnostics explain what the runtime is warning about. They are not approval prompts and do not need responses.
+
+### Models And MCP Status
+
+Use app-wide snapshots for settings, inspectors, and runtime health:
+
+- `CodexAppServer.listModels(...)`
+- `CodexAppServer.listMcpServerStatuses(...)`
+
+If an MCP issue appears in the UI, inspect whether the app is showing configured server status, auth state, tools/resources metadata, or startup notifications. Do not infer MCP health only from a failed turn unless the app-wide status surface has also been checked.
+
+### History And Paging
+
+Distinguish local history helpers from direct app-server paging.
+
+Use recent companions and local history helpers for UI history:
+
+- `CodexThread.makeRecentTurns(...)`
+- `CodexThread.makeRecentFiles(...)`
+- `CodexThread.makeRecentCommands(...)`
+- `CodexThread.readRecentTurnHistoryWindow(limit:)`
+- `CodexThread.windowAroundTurn(...)`
+- `CodexThread.windowAroundItem(...)`
+
+Use `CodexAppServer.listThreadTurns(...)` when the app specifically needs direct app-server paging and is prepared to surface app-server failures.
+
+Recent companions may start from an empty local view for ephemeral or not-yet-materialized history while still listening to live events. That is different from a lower-level remote paging failure.
+
+### Test Isolation
+
+Keep normal package tests deterministic. Use live Codex probes only when the purpose is runtime compatibility or real app-server behavior.
+
+Live probes should be:
+
+- opt-in by environment flag
+- run in a temporary workspace
+- bounded by hard timeouts
+- serial rather than parallel with other SwiftPM or Xcode test runs
+- written so failure text names the exact runtime boundary
+
+## Output Shape
+
+Return:
+
+1. `Most likely boundary`: the narrow failure boundary.
+2. `Evidence`: the log, code path, command, or API behavior that supports it.
+3. `What it means`: plain-language impact for the app or package.
+4. `Fix`: one narrow repair path.
+5. `Validation`: exact command or manual check.
+6. `Escalate to SwiftASB?`: yes/no, with the reason.
+
+## Guardrails
+
+- Do not call every thrown error a SwiftASB bug.
+- Do not change the consumer app and SwiftASB package in the same pass unless the evidence proves both need edits.
+- Do not run live Codex probes as default unit tests.
+- Do not hide exact operation names inside vague messages like "failed" or "invalid."
+- Do not answer approval or elicitation requests as if they were diagnostics.
+- Do not use raw generated wire types as the consumer-facing repair path unless the user is intentionally debugging protocol internals.

--- a/plugins/swiftasb-skills/skills/explain-swiftasb/SKILL.md
+++ b/plugins/swiftasb-skills/skills/explain-swiftasb/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: explain-swiftasb
+description: Explain SwiftASB in user-facing terms, including what it does, what it does not do, adoption tradeoffs, licensing, and when it is or is not the right foundation for a Swift app or package.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with SwiftASB v1.0.0 or newer, Swift 6, SwiftPM, SwiftUI, AppKit, and local Codex app-server integrations.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  package: SwiftASB
+  category: swiftasb-explanation
+allowed-tools: Read Bash(rg:*) Bash(git:*)
+---
+
+# Explain SwiftASB
+
+## Purpose
+
+Help a user understand whether [SwiftASB](https://github.com/gaelic-ghost/SwiftASB) is the right foundation for their Swift app, tool, or package before implementation starts.
+
+Start with the real job: SwiftASB lets Swift code drive the local Codex app-server through a Swift-native API. It owns the local Codex subprocess, typed request and response conversion, thread and turn handles, interactive request handling, diagnostics, local history reads, and SwiftUI-friendly observable companions.
+
+## When To Use
+
+- Use this skill when a user asks what SwiftASB is or whether they should build on it.
+- Use this skill before planning a SwiftASB integration when the app shape or adoption tradeoffs are unclear.
+- Use this skill when an agent needs to explain SwiftASB to a non-maintainer user in plain language.
+- Use this skill when licensing, runtime dependency, or API-boundary concerns affect adoption.
+
+## Source Check
+
+Before giving exact API claims, inspect the current SwiftASB source of truth:
+
+- [SwiftASB GitHub repository](https://github.com/gaelic-ghost/SwiftASB)
+- `README.md`
+- `Sources/SwiftASB/SwiftASB.docc/`
+- the public files under `Sources/SwiftASB/Public/`
+- the latest release notes or tags
+
+As of SwiftASB `v1.0.0`, the supported public surface centers on:
+
+- `CodexAppServer`, the owner of the local Codex subprocess and app-wide capability reads
+- `CodexThread`, the handle for one Codex conversation thread
+- `CodexTurnHandle`, the handle for one active turn
+- observable companions such as `CodexThread.Dashboard`, `CodexTurnHandle.Minimap`, `RecentTurns`, `RecentFiles`, and `RecentCommands`
+
+Generated `CodexWire...` models are internal scaffolding, not the recommended app-facing API.
+
+## Explanation Workflow
+
+1. Identify what the user wants to build.
+2. State SwiftASB's job in one plain paragraph.
+3. Name the runtime dependency: a local Codex CLI/app-server must be available.
+4. Explain the main public owners only after the practical job is clear.
+5. Describe the adoption benefits:
+   - Swift-native values instead of raw JSON-RPC payloads
+   - async streams for live thread and turn events
+   - typed approval and elicitation responses
+   - observable companions for SwiftUI inspectors, rails, and progress views
+   - local history helpers for recent turns, files, and commands
+6. Describe the adoption costs:
+   - the app depends on a local Codex runtime
+   - compatibility follows SwiftASB's reviewed Codex CLI support window
+   - same-thread overlapping turns are rejected client-side
+   - generated wire features are not all public API
+   - users must understand the package license before commercial use
+7. Give a clear fit recommendation.
+
+## Fit Guidance
+
+SwiftASB is a good fit when the user needs a Swift app or package to:
+
+- start or control local Codex work
+- show live command, file-edit, MCP, approval, diagnostic, or history state
+- build SwiftUI or AppKit surfaces around Codex conversations
+- keep raw app-server protocol models out of their own public API
+- use typed Swift handles for threads, turns, approvals, elicitation, diagnostics, and recent history
+
+SwiftASB is probably not the right first choice when the user needs:
+
+- a hosted AI SDK unrelated to the local Codex app-server
+- a server-side multi-user agent platform
+- a cross-platform non-Apple UI toolkit as the primary target
+- a stable public wrapper for every experimental Codex app-server feature
+- an integration that cannot depend on a local Codex CLI runtime
+
+## Output Shape
+
+Answer in this order:
+
+1. `Recommendation`: one direct fit call.
+2. `What SwiftASB would do here`: plain-language role.
+3. `What the app would own`: UI, product behavior, persistence choices, and user policy.
+4. `What SwiftASB would own`: app-server process, typed thread and turn API, events, requests, diagnostics, and companions.
+5. `Tradeoffs`: runtime, compatibility, same-thread turn policy, and licensing.
+6. `Next integration step`: the next skill or repo action.
+
+## Handoffs
+
+- Use `swiftasb:choose-integration-shape` when the user wants to proceed but the app shape is not settled.
+- Use `swiftasb:build-swiftui-app` when the chosen target is a SwiftUI app.
+- Use `apple-dev-skills:explore-apple-swift-docs` before making Apple framework claims.
+- Use Apple build or Xcode workflow skills when the task shifts from explanation to project execution.
+
+## Guardrails
+
+- Do not call SwiftASB a general AI SDK.
+- Do not present generated wire models as the public consumer API.
+- Do not promise support for app-server families that SwiftASB has not promoted into public API.
+- Do not hide the local Codex runtime dependency.
+- Do not flatten licensing into "open source" without explaining that SwiftASB's package license is documented in its own repository.

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.3.4"
+version = "6.4.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.3.4"
+version = "6.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.3.4",
+  "version": "6.4.0",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/scripts/validate_socket_metadata.py
+++ b/scripts/validate_socket_metadata.py
@@ -14,6 +14,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MARKETPLACE_PATH = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
 GIT_SOURCE_KINDS = {"url", "git-subdir"}
+INSTALLATION_POLICIES = {"AVAILABLE", "INSTALLED_BY_DEFAULT", "NOT_AVAILABLE"}
+AUTHENTICATION_POLICIES = {"ON_INSTALL", "ON_FIRST_USE"}
 
 
 def fail(message: str) -> None:
@@ -110,7 +112,58 @@ def validate_manifest_path(
     return component_path
 
 
-def validate_local_plugin_entry(*, name: str, source: dict[str, object]) -> None:
+def validate_policy(*, plugin_name: str, entry: dict[str, object]) -> str:
+    policy = entry.get("policy")
+    if not isinstance(policy, dict):
+        fail(f"Marketplace plugin `{plugin_name}` is missing its `policy` object.")
+
+    installation = policy.get("installation")
+    if installation not in INSTALLATION_POLICIES:
+        allowed = ", ".join(sorted(INSTALLATION_POLICIES))
+        fail(
+            f"Marketplace plugin `{plugin_name}` has invalid policy.installation "
+            f"`{installation}`. Expected one of: {allowed}."
+        )
+
+    authentication = policy.get("authentication")
+    if authentication not in AUTHENTICATION_POLICIES:
+        allowed = ", ".join(sorted(AUTHENTICATION_POLICIES))
+        fail(
+            f"Marketplace plugin `{plugin_name}` has invalid policy.authentication "
+            f"`{authentication}`. Expected one of: {allowed}."
+        )
+
+    category = entry.get("category")
+    if not isinstance(category, str) or not category:
+        fail(f"Marketplace plugin `{plugin_name}` must define a non-empty category.")
+
+    return installation
+
+
+def manifest_exports_content(*, plugin_root: Path, plugin_manifest: dict[str, object]) -> bool:
+    skills_path = plugin_manifest.get("skills")
+    if isinstance(skills_path, str):
+        skills_root = (plugin_root / skills_path).resolve()
+        try:
+            skills_root.relative_to(plugin_root)
+        except ValueError:
+            return False
+        if skills_root.is_dir() and any(skills_root.glob("*/SKILL.md")):
+            return True
+
+    for field_name in ("mcpServers", "hooks", "apps"):
+        if plugin_manifest.get(field_name) is not None:
+            return True
+
+    return False
+
+
+def validate_local_plugin_entry(
+    *,
+    name: str,
+    source: dict[str, object],
+    installation_policy: str,
+) -> None:
     relative_path = source.get("path")
     if not isinstance(relative_path, str) or not relative_path.startswith("./"):
         fail(
@@ -151,6 +204,16 @@ def validate_local_plugin_entry(*, name: str, source: dict[str, object]) -> None
         fail(
             f"Marketplace plugin `{name}` points at a packaged manifest that declares "
             f"`{manifest_name}` instead."
+        )
+
+    if (
+        installation_policy != "NOT_AVAILABLE"
+        and not manifest_exports_content(plugin_root=plugin_root, plugin_manifest=plugin_manifest)
+    ):
+        fail(
+            f"Marketplace plugin `{name}` is installable but does not export skills, "
+            "MCP servers, hooks, or apps. Empty placeholder plugins must use "
+            "policy.installation `NOT_AVAILABLE` until they ship content."
         )
 
     skills_dir = plugin_root / "skills"
@@ -210,12 +273,18 @@ def validate_plugin_entry(entry: object, seen_names: set[str]) -> None:
         fail(f"Marketplace plugin name `{name}` is duplicated.")
     seen_names.add(name)
 
+    installation_policy = validate_policy(plugin_name=name, entry=entry)
+
     source = entry.get("source")
     if not isinstance(source, dict):
         fail(f"Marketplace plugin `{name}` is missing its `source` object.")
     source_kind = source.get("source")
     if source_kind == "local":
-        validate_local_plugin_entry(name=name, source=source)
+        validate_local_plugin_entry(
+            name=name,
+            source=source,
+            installation_policy=installation_policy,
+        )
         return
     if source_kind in GIT_SOURCE_KINDS:
         validate_git_source(plugin_name=name, source=source, source_kind=source_kind)

--- a/tests/test_validate_socket_metadata.py
+++ b/tests/test_validate_socket_metadata.py
@@ -35,6 +35,11 @@ def make_marketplace_repo(tmp_path: Path, manifest: dict[str, object]) -> Path:
                             "source": "local",
                             "path": "./plugins/example-skills",
                         },
+                        "policy": {
+                            "installation": "AVAILABLE",
+                            "authentication": "ON_INSTALL",
+                        },
+                        "category": "Developer Tools",
                     }
                 ]
             },
@@ -43,7 +48,7 @@ def make_marketplace_repo(tmp_path: Path, manifest: dict[str, object]) -> Path:
         + "\n",
     )
     write(plugin_root / ".codex-plugin" / "plugin.json", json.dumps(manifest, indent=2) + "\n")
-    (plugin_root / "skills" / "example").mkdir(parents=True)
+    write(plugin_root / "skills" / "example" / "SKILL.md", "---\nname: example\n---\n")
     return repo_root
 
 
@@ -61,6 +66,11 @@ def make_remote_marketplace_repo(
                     {
                         "name": "speak-swiftly",
                         "source": source,
+                        "policy": {
+                            "installation": "AVAILABLE",
+                            "authentication": "ON_INSTALL",
+                        },
+                        "category": "Productivity",
                     }
                 ]
             },
@@ -109,6 +119,43 @@ def test_main_rejects_plugin_manifest_missing_root_skills_component(
 
     with pytest.raises(SystemExit):
         run_validator(repo_root, monkeypatch)
+
+
+def test_main_accepts_unavailable_empty_placeholder_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path
+    plugin_root = repo_root / "plugins" / "placeholder-skills"
+    write(
+        repo_root / ".agents" / "plugins" / "marketplace.json",
+        json.dumps(
+            {
+                "plugins": [
+                    {
+                        "name": "placeholder-skills",
+                        "source": {
+                            "source": "local",
+                            "path": "./plugins/placeholder-skills",
+                        },
+                        "policy": {
+                            "installation": "NOT_AVAILABLE",
+                            "authentication": "ON_INSTALL",
+                        },
+                        "category": "Developer Tools",
+                    }
+                ]
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    write(
+        plugin_root / ".codex-plugin" / "plugin.json",
+        json.dumps({"name": "placeholder-skills"}, indent=2) + "\n",
+    )
+
+    run_validator(repo_root, monkeypatch)
 
 
 def test_main_accepts_root_git_plugin_source(

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.3.4"
+version = "6.4.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What changed
- Add the Socket-hosted swiftasb-skills companion plugin with explanation, integration-shape, SwiftUI app, and integration diagnostics skills.
- Keep future empty placeholder plugins visible but unavailable for install until they export real content.
- Harden reusable release assets around delayed GitHub branch, tag, PR check, review/comment, and release visibility.
- Align maintained version surfaces to 6.4.0.

## Verification
- uv run pytest
- uv run scripts/validate_socket_metadata.py
- uv run plugins/productivity-skills/skills/maintain-project-roadmap/scripts/maintain_project_roadmap.py --project-root /Users/galew/Workspace/gaelic-ghost/socket --run-mode check-only

Closes #35
Closes #37