### PR TITLE
plugin: add server-side Swift Vapor workflow

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -42,6 +42,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "server-side-swift",
+      "source": {
+        "source": "local",
+        "path": "./plugins/server-side-swift"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "dotnet-skills",
       "source": {
         "source": "local",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ The installable local child entries currently point at:
 - `./plugins/cardhop-app`
 - `./plugins/productivity-skills`
 - `./plugins/python-skills`
+- `./plugins/server-side-swift`
 - `./plugins/swiftasb-skills`
 - `./plugins/things-app`
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Currently available from the catalog:
 - `dotnet-skills`
 - `productivity-skills`
 - `python-skills`
+- `server-side-swift`
 - `speak-swiftly`
 - `swiftasb-skills`
 - `things-app`
@@ -79,6 +80,7 @@ Current Socket catalog shape:
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
+- `server-side-swift`: server-side Swift and Vapor service workflows with SwiftPM-first build, run, test, migration, and diagnostics guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance
 - `things-app`: mixed skill plus bundled MCP server for Things.app workflows

--- a/TODO.md
+++ b/TODO.md
@@ -48,6 +48,14 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 - [x] Update `plugins/python-skills/.codex-plugin/plugin.json` after the new skills exist.
 - [x] Confirm `uv run scripts/validate_repo_metadata.py`, `uv run pytest`, `uv run ruff check .`, and `uv run mypy .` pass after the second skill slice.
 
+### server-side-swift
+
+- [x] Create the Socket-owned `server-side-swift` plugin surface.
+- [x] Add the first real Vapor-focused server-side Swift skill.
+- [ ] Add validation coverage for skill metadata and exported skill inventory once central Socket child-skill validation exists.
+- [ ] Decide whether future server-side Swift skills should cover SwiftNIO, Hummingbird, deployment, or database workflows as separate skills.
+- [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
+
 ### swiftasb-skills
 
 - [x] Sync `swiftasb-skills` with current SwiftASB source and docs.

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "server-side-swift",
+  "version": "6.10.2",
+  "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor and SwiftPM-first workflows.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "homepage": "https://github.com/gaelic-ghost/socket/tree/main/plugins/server-side-swift",
+  "repository": "https://github.com/gaelic-ghost/socket",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "plugin",
+    "skills",
+    "swift",
+    "server-side-swift",
+    "vapor",
+    "swiftpm"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Server-Side Swift",
+    "shortDescription": "Server-side Swift and Vapor workflow guidance for Codex.",
+    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor documentation, Vapor Toolbox usage, local run commands, app structure, routing, middleware, Fluent migrations, environment configuration, tests, and deployment handoffs.",
+    "developerName": "gaelic-ghost",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/server-side-swift",
+    "defaultPrompt": [
+      "Create a Vapor service plan using current Vapor CLI and SwiftPM workflows.",
+      "Inspect this Vapor app and explain its routes, configuration, and run commands.",
+      "Add a Vapor route with tests while keeping domain logic outside handlers.",
+      "Set up Fluent migrations and explain the migration commands.",
+      "Diagnose why this Vapor build, run, migrate, or local server command failed."
+    ],
+    "brandColor": "#0EA5E9"
+  }
+}

--- a/plugins/server-side-swift/AGENTS.md
+++ b/plugins/server-side-swift/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+This file is the Server-Side Swift child-plugin override for work done from `socket`. Follow the root `socket` guidance for general git, docs, release, branch, dependency-provenance, and maintainer workflow rules.
+
+## Scope
+
+- `server-side-swift` is a monorepo-owned Socket child and the canonical source of truth for shipped server-side Swift workflow skills in this repository.
+- Root [`skills/`](./skills/) is the authored workflow surface.
+- The repo root is the Codex plugin root through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+- Treat `apple-dev-skills` as the Apple-platform specialist layer and `server-side-swift` as the server-side Swift layer. Do not put Vapor, SwiftNIO service-hosting, Linux deployment, database, or HTTP server guidance into Apple Dev Skills unless the task is specifically about Apple-platform integration.
+
+## Local Rules
+
+- Match the `socket` shared semantic version exactly; use the Socket root release workflow for version inventory and bumps.
+- Prefer Swift Package Manager as the source of truth for server-side Swift package structure, dependencies, builds, tests, and run commands.
+- Use official framework documentation first for server-side Swift libraries and tools. For Vapor work, use the official Vapor docs before proposing CLI usage, app structure, migrations, deployment, or runtime changes.
+- Treat the Vapor Toolbox as project-creation and convenience tooling, not as a replacement for SwiftPM. Prefer `swift build`, `swift test`, `swift run`, and `swift run App serve` after a project exists unless current Vapor documentation says otherwise for the specific task.
+- Keep server-side Swift examples portable across macOS and Linux unless the target repository documents an Apple-only service environment.
+- Keep dependencies fetchable from GitHub, package registries, package-manager URLs, or other real remote repositories. Do not commit machine-local package paths.
+- Do not add bundled services, local daemons, deployment scripts, template feeds, or MCP servers unless a later plan explicitly calls for that scope.

--- a/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   owner: gaelic-ghost
   repo: socket
   category: server-side-swift-vapor
-allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(vapor:*) Bash(curl:*)
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(brew:*) Bash(swift:*) Bash(vapor:*) Bash(curl:*)
 ---
 
 # Vapor Server Workflow

--- a/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: vapor-server-workflow
+description: Plan, build, run, test, and diagnose Vapor server-side Swift services using current Vapor documentation, Vapor Toolbox project creation, SwiftPM-first commands, routing, middleware, Fluent migrations, environment configuration, and deployment handoffs.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with Vapor, SwiftPM, and server-side Swift projects on macOS or Linux.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: server-side-swift-vapor
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(vapor:*) Bash(curl:*)
+---
+
+# Vapor Server Workflow
+
+## Purpose
+
+Build, modify, run, or diagnose a Vapor service without confusing Vapor-specific server behavior with generic Swift package work or Apple-platform Xcode work.
+
+The practical decision is what the HTTP service exposes, which target owns the Vapor app, where domain logic lives, how configuration reaches the service, how migrations are run, and which command proves the app starts or behaves correctly.
+
+## When To Use
+
+- Use this skill when creating a new Vapor service with the Vapor Toolbox.
+- Use this skill when modifying Vapor routes, route groups, controllers, middleware, app configuration, commands, migrations, or local server behavior.
+- Use this skill when diagnosing `vapor new`, `swift build`, `swift test`, `swift run`, `swift run App serve`, migration, or local HTTP failures in a Vapor project.
+- Use this skill when deciding whether an existing Swift package should become a Vapor service or stay a library consumed by one.
+- Do not use this skill for generic Swift package work that has no Vapor-specific behavior. Hand that work to a SwiftPM package workflow when available.
+- Do not use this skill for Apple-platform app, simulator, preview, or Xcode project membership work.
+- Do not use this skill for non-Vapor server-side Swift frameworks unless the task is a comparison or migration involving Vapor.
+
+## Source Check
+
+Use official Vapor documentation first:
+
+- [Vapor installation](https://docs.vapor.codes/install/macos/)
+- [Vapor Hello, world](https://docs.vapor.codes/getting-started/hello-world/)
+- [Vapor server configuration](https://docs.vapor.codes/advanced/server/)
+- [Vapor commands](https://docs.vapor.codes/advanced/commands/)
+- [Vapor environment](https://docs.vapor.codes/basics/environment/)
+- [Vapor Fluent migrations](https://docs.vapor.codes/fluent/migration/)
+
+Use Swift.org or Swift Package Manager documentation for Swift toolchain and package behavior when Vapor docs do not own the rule being used.
+
+## Planning Workflow
+
+1. Inspect project shape:
+   - `Package.swift`
+   - executable target name, usually `App`
+   - `Sources/App/configure.swift`
+   - `Sources/App/routes.swift`
+   - controllers, models, migrations, middleware, and tests
+   - Docker, deployment, or environment files when present
+2. Identify the service job:
+   - JSON API
+   - website or Leaf-rendered app
+   - webhook receiver
+   - internal service
+   - background command plus HTTP health surface
+3. Confirm the documented command path before running or recommending commands.
+4. Keep SwiftPM as the default execution surface after creation:
+   - create with `vapor new <name>` when the user wants Vapor's template flow
+   - build with `swift build`
+   - test with `swift test`
+   - run locally with `swift run` or `swift run App serve`
+   - inspect Vapor app commands with `swift run App --help`
+   - inspect serve options with `swift run App serve --help`
+5. Keep domain logic outside route handlers when it has meaningful behavior.
+6. Keep configuration explicit and environment-safe.
+7. Add tests at the smallest level that proves behavior.
+8. Validate with the narrowest useful SwiftPM, Vapor app, or HTTP check.
+
+## Vapor Toolbox Usage
+
+The Vapor Toolbox is useful for creating a new Vapor project, but current Vapor documentation does not require it for ordinary development after the package exists.
+
+Use this default creation path on macOS when the user wants a fresh Vapor app and Homebrew is the accepted local package manager:
+
+```bash
+brew install vapor
+vapor new MyService
+cd MyService
+swift run
+```
+
+Use `vapor new MyService -n` only when the user wants the non-interactive bare template and the documented options fit the task. Otherwise, preserve the interactive template questions because they choose real project features such as Fluent, database support, or Leaf.
+
+## App Structure
+
+For typical Vapor 4 projects:
+
+- `configure.swift` owns app-wide setup such as middleware, databases, migrations, commands, encoders, and services.
+- `routes.swift` owns route registration and should stay readable.
+- Controllers are useful when a route group has enough behavior to deserve a named owner.
+- Models and migrations should stay paired closely enough that schema changes are easy to audit.
+- Domain transformations that can be tested without a running HTTP server should live outside route closures.
+
+Do not introduce a service, repository, coordinator, or manager unless it removes a concrete duplication, testability problem, or dependency boundary issue in the current service.
+
+## Configuration And Secrets
+
+Do not commit secrets.
+
+Use environment variables for deployment-sensitive values. For local development, follow existing repo conventions first. If none exist, recommend committed safe defaults and ignored local overrides rather than hard-coded credentials.
+
+When diagnosing configuration, state which variable is missing, where Vapor reads it, which command was running, and what local or deployment setup likely needs correction.
+
+## Routes, Middleware, And Errors
+
+When adding or changing routes:
+
+- name the route method and path
+- describe request body, query, path parameters, response body, and status codes
+- keep validation errors explicit and user-readable
+- avoid blocking work on the event loop
+- use async APIs where the project already uses async handlers
+- prefer typed request and response models over ad hoc dictionaries
+
+When adding middleware:
+
+- identify whether it is global, grouped, or route-specific
+- explain the request or response behavior it changes
+- include a small test or manual check that proves the middleware is active
+
+## Fluent Migrations
+
+When a Vapor project uses Fluent:
+
+- define schema changes as migrations
+- register migrations in app configuration
+- run migrations with `swift run App migrate`
+- revert only when the user understands data-loss risk and the migration supports it
+- use `swift run App migrate --revert` as the documented command form when a revert is intentionally needed
+
+Do not edit a database manually as a substitute for a migration unless the task is explicitly an emergency data repair and the user accepts that risk.
+
+## Testing
+
+Choose the smallest test that proves the behavior:
+
+- pure Swift test for domain logic
+- handler or controller test for request and response behavior
+- migration test when schema setup is the risk
+- local HTTP check only when runtime routing, middleware, or server binding matters
+
+Prefer `swift test` for normal validation. Use `curl` against a locally running server only when the user asked for runtime validation or the change cannot be proven through tests alone.
+
+## Deployment Handoffs
+
+Keep deployment guidance grounded in the repository's existing target first.
+
+When no target exists, distinguish:
+
+- local development run
+- Docker image or Compose workflow
+- Linux process manager or system service
+- hosted platform deployment
+- database migration timing
+
+Do not add Docker, CI, process-manager, or cloud deployment files as part of a route or local development change unless the user asked for deployment scope.
+
+## Output Shape
+
+Return:
+
+1. `Service shape`: package root, executable target, app configuration, route owners, and test surface.
+2. `Vapor docs used`: specific official docs relied on for CLI, app, migration, or runtime behavior.
+3. `Command path`: exact commands run or recommended.
+4. `Behavior`: routes, inputs, outputs, errors, middleware, migrations, or configuration changes.
+5. `Validation`: build, test, serve, migrate, or HTTP check results.
+6. `Handoffs`: SwiftPM, testing, Apple-platform, deployment, or database follow-up when the task crosses this skill's boundary.
+
+## Guardrails
+
+- Do not treat Xcode as required for Vapor service work unless the repository already uses Xcode-specific workflow.
+- Do not let route closures accumulate unrelated business rules.
+- Do not commit secrets, machine-local paths, or deployment credentials.
+- Do not run migration reverts or destructive database commands without explicit user approval.
+- Do not claim Vapor CLI behavior from memory when current official docs can be checked.
+- Do not use obsolete Vapor Toolbox command habits when SwiftPM is the documented path for the task.


### PR DESCRIPTION
## Summary
- add the Socket-owned server-side-swift plugin surface
- ship the first vapor-server-workflow skill with SwiftPM-first Vapor guidance
- wire the plugin into the Socket marketplace and root docs/backlog

## Verification
- uv run scripts/validate_socket_metadata.py
- uv run mypy
- uv run python /Users/galew/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/server-side-swift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `server-side-swift` plugin—a new Developer Tools plugin enabling server-side Swift and Vapor workflows.
  * Introduced Vapor server workflow skill with guidance for building, testing, and deploying Vapor applications.

* **Documentation**
  * Updated marketplace catalog and documentation to reflect the new server-side-swift plugin availability.
  * Added comprehensive guidelines for server-side Swift development practices and conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaelic-ghost/socket/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->