### PR TITLE
release: socket 6.5.1

### DIFF
--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Apple development workflows for Codex and Claude Code, including SwiftUI architecture and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.5.0"
+version = "6.5.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.5.0"
+version = "6.5.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Standalone plugin repository for future .NET-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Broadly useful productivity workflows for Codex and Claude Code.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/skills/maintain-project-readme/SKILL.md
+++ b/plugins/productivity-skills/skills/maintain-project-readme/SKILL.md
@@ -29,11 +29,14 @@ This skill is the primary layer for README maintenance. It defines the canonical
 
 ## Writing Expectations
 
+- `README.md` is product-focused: write it for end users, evaluators, integrators, and their agents who need to understand what the project is, whether it fits, how to try it, and where the shipped surface lives.
+- Contributor, maintainer, release, validation, branch, review, and local development procedures belong in `CONTRIBUTING.md` or a linked maintainer document. In `README.md`, keep only the shortest useful pointer to that contributor path.
 - `Overview > Status` should be very short and plain: one simple, blunt sentence stating about whether the project is just starting out, exploratory, in early development, stable enough to try, actively available, or superseded/inactive.
 - `Overview > What This Project Is` must be written by the user in the user's own words. If there is no user-authored content available for this section, insert "TBD" and remind the user to author it.
 - `Overview > Motivation` must be written by the user in the user's own words. If there is no user-authored content available for this section, insert "TBD" and remind the user to author it.
 - `Quick Start` should stay human-focused, short, concise, and end-user friendly, or explicitly say the project is still too early for a real quick start and direct curious readers to `Development`.
 - `Usage` should stay human-focused, concise, and informative. Prefer fenced code blocks with info strings when examples help.
+- `Development` should stay short and reader-oriented. Prefer a direct link to `CONTRIBUTING.md` for setup, workflow, validation, review, and maintainer commands instead of duplicating those procedures in the README.
 - `Repo Structure` should be a small directory tree or outline diagram, not a prose section.
 
 ## Codex Subagent Fit
@@ -69,6 +72,7 @@ Treat those two files as the source of truth for the canonical base schema and t
 - Never auto-commit, auto-push, or open a PR.
 - Never invent commands, setup steps, or product claims that are not grounded in the repo.
 - Never edit files other than the target `README.md`.
+- Never move contributor or maintainer procedures into `README.md` when `CONTRIBUTING.md` or a maintainer doc is the correct owner.
 - Keep the README schema hard-enforced against the configured contract instead of inferring structure from repo profile heuristics.
 - Do not relax the configured schema just because the repository is a plugin, skills, or hybrid repo. Use explicit extension via preamble or appendices when the repo genuinely needs an additional structure or section.
 

--- a/plugins/productivity-skills/skills/maintain-project-readme/agents/openai.yaml
+++ b/plugins/productivity-skills/skills/maintain-project-readme/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Maintain Project README"
   short_description: "Audit and apply bounded fixes to README.md files against a hard-enforced base schema."
-  default_prompt: "Use $maintain-project-readme for any repository README that should be normalized against the bundled canonical schema. Load the canonical README config first, enforce the configured section names, ordering, required subsections, and the required table of contents, return audit findings in check-only mode, and in apply mode keep edits bounded to README structure and grounded wording only."
+  default_prompt: "Use $maintain-project-readme for any repository README that should be normalized against the bundled canonical schema. Treat README.md as product-focused for end users, evaluators, integrators, and their agents; contributor and maintainer procedure belongs in CONTRIBUTING.md or linked maintainer docs. Load the canonical README config first, enforce the configured section names, ordering, required subsections, and the required table of contents, return audit findings in check-only mode, and in apply mode keep edits bounded to README structure and grounded wording only."

--- a/plugins/productivity-skills/skills/maintain-project-readme/assets/README.template.md
+++ b/plugins/productivity-skills/skills/maintain-project-readme/assets/README.template.md
@@ -28,7 +28,7 @@ Describe why this project exists, what problem it solves, or why this repo is ma
 
 ## Quick Start
 
-Give a short, succinct, human-friendly quick start for trying or using the project. If the project is still too early for a real quick start, say that plainly and direct curious readers to the Development section instead.
+Give a short, succinct, human-friendly quick start for trying or using the project. If the project is still too early for a real quick start, say that plainly and direct curious readers to the Development section for contributor documentation.
 
 ## Usage
 
@@ -36,17 +36,7 @@ Keep this section concise, consolidated, and human-focused. Prefer fenced code b
 
 ## Development
 
-### Setup
-
-Document the concrete setup steps needed before someone can develop this project.
-
-### Workflow
-
-Explain the normal local development workflow for maintainers and contributors.
-
-### Validation
-
-List the grounded checks used to verify local changes for this project.
+For setup, local workflow, validation, and contribution expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Repo Structure
 

--- a/plugins/productivity-skills/skills/maintain-project-readme/config/readme-customization.template.yaml
+++ b/plugins/productivity-skills/skills/maintain-project-readme/config/readme-customization.template.yaml
@@ -25,10 +25,6 @@ settings:
       - Status
       - What This Project Is
       - Motivation
-    Development:
-      - Setup
-      - Workflow
-      - Validation
   sectionAliases:
     Quick Start:
       - Getting Started
@@ -49,21 +45,11 @@ settings:
 
       Describe why this project exists, what problem it solves, or why this repo is maintained separately.
     Quick Start: |
-      Give a human-friendly quick start for trying or using the project. If the project is still too early for a real quick start, say that plainly and direct curious readers to the Development section instead.
+      Give a human-friendly quick start for trying or using the project. If the project is still too early for a real quick start, say that plainly and direct curious readers to the Development section for contributor documentation.
     Usage: |
       Keep this section concise and human-focused. Prefer fenced code blocks with language info strings when examples help explain normal usage.
     Development: |
-      ### Setup
-
-      Document the concrete setup steps needed before someone can develop this project.
-
-      ### Workflow
-
-      Explain the normal local development workflow for maintainers and contributors.
-
-      ### Validation
-
-      List the grounded checks used to verify local changes for this project.
+      For setup, local workflow, validation, and contribution expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).
     Repo Structure: |
       ```text
       .
@@ -83,9 +69,3 @@ settings:
       Describe the concrete shipped surface, primary audience, and the main repo boundaries for this project.
     Overview/Motivation: |
       Describe why this project exists, what problem it solves, or why this repo is maintained separately.
-    Development/Setup: |
-      Document the concrete setup steps needed before someone can develop this project.
-    Development/Workflow: |
-      Explain the normal local development workflow for maintainers and contributors.
-    Development/Validation: |
-      List the grounded checks used to verify local changes for this project.

--- a/plugins/productivity-skills/skills/maintain-project-readme/references/readme-customization.md
+++ b/plugins/productivity-skills/skills/maintain-project-readme/references/readme-customization.md
@@ -12,7 +12,7 @@ The built-in template config in `config/readme-customization.template.yaml` defi
 - always-required H2-only table of contents
 - canonical top-level sections
 - required `Overview` subsections
-- required `Development` subsections
+- a short `Development` handoff to contributor documentation, usually `CONTRIBUTING.md`
 
 ## Supported Customization Knobs
 

--- a/plugins/productivity-skills/skills/maintain-project-readme/references/section-schema.md
+++ b/plugins/productivity-skills/skills/maintain-project-readme/references/section-schema.md
@@ -10,7 +10,7 @@ The canonical base README structure is defined in `config/readme-customization.t
 - Required subsections use exact `###` heading names from the configured schema.
 - Canonical sections appear in canonical order.
 - `Overview` owns the canonical `Status`, `What This Project Is`, and `Motivation` subsections.
-- `Development` owns the canonical `Setup`, `Workflow`, and `Validation` subsections.
+- `Development` is a short handoff to contributor documentation, usually `CONTRIBUTING.md`; setup, workflow, validation, release, branch, and review procedures do not belong in the base README contract.
 - `Table of Contents` is always required in the base workflow.
 - Additional repo-specific sections may exist, but they follow the canonical block unless a customization override defines a different order.
 - `Table of Contents` is generated from H2 headings only and should use the canonical heading names that appear in the README.

--- a/plugins/productivity-skills/skills/maintain-project-readme/references/verification-checklist.md
+++ b/plugins/productivity-skills/skills/maintain-project-readme/references/verification-checklist.md
@@ -3,7 +3,8 @@
 - The README has a title and one-line summary.
 - The README has a table of contents.
 - The configured canonical top-level sections all exist.
-- The configured required subsections all exist beneath the correct parent section, including `Overview > Status`, `Overview > What This Project Is`, `Overview > Motivation`, `Development > Setup`, `Development > Workflow`, and `Development > Validation`.
+- The configured required subsections all exist beneath the correct parent section, including `Overview > Status`, `Overview > What This Project Is`, and `Overview > Motivation` in the base schema.
+- The base `Development` section stays a short handoff to contributor documentation instead of duplicating setup, workflow, validation, branch, review, release, or maintainer procedure.
 - Canonical sections appear in canonical order.
 - Alias headings are migrated or reported as non-canonical.
 - The table of contents lists the actual H2 headings in order.

--- a/plugins/productivity-skills/skills/maintain-project-readme/scripts/maintain_project_readme.py
+++ b/plugins/productivity-skills/skills/maintain-project-readme/scripts/maintain_project_readme.py
@@ -27,6 +27,16 @@ PLACEHOLDER_PATTERNS = [
     re.compile(r"\bTBD\b", re.IGNORECASE),
     re.compile(r"<[^>]+>"),
 ]
+CONTRIBUTOR_PROCEDURE_HEADINGS = {
+    "Setup",
+    "Workflow",
+    "Validation",
+    "Local Setup",
+    "Development Workflow",
+    "Release Workflow",
+    "Review Workflow",
+    "Maintainer Workflow",
+}
 
 
 @dataclass
@@ -512,6 +522,29 @@ def validate_schema(
                     auto_fixable=False,
                 )
             )
+        if heading == "Development" and not required_subsections(settings).get("Development"):
+            procedure_headings = [
+                subsection for subsection in collect_subsection_headings(body) if subsection in CONTRIBUTOR_PROCEDURE_HEADINGS
+            ]
+            if procedure_headings:
+                content_issues.append(
+                    Issue(
+                        issue_id="readme-development-contains-contributor-procedure",
+                        category="content-quality",
+                        severity="medium",
+                        file=str(readme_path),
+                        evidence=(
+                            "Section '## Development' contains contributor-procedure subsections: "
+                            + ", ".join(f"'### {heading}'" for heading in procedure_headings)
+                            + "."
+                        ),
+                        recommended_fix=(
+                            "Move setup, workflow, validation, release, branch, and review procedures to "
+                            "`CONTRIBUTING.md` or a maintainer document, and keep README.md to a short pointer."
+                        ),
+                        auto_fixable=False,
+                    )
+                )
 
     return schema_issues, content_issues, sections
 

--- a/plugins/productivity-skills/skills/maintain-project-readme/tests/test_maintain_project_readme.py
+++ b/plugins/productivity-skills/skills/maintain-project-readme/tests/test_maintain_project_readme.py
@@ -79,17 +79,7 @@ Use the project according to the documented local workflow.
 
 ## Development
 
-### Setup
-
-Document the concrete setup steps needed before someone can develop this project.
-
-### Workflow
-
-Explain the normal local development workflow for maintainers and contributors.
-
-### Validation
-
-List the grounded checks used to verify local changes for this project.
+For setup, local workflow, validation, and contribution expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Repo Structure
 
@@ -118,16 +108,17 @@ def test_valid_base_readme_has_no_findings(tmp_path: Path) -> None:
     assert report["errors"] == []
 
 
-def test_missing_development_subsection_is_reported(tmp_path: Path) -> None:
+def test_old_style_development_procedure_is_reported(tmp_path: Path) -> None:
     write(
         tmp_path / "README.md",
         valid_readme().replace(
-            "\n### Validation\n\nList the grounded checks used to verify local changes for this project.\n", "\n"
+            "For setup, local workflow, validation, and contribution expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md).",
+            "### Setup\n\nInstall dependencies.\n\n### Workflow\n\nMake a branch and edit files.\n\n### Validation\n\nRun tests.",
         ),
     )
     report, _md = run(tmp_path)
-    issue_ids = {issue["issue_id"] for issue in report["schema_violations"]}
-    assert "missing-subsection-development-validation" in issue_ids
+    issue_ids = {issue["issue_id"] for issue in report["content_quality_issues"]}
+    assert "readme-development-contains-contributor-procedure" in issue_ids
 
 
 def test_overlong_status_is_reported(tmp_path: Path) -> None:
@@ -192,9 +183,7 @@ demo-project keeps the structure tight.
     assert "## Table of Contents" in updated
     assert "## Quick Start" in updated
     assert "### Status" in updated
-    assert "### Setup" in updated
-    assert "### Workflow" in updated
-    assert "### Validation" in updated
+    assert "For setup, local workflow, validation, and contribution expectations" in updated
     assert "## Repo Structure" in updated
     assert "## Release Notes" in updated
     assert report["post_fix_status"] == []
@@ -339,8 +328,7 @@ def test_apply_mode_bootstraps_missing_readme_from_template(tmp_path: Path) -> N
     assert "## Table of Contents" in content
     assert "## Quick Start" in content
     assert "### Status" in content
-    assert "### Setup" in content
-    assert "### Validation" in content
+    assert "For setup, local workflow, validation, and contribution expectations" in content
     assert "## Repo Structure" in content
     assert "```text" in content
     assert "## Release Notes" in content

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, FastAPI and FastMCP scaffolding, FastAPI/FastMCP integration, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.5.0"
+version = "6.5.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Standalone plugin repository for future Rust-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.5.0"
+version = "6.5.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.5.0"
+version = "6.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.5.0"
+version = "6.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- clarifies the maintain-project-readme README/CONTRIBUTING boundary
- updates README skill references so the base Development section is a contributor-doc handoff, not a maintainer procedure block
- bumps maintained socket plugin version surfaces to 6.5.1

## Verification
- uv run pytest plugins/productivity-skills/skills/maintain-project-readme/tests/test_maintain_project_readme.py
- uv run scripts/validate_socket_metadata.py
- uv run pytest
- git diff --check

## Subtree accounting
- No subtree pull or push required; this patch only changes the productivity-skills subtree copy in socket plus shared version surfaces.