### PR TITLE
plugin: add installable Rust skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -30,28 +30,16 @@
       "category": "Developer Tools"
     },
     {
-      "name": "swiftasb-skills",
+      "name": "cardhop-app",
       "source": {
         "source": "local",
-        "path": "./plugins/swiftasb-skills"
+        "path": "./plugins/cardhop-app"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Developer Tools"
-    },
-    {
-      "name": "server-side-swift",
-      "source": {
-        "source": "local",
-        "path": "./plugins/server-side-swift"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Developer Tools"
+      "category": "Productivity"
     },
     {
       "name": "dotnet-skills",
@@ -78,28 +66,22 @@
       "category": "Productivity"
     },
     {
-      "name": "speak-swiftly",
+      "name": "python-skills",
       "source": {
-        "source": "url",
-        "url": "https://github.com/gaelic-ghost/SpeakSwiftlyServer.git",
-        "ref": "main"
+        "source": "local",
+        "path": "./plugins/python-skills"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity",
-      "description": "Local Speak Swiftly speech, playback, runtime operation, MCP, and Codex final-reply TTS hooks.",
-      "interface": {
-        "displayName": "Speak Swiftly",
-        "shortDescription": "Local speech and playback workflows for Codex."
-      }
+      "category": "Developer Tools"
     },
     {
-      "name": "python-skills",
+      "name": "server-side-swift",
       "source": {
         "source": "local",
-        "path": "./plugins/python-skills"
+        "path": "./plugins/server-side-swift"
       },
       "policy": {
         "installation": "AVAILABLE",
@@ -120,16 +102,34 @@
       "category": "Developer Tools"
     },
     {
-      "name": "cardhop-app",
+      "name": "speak-swiftly",
       "source": {
-        "source": "local",
-        "path": "./plugins/cardhop-app"
+        "source": "url",
+        "url": "https://github.com/gaelic-ghost/SpeakSwiftlyServer.git",
+        "ref": "main"
       },
       "policy": {
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "description": "Local Speak Swiftly speech, playback, runtime operation, MCP, and Codex final-reply TTS hooks.",
+      "interface": {
+        "displayName": "Speak Swiftly",
+        "shortDescription": "Local speech and playback workflows for Codex."
+      }
+    },
+    {
+      "name": "swiftasb-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/swiftasb-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     },
     {
       "name": "things-app",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -114,7 +114,7 @@
         "path": "./plugins/rust-skills"
       },
       "policy": {
-        "installation": "NOT_AVAILABLE",
+        "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,17 @@ The installable local child entries currently point at:
 - `./plugins/agent-plugin-skills`
 - `./plugins/apple-dev-skills`
 - `./plugins/cardhop-app`
+- `./plugins/dotnet-skills`
 - `./plugins/productivity-skills`
 - `./plugins/python-skills`
 - `./plugins/server-side-swift`
+- `./plugins/rust-skills`
 - `./plugins/swiftasb-skills`
 - `./plugins/things-app`
 
 The Speak Swiftly entry points at the canonical Git-backed `gaelic-ghost/SpeakSwiftlyServer` plugin source as `speak-swiftly`, with the display name `Speak Swiftly`.
 
-Placeholder entries may stay visible with `policy.installation: NOT_AVAILABLE` until they ship real plugin content. Current placeholder entries are `dotnet-skills`, `rust-skills`, `spotify`, and `web-dev-skills`.
+Placeholder entries may stay visible with `policy.installation: NOT_AVAILABLE` until they ship real plugin content. Current placeholder entries are `spotify` and `web-dev-skills`.
 
 For the detailed packaging stance, use [`docs/maintainers/plugin-packaging-strategy.md`](./docs/maintainers/plugin-packaging-strategy.md). For isolated install testing that leaves personal production installs alone, use [`docs/maintainers/plugin-install-testing.md`](./docs/maintainers/plugin-install-testing.md).
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Currently available from the catalog:
 - `productivity-skills`
 - `python-skills`
 - `server-side-swift`
+- `rust-skills`
 - `speak-swiftly`
 - `swiftasb-skills`
 - `things-app`
@@ -81,13 +82,13 @@ Current Socket catalog shape:
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
 - `server-side-swift`: server-side Swift and Vapor service workflows with SwiftPM-first build, run, test, migration, and diagnostics guidance
+- `rust-skills`: Rust, Cargo, rustup, crate, workspace, test, lint, format, package, and CI workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance
 - `things-app`: mixed skill plus bundled MCP server for Things.app workflows
 
 Placeholder directories for future plugins (not available for install):
 
-- `rust-skills`
 - `spotify`
 - `web-dev-skills`
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current Socket catalog shape:
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
 - `server-side-swift`: server-side Swift and Vapor service workflows with SwiftPM-first build, run, test, migration, and diagnostics guidance
-- `rust-skills`: Rust, Cargo, rustup, crate, workspace, test, lint, format, package, and CI workflow guidance
+- `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, test, lint, format, package, and CI workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance
 - `things-app`: mixed skill plus bundled MCP server for Things.app workflows

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current Socket catalog shape:
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
 - `server-side-swift`: server-side Swift and Vapor service workflows with SwiftPM-first build, run, test, migration, and diagnostics guidance
-- `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, test, lint, format, package, and CI workflow guidance
+- `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, test, lint, and format workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance
 - `things-app`: mixed skill plus bundled MCP server for Things.app workflows

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -183,6 +183,7 @@ In Progress
 - [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
 - [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
 - [x] Add implementation skills for Rust CLI and library crate work.
+- [x] Add package and CI workflow skills for publish-facing and automation guidance.
 - [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable only after real skill content exists.
 - [x] Update root README and maintainer docs so users understand the new installable child plugin surface.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
@@ -191,7 +192,7 @@ In Progress
 
 - [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
 - [x] The new skills can help an agent choose a Rust project shape before implementation.
-- [x] The new skills guide Cargo bootstrap, CLI and library implementation, testing, formatting, linting, and toolchain alignment without bundling broad runtime behavior.
+- [x] The new skills guide Cargo bootstrap, CLI and library implementation, package preparation, CI alignment, testing, formatting, linting, and toolchain alignment without bundling broad runtime behavior.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 
 ## Backlog Candidates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,6 +182,7 @@ In Progress
 - [x] Update `plugins/rust-skills/AGENTS.md` with Rust workflow policy and validation expectations.
 - [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
 - [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
+- [x] Add implementation skills for Rust CLI and library crate work.
 - [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable only after real skill content exists.
 - [x] Update root README and maintainer docs so users understand the new installable child plugin surface.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
@@ -190,7 +191,7 @@ In Progress
 
 - [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
 - [x] The new skills can help an agent choose a Rust project shape before implementation.
-- [x] The new skills guide Cargo bootstrap, testing, formatting, linting, and toolchain alignment without bundling broad runtime behavior.
+- [x] The new skills guide Cargo bootstrap, CLI and library implementation, testing, formatting, linting, and toolchain alignment without bundling broad runtime behavior.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 
 ## Backlog Candidates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 - [Milestone 6: Dotnet skills plugin](#milestone-6-dotnet-skills-plugin)
 - [Milestone 7: Python skills plugin expansion](#milestone-7-python-skills-plugin-expansion)
 - [Milestone 8: Server-Side Swift skills plugin](#milestone-8-server-side-swift-skills-plugin)
+- [Milestone 9: Rust skills plugin](#milestone-9-rust-skills-plugin)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -29,6 +30,7 @@
 - Milestone 6: Dotnet skills plugin - In Progress
 - Milestone 7: Python skills plugin expansion - In Progress
 - Milestone 8: Server-Side Swift skills plugin - In Progress
+- Milestone 9: Rust skills plugin - In Progress
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -161,6 +163,35 @@ In Progress
 - [ ] The plugin gives agents clear framework-specific paths for Vapor and Hummingbird without duplicating generic SwiftPM or Apple-platform workflow guidance.
 - [ ] Protocol, runtime, observability, tracing, Docker, and Apple Containerization guidance each has a clear owner skill or an explicit reason to stay backlog-only.
 - [ ] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
+
+## Milestone 9: Rust skills plugin
+
+### Status
+
+In Progress
+
+### Scope
+
+- [x] Turn the placeholder `rust-skills` child plugin into an installable Rust guidance plugin.
+- [x] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle an MCP server, custom package manager, private template feed, generated scaffold script, or machine-local toolchain state.
+- [x] Keep Rust workflow guidance grounded in official Rust, Cargo, rustup, rustfmt, and Clippy documentation.
+
+### Tickets
+
+- [x] Record the detailed plugin plan in [`docs/maintainers/rust-skills-plugin-plan.md`](./docs/maintainers/rust-skills-plugin-plan.md).
+- [x] Update `plugins/rust-skills/AGENTS.md` with Rust workflow policy and validation expectations.
+- [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
+- [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
+- [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable only after real skill content exists.
+- [x] Update root README and maintainer docs so users understand the new installable child plugin surface.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+### Exit Criteria
+
+- [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
+- [x] The new skills can help an agent choose a Rust project shape before implementation.
+- [x] The new skills guide Cargo bootstrap, testing, formatting, linting, and toolchain alignment without bundling broad runtime behavior.
+- [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 
 ## Backlog Candidates
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,7 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 ### rust-skills
 
 - [x] Author the first real Rust-focused skill tranche for Codex.
+- [x] Add Rust CLI and library implementation guidance after the first planning and validation slice.
 - [x] Update docs to describe shipped behavior once real skill content exists.
 - [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable after real skill content exists.
 - [ ] Add focused validation only if the plugin gains generated examples, scripts, or metadata checks that need more than root marketplace validation.

--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,14 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 - [ ] Decide whether future server-side Swift skills should cover SwiftNIO, Hummingbird, deployment, or database workflows as separate skills.
 - [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
 
+### rust-skills
+
+- [x] Author the first real Rust-focused skill tranche for Codex.
+- [x] Update docs to describe shipped behavior once real skill content exists.
+- [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable after real skill content exists.
+- [ ] Add focused validation only if the plugin gains generated examples, scripts, or metadata checks that need more than root marketplace validation.
+- [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
+
 ### swiftasb-skills
 
 - [x] Sync `swiftasb-skills` with current SwiftASB source and docs.
@@ -81,13 +89,6 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 ### dotnet-skills
 
 - [ ] Author the first real .NET-focused skill for Codex.
-- [ ] Update docs to describe shipped behavior once real skill content exists.
-- [ ] Add the minimum validation or smoke coverage needed for the shipped skill surface.
-- [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
-
-### rust-skills
-
-- [ ] Author the first real Rust-focused skill for Codex.
 - [ ] Update docs to describe shipped behavior once real skill content exists.
 - [ ] Add the minimum validation or smoke coverage needed for the shipped skill surface.
 - [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.

--- a/TODO.md
+++ b/TODO.md
@@ -60,6 +60,7 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 
 - [x] Author the first real Rust-focused skill tranche for Codex.
 - [x] Add Rust CLI and library implementation guidance after the first planning and validation slice.
+- [x] Add Rust package and CI workflow guidance.
 - [x] Update docs to describe shipped behavior once real skill content exists.
 - [x] Switch the root marketplace entry for `rust-skills` from placeholder to installable after real skill content exists.
 - [ ] Add focused validation only if the plugin gains generated examples, scripts, or metadata checks that need more than root marketplace validation.

--- a/docs/maintainers/rust-skills-plugin-plan.md
+++ b/docs/maintainers/rust-skills-plugin-plan.md
@@ -95,6 +95,31 @@ This skill covers:
 - test layout
 - initial build, test, format, and lint validation
 
+### `rust:build-cli-project`
+
+Guide agents through implementing Rust command-line tools.
+
+This skill covers:
+
+- keeping CLI parsing separate from domain behavior
+- choosing dependencies from existing repo policy or explicit user approval
+- shaping user-facing output and exit behavior
+- testing command behavior without turning every test into a shell process
+- handing off to Cargo validation and packaging workflows
+
+### `rust:build-library-crate`
+
+Guide agents through implementing reusable Rust library crates.
+
+This skill covers:
+
+- public API ownership
+- module visibility
+- error types
+- feature flags
+- documentation examples
+- unit, integration, and doctest boundaries
+
 ### `rust:testing-workflow`
 
 Guide agents through Rust test execution and failure triage.
@@ -124,8 +149,6 @@ This skill covers:
 
 ## Next Skill Candidates
 
-- `rust:build-cli-project`
-- `rust:build-library-crate`
 - `rust:package-workflow`
 - `rust:ci-workflow`
 - `rust:upgrade-workflow`
@@ -138,6 +161,7 @@ This skill covers:
 - [x] Update `plugins/rust-skills/AGENTS.md` with Rust workflow policy and validation expectations.
 - [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
 - [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
+- [x] Add implementation skills for Rust CLI and library crate work.
 - [x] Switch the root marketplace entry for `rust-skills` to installable only after real skill content exists.
 - [x] Update root README and TODO so users understand the new installable child plugin surface.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
@@ -146,5 +170,5 @@ This skill covers:
 
 - [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
 - [x] The new skills can help an agent choose a Rust project shape before implementation.
-- [x] The new skills guide Cargo bootstrap, testing, formatting, linting, and toolchain alignment without bundling a runtime service.
+- [x] The new skills guide Cargo bootstrap, CLI and library implementation, testing, formatting, linting, and toolchain alignment without bundling a runtime service.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.

--- a/docs/maintainers/rust-skills-plugin-plan.md
+++ b/docs/maintainers/rust-skills-plugin-plan.md
@@ -1,0 +1,150 @@
+# Rust Skills Plugin Plan
+
+This plan records the first durable shape for a Socket-hosted Rust skills plugin.
+
+The plugin's job is to help agents choose Rust project shapes, bootstrap Cargo crates and workspaces, test and validate Rust projects, and keep Rust tooling guidance grounded in official Rust documentation.
+
+## Intent
+
+The `rust-skills` plugin should help agents do four things:
+
+- choose a Rust crate, package, workspace, or maintenance shape before implementation starts
+- bootstrap reproducible Cargo projects without inventing local-only templates or package sources
+- run and explain Rust build, test, lint, format, package, and CI workflows
+- keep Rust guidance grounded in official Rust language, Cargo, rustup, rustfmt, and Clippy documentation
+
+This is a companion guidance plugin, not a runtime plugin. The first version should not bundle an MCP server, custom package manager, private template feed, generated scaffold script, or machine-local toolchain state.
+
+## Packaging Direction
+
+Package the guidance as an independent child plugin under:
+
+```text
+plugins/rust-skills/
+```
+
+The child plugin owns its Codex-facing guidance surface:
+
+- `.codex-plugin/plugin.json`
+- `skills/`
+- plugin metadata, skill metadata, `AGENTS.md`, and maintainer notes that explain the plugin's role
+- any validation scripts needed for the plugin's own authored guidance
+
+The root Socket marketplace now lists `rust-skills` as an installable child plugin because the first real skills have landed. If the plugin ever loses its exported skill content, switch the marketplace entry back to `NOT_AVAILABLE` in the same pass.
+
+## Rust Workflow Policy
+
+Rust guidance should stay close to the standard toolchain:
+
+- use `cargo` as the default project, package, build, test, and metadata command surface
+- use `rustup` for toolchain installation, overrides, and components
+- treat MSRV as an explicit compatibility contract, not a guess
+- preserve existing repository decisions for edition, workspace layout, lint strictness, and CI matrices
+- prefer narrow validation commands that match the change risk
+- do not add local path dependencies, private registries, custom templates, or extra package managers without an explicit repository reason
+
+When a user has not chosen a project shape, ask or return a decision point before scaffolding.
+
+## Documentation Sources
+
+Use official Rust documentation first:
+
+- [Rust documentation](https://doc.rust-lang.org/)
+- [The Rust Programming Language](https://doc.rust-lang.org/book/)
+- [The Cargo Book](https://doc.rust-lang.org/cargo/)
+- [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html)
+- [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
+- [Cargo continuous integration guide](https://doc.rust-lang.org/cargo/guide/continuous-integration.html)
+- [The rustup book](https://rust-lang.github.io/rustup/)
+- [Clippy documentation](https://doc.rust-lang.org/clippy/)
+- [Rustfmt 2024 style edition guide](https://doc.rust-lang.org/stable/edition-guide/rust-2024/rustfmt-style-edition.html)
+
+When a skill relies on documentation, translate the relevant rule into practical workflow guidance. Do not drop citations into a skill as a substitute for explaining the effect on scaffolding, validation, project layout, or user-facing behavior.
+
+## Shipped Skill Inventory
+
+### `rust:choose-project-shape`
+
+Help an agent decide how Rust should fit into a user's project before implementation starts.
+
+This skill classifies the requested work:
+
+- binary crate
+- library crate
+- Cargo workspace
+- CLI tool
+- service or daemon
+- proc macro
+- FFI boundary
+- embedded or `no_std` target
+- package maintenance or upgrade pass
+
+The output recommends crate shape, workspace boundaries, edition and MSRV checks, validation commands, package boundaries, and documentation updates.
+
+### `rust:bootstrap-cargo-project`
+
+Create or guide a reproducible Cargo project scaffold.
+
+This skill covers:
+
+- `cargo new` versus `cargo init`
+- binary versus library packages
+- workspace layout
+- Rust edition and MSRV handling
+- `rust-toolchain.toml`
+- test layout
+- initial build, test, format, and lint validation
+
+### `rust:testing-workflow`
+
+Guide agents through Rust test execution and failure triage.
+
+This skill covers:
+
+- unit tests
+- integration tests
+- documentation tests
+- examples compiled by `cargo test`
+- feature-gated test matrices
+- failure filtering and targeted reruns
+
+### `rust:tooling-style-workflow`
+
+Align Rust formatting, linting, toolchain, and CI behavior with repository policy.
+
+This skill covers:
+
+- `cargo fmt --check`
+- `cargo clippy`
+- `rustfmt.toml`
+- Rust 2024 style edition behavior
+- `rust-toolchain.toml`
+- CI command shape
+- lint strictness and warnings-as-errors decisions
+
+## Next Skill Candidates
+
+- `rust:build-cli-project`
+- `rust:build-library-crate`
+- `rust:package-workflow`
+- `rust:ci-workflow`
+- `rust:upgrade-workflow`
+- `rust:ffi-workflow`
+- `rust:wasm-workflow`
+- `rust:embedded-workflow`
+
+## Completion Checklist
+
+- [x] Update `plugins/rust-skills/AGENTS.md` with Rust workflow policy and validation expectations.
+- [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
+- [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
+- [x] Switch the root marketplace entry for `rust-skills` to installable only after real skill content exists.
+- [x] Update root README and TODO so users understand the new installable child plugin surface.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+## Exit Criteria
+
+- [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
+- [x] The new skills can help an agent choose a Rust project shape before implementation.
+- [x] The new skills guide Cargo bootstrap, testing, formatting, linting, and toolchain alignment without bundling a runtime service.
+- [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.

--- a/docs/maintainers/rust-skills-plugin-plan.md
+++ b/docs/maintainers/rust-skills-plugin-plan.md
@@ -6,10 +6,11 @@ The plugin's job is to help agents choose Rust project shapes, bootstrap Cargo c
 
 ## Intent
 
-The `rust-skills` plugin should help agents do four things:
+The `rust-skills` plugin should help agents do five things:
 
 - choose a Rust crate, package, workspace, or maintenance shape before implementation starts
 - bootstrap reproducible Cargo projects without inventing local-only templates or package sources
+- implement Rust CLI and library crates with clear public boundaries, diagnostics, tests, and validation
 - run and explain Rust build, test, lint, format, package, and CI workflows
 - keep Rust guidance grounded in official Rust language, Cargo, rustup, rustfmt, and Clippy documentation
 

--- a/docs/maintainers/rust-skills-plugin-plan.md
+++ b/docs/maintainers/rust-skills-plugin-plan.md
@@ -2,7 +2,7 @@
 
 This plan records the first durable shape for a Socket-hosted Rust skills plugin.
 
-The plugin's job is to help agents choose Rust project shapes, bootstrap Cargo crates and workspaces, test and validate Rust projects, and keep Rust tooling guidance grounded in official Rust documentation.
+The plugin's job is to help agents choose Rust project shapes, bootstrap Cargo crates and workspaces, implement CLI and library crates, prepare package surfaces, align CI, test and validate Rust projects, and keep Rust tooling guidance grounded in official Rust documentation.
 
 ## Intent
 
@@ -11,7 +11,7 @@ The `rust-skills` plugin should help agents do five things:
 - choose a Rust crate, package, workspace, or maintenance shape before implementation starts
 - bootstrap reproducible Cargo projects without inventing local-only templates or package sources
 - implement Rust CLI and library crates with clear public boundaries, diagnostics, tests, and validation
-- run and explain Rust build, test, lint, format, package, and CI workflows
+- prepare package surfaces and run Rust build, test, lint, format, package, and CI workflows
 - keep Rust guidance grounded in official Rust language, Cargo, rustup, rustfmt, and Clippy documentation
 
 This is a companion guidance plugin, not a runtime plugin. The first version should not bundle an MCP server, custom package manager, private template feed, generated scaffold script, or machine-local toolchain state.
@@ -54,6 +54,11 @@ Use official Rust documentation first:
 - [The Rust Programming Language](https://doc.rust-lang.org/book/)
 - [The Cargo Book](https://doc.rust-lang.org/cargo/)
 - [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html)
+- [Cargo manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html)
+- [`cargo package`](https://doc.rust-lang.org/cargo/commands/cargo-package.html)
+- [`cargo publish`](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)
+- [Cargo workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
+- [Cargo features reference](https://doc.rust-lang.org/cargo/reference/features.html)
 - [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
 - [Cargo continuous integration guide](https://doc.rust-lang.org/cargo/guide/continuous-integration.html)
 - [The rustup book](https://rust-lang.github.io/rustup/)
@@ -134,6 +139,33 @@ This skill covers:
 - feature-gated test matrices
 - failure filtering and targeted reruns
 
+### `rust:package-workflow`
+
+Guide agents through publish-facing Cargo package preparation.
+
+This skill covers:
+
+- manifest metadata
+- `rust-version` and MSRV checks
+- lockfile policy
+- path dependency restrictions
+- package inclusion and exclusion
+- dry-run package validation
+- publish versus no-publish decisions
+
+### `rust:ci-workflow`
+
+Guide agents through Rust CI validation design.
+
+This skill covers:
+
+- local-to-CI command alignment
+- format, lint, build, test, docs, package, and MSRV checks
+- workspace and feature matrix choices
+- toolchain component setup
+- warnings-as-errors policy
+- cache and artifact boundaries
+
 ### `rust:tooling-style-workflow`
 
 Align Rust formatting, linting, toolchain, and CI behavior with repository policy.
@@ -150,8 +182,6 @@ This skill covers:
 
 ## Next Skill Candidates
 
-- `rust:package-workflow`
-- `rust:ci-workflow`
 - `rust:upgrade-workflow`
 - `rust:ffi-workflow`
 - `rust:wasm-workflow`
@@ -163,6 +193,7 @@ This skill covers:
 - [x] Update `plugins/rust-skills/.codex-plugin/plugin.json` so plugin metadata describes shipped Rust guidance.
 - [x] Add first-slice skills for project-shape choice, Cargo bootstrap, testing, and tooling/style alignment.
 - [x] Add implementation skills for Rust CLI and library crate work.
+- [x] Add package and CI workflow skills for publish-facing and automation guidance.
 - [x] Switch the root marketplace entry for `rust-skills` to installable only after real skill content exists.
 - [x] Update root README and TODO so users understand the new installable child plugin surface.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
@@ -171,5 +202,5 @@ This skill covers:
 
 - [x] The Socket marketplace exposes `rust-skills` as an installable child plugin.
 - [x] The new skills can help an agent choose a Rust project shape before implementation.
-- [x] The new skills guide Cargo bootstrap, CLI and library implementation, testing, formatting, linting, and toolchain alignment without bundling a runtime service.
+- [x] The new skills guide Cargo bootstrap, CLI and library implementation, package preparation, CI alignment, testing, formatting, linting, and toolchain alignment without bundling a runtime service.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.10.2"
+version = "6.11.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.10.2"
+version = "6.11.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.10.2"
+version = "6.11.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "rust-skills",
   "version": "6.10.2",
-  "description": "Standalone plugin repository for future Rust-focused Codex skills.",
+  "description": "Rust, Cargo, rustup, crate, workspace, testing, linting, formatting, package, and CI workflow skills.",
+  "skills": "./skills/",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -18,8 +19,8 @@
   ],
   "interface": {
     "displayName": "Rust Skills",
-    "shortDescription": "Future Rust-focused Codex skills.",
-    "longDescription": "Standalone plugin repository for future Rust-focused Codex skills and maintainer workflows.",
+    "shortDescription": "Rust and Cargo workflow skills for Codex.",
+    "longDescription": "Guidance for choosing Rust project shapes, bootstrapping Cargo crates and workspaces, testing Rust projects, and aligning rustfmt, Clippy, toolchain, package, and CI workflows.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rust-skills",
   "version": "6.10.2",
-  "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, testing, linting, formatting, package, and CI workflow skills.",
+  "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {
     "name": "Gale",
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Rust Skills",
     "shortDescription": "Rust and Cargo workflow skills for Codex.",
-    "longDescription": "Guidance for choosing Rust project shapes, bootstrapping Cargo crates and workspaces, implementing CLI and library crates, testing Rust projects, and aligning rustfmt, Clippy, toolchain, package, and CI workflows.",
+    "longDescription": "Guidance for choosing Rust project shapes, bootstrapping Cargo crates and workspaces, implementing CLI and library crates, preparing Cargo package surfaces, aligning CI, testing Rust projects, and coordinating rustfmt, Clippy, and toolchain workflows.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rust-skills",
   "version": "6.10.2",
-  "description": "Rust, Cargo, rustup, crate, workspace, testing, linting, formatting, package, and CI workflow skills.",
+  "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, testing, linting, formatting, package, and CI workflow skills.",
   "skills": "./skills/",
   "author": {
     "name": "Gale",
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Rust Skills",
     "shortDescription": "Rust and Cargo workflow skills for Codex.",
-    "longDescription": "Guidance for choosing Rust project shapes, bootstrapping Cargo crates and workspaces, testing Rust projects, and aligning rustfmt, Clippy, toolchain, package, and CI workflows.",
+    "longDescription": "Guidance for choosing Rust project shapes, bootstrapping Cargo crates and workspaces, implementing CLI and library crates, testing Rust projects, and aligning rustfmt, Clippy, toolchain, package, and CI workflows.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/AGENTS.md
+++ b/plugins/rust-skills/AGENTS.md
@@ -4,11 +4,19 @@ This file is the Rust Skills child-repo override for work done from `socket`. Fo
 
 ## Scope
 
-- `rust-skills` is a placeholder source for future Rust-focused Codex skills.
-- Keep the repo intentionally minimal until the first real skill lands.
-- [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) is the required plugin root today.
+- `rust-skills` is a monorepo-owned Socket child and the canonical source of truth for shipped Rust workflow skills.
+- Root [`skills/`](./skills/) is the authored workflow surface.
+- The repo root is the Codex plugin root through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+- Treat `productivity-skills` as the default baseline maintainer layer for general repo-doc and maintenance work; use this repo when Rust, Cargo, rustup, crate, workspace, package, test, lint, or formatting behavior should materially change the workflow.
 
 ## Local Rules
 
-- Do not add extra packaging layers, repo-local install machinery, or broad maintainer automation before real skill content exists.
-- Prefer adding actual skill content before expanding docs or workflow complexity.
+- Match the `socket` shared semantic version exactly; use the Socket root release workflow for version inventory and bumps.
+- Use official Rust project documentation first for Rust language, Cargo, rustup, rustfmt, Clippy, testing, package, workspace, edition, and CI behavior.
+- Keep Rust examples grounded in `cargo` and `rustup` unless a repository already documents a different tool path.
+- Ask before choosing a crate or workspace shape when the user's request is ambiguous.
+- Prefer small crates with clear ownership boundaries. Use a Cargo workspace only when multiple crates, packages, or examples need shared dependency and validation behavior.
+- Treat MSRV as an explicit compatibility contract. Do not invent or raise a repo's minimum supported Rust version without checking existing docs, `Cargo.toml`, `rust-toolchain.toml`, CI, or user intent.
+- Keep package dependencies fetchable from crates.io, GitHub, package registries, or other real remote repositories; do not commit machine-local path dependencies.
+- For validation guidance, prefer the narrowest relevant `cargo fmt --check`, `cargo clippy`, `cargo test`, `cargo build`, or `cargo package` command for the project shape.
+- Do not add extra packaging layers, repo-local install machinery, broad maintainer automation, custom templates, or bundled MCP servers unless a later plan explicitly calls for that scope.

--- a/plugins/rust-skills/skills/bootstrap-cargo-project/SKILL.md
+++ b/plugins/rust-skills/skills/bootstrap-cargo-project/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: bootstrap-cargo-project
+description: Bootstrap or guide a reproducible Rust Cargo project with explicit package or workspace shape, cargo new or cargo init usage, edition and MSRV checks, rust-toolchain handling, test layout, and initial validation commands. Use after the Rust project shape is settled or when adding a new Cargo package to an existing repository.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-bootstrap
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Bootstrap Cargo Project
+
+## Purpose
+
+Create or guide a reproducible Rust project scaffold without hiding important Cargo, edition, MSRV, or workspace decisions.
+
+The user should leave with a clear package or workspace layout and validation commands that prove the scaffold works.
+
+## Source Check
+
+Use official Rust documentation first:
+
+- [The Cargo Book](https://doc.rust-lang.org/cargo/)
+- [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html)
+- [`cargo init`](https://doc.rust-lang.org/cargo/commands/cargo-init.html)
+- [Cargo package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [The rustup book](https://rust-lang.github.io/rustup/)
+- [Rust editions](https://doc.rust-lang.org/edition-guide/editions/)
+
+Cargo currently defaults new packages to the current Rust edition documented by Cargo. Do not hard-code an older edition in new scaffolds unless the repository compatibility policy calls for it.
+
+## Required Inputs
+
+- target path
+- package or workspace name
+- project shape
+- binary, library, or workspace expectation
+- edition expectation
+- MSRV expectation
+- test expectation
+- toolchain pinning expectation
+- git initialization or commit expectation
+
+If the user has not selected a package or workspace shape, use `rust:choose-project-shape` first.
+
+## Guidance Workflow
+
+1. Inspect the target:
+   - existing files
+   - git state
+   - `Cargo.toml`
+   - `Cargo.lock`
+   - `rust-toolchain.toml` or `rust-toolchain`
+   - `.cargo/config.toml`
+   - CI workflows
+2. Confirm the project shape and target path.
+3. Choose Cargo creation command:
+   - use `cargo new` for a new package directory
+   - use `cargo init` for an existing directory
+   - use `--bin` for executable packages
+   - use `--lib` for library packages
+   - use `--vcs none` when inside an existing repository
+4. Choose edition and MSRV behavior:
+   - preserve existing edition in established repos
+   - use Cargo's current default for new standalone packages unless the user asks for a specific edition
+   - add `rust-toolchain.toml` only when reproducibility or contributor setup needs it
+   - do not invent an MSRV without a repository or user decision
+5. Add test layout:
+   - unit tests near implementation for private behavior
+   - `tests/` for integration tests that use the crate externally
+   - doctests when public examples should compile
+6. Run validation appropriate to the scaffold.
+7. Report generated paths and exact commands.
+
+## Command Recipes
+
+Binary package:
+
+```bash
+cargo new my-tool --bin
+cd my-tool
+cargo test
+```
+
+Library package:
+
+```bash
+cargo new my-library --lib
+cd my-library
+cargo test
+```
+
+Package inside an existing Git repository:
+
+```bash
+cargo new crates/my-crate --lib --vcs none
+cargo test -p my-crate
+```
+
+Existing directory:
+
+```bash
+cargo init --lib --vcs none
+cargo test
+```
+
+Minimal workspace root:
+
+```toml
+[workspace]
+resolver = "3"
+members = [
+    "crates/my-crate",
+]
+```
+
+Check the resolver against the repository's edition and Cargo policy before adding it.
+
+## Validation
+
+Prefer the smallest validation that proves the scaffold:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features
+cargo test
+```
+
+Use `cargo build` when tests are intentionally absent. Use `cargo package` only for publishable crate surfaces.
+
+## Output Shape
+
+Return:
+
+1. `Created or planned layout`: package, crate targets, workspace members, tests, and examples.
+2. `Cargo commands`: exact commands run or recommended.
+3. `Compatibility behavior`: edition, MSRV, toolchain, and feature constraints.
+4. `Validation`: format, lint, build, test, or package results.
+5. `Next skill`: implementation, testing, or tooling handoff.
+
+## Guardrails
+
+- Do not scaffold into a non-empty directory without checking the user's intent.
+- Do not initialize nested Git repositories inside an existing repository unless the user explicitly asks for that.
+- Do not add `rust-toolchain.toml` or pin nightly without a concrete reproducibility reason.
+- Do not add dependencies before the project shape and validation path are clear.
+- Do not commit generated files unless the user asks for a commit or the active repo workflow calls for one.

--- a/plugins/rust-skills/skills/build-cli-project/SKILL.md
+++ b/plugins/rust-skills/skills/build-cli-project/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: build-cli-project
+description: Implement Rust command-line tools after the project shape is chosen, including argument parsing boundaries, command dispatch, stdin/stdout/stderr behavior, exit codes, configuration input, error messages, tests, and Cargo validation. Use for Rust CLI feature work, CLI refactors, or new binary crate implementation.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-implementation
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Build Rust CLI Project
+
+## Purpose
+
+Implement Rust command-line behavior with a clear boundary between user input, command execution, domain logic, and output.
+
+The practical goal is a CLI that is easy to test, has descriptive operator-facing messages, and validates with the repository's Cargo commands.
+
+## Source Check
+
+Use official Rust and Cargo documentation first:
+
+- [The Rust Programming Language](https://doc.rust-lang.org/book/)
+- [The Cargo Book](https://doc.rust-lang.org/cargo/)
+- [Cargo package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
+- [`std::process::ExitCode`](https://doc.rust-lang.org/std/process/struct.ExitCode.html)
+- [`std::env::args`](https://doc.rust-lang.org/std/env/fn.args.html)
+
+For third-party argument parsers, error crates, config crates, terminal styling, or snapshot tools, prefer the repository's existing dependencies first. Add a new crate only when it removes real implementation complexity and comes from a fetchable registry or repository.
+
+## Workflow
+
+1. Inspect the CLI shape:
+   - `Cargo.toml`
+   - `src/main.rs`
+   - `src/bin/`
+   - `src/lib.rs`
+   - existing argument parser or command modules
+   - existing tests in `tests/` or near command code
+2. Identify the command surface:
+   - command name
+   - subcommands
+   - flags and options
+   - positional arguments
+   - stdin, stdout, stderr, files, or environment variables
+   - exit-code expectations
+3. Keep behavior testable:
+   - parse user input into explicit command data
+   - put domain work in functions that accept normal Rust values
+   - keep printing and process exit decisions at the edge
+   - return structured errors or clear result types from internal functions
+4. Implement output deliberately:
+   - stdout for requested command output
+   - stderr for diagnostics, warnings, and failures
+   - descriptive errors that name the failed operation and likely cause
+   - stable text only where tests or downstream users depend on it
+5. Validate with targeted Cargo commands.
+
+## Dependency Decisions
+
+Use the standard library for small internal tools when argument parsing is simple.
+
+Use the repo's existing parser or error-handling crate when one is already established. If adding a new dependency, explain:
+
+- what repeated parsing, validation, help, or error behavior it replaces
+- why the standard library or existing dependency is not enough
+- how the dependency affects MSRV, binary size, and package policy
+
+Do not add a CLI framework only because one is popular.
+
+## Testing Strategy
+
+Prefer fast tests around parsing and command execution functions:
+
+```rust
+#[test]
+fn parses_verbose_flag() {
+    let command = parse_args(["tool", "--verbose", "input.txt"]).unwrap();
+    assert!(command.verbose);
+}
+```
+
+Use process-level integration tests only for behavior that truly depends on the executable boundary, such as stdout, stderr, current directory, environment, or exit status.
+
+Keep error-message tests focused on stable user-facing text.
+
+## Validation
+
+Choose the narrowest command that proves the change:
+
+```bash
+cargo test -p package-name
+cargo clippy -p package-name --all-targets --all-features
+cargo fmt --check
+```
+
+Use workspace-wide commands when the CLI change crosses package boundaries.
+
+## Output Shape
+
+Return:
+
+1. `Command surface`: subcommands, flags, inputs, outputs, and exit behavior changed.
+2. `Implementation boundary`: what lives in parsing, execution, domain logic, and output code.
+3. `Dependencies`: reused, added, or intentionally avoided dependencies.
+4. `Tests`: unit, integration, or process-level coverage added or recommended.
+5. `Validation`: exact Cargo commands run or skipped with the concrete reason.
+6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or future `rust:package-workflow`.
+
+## Guardrails
+
+- Do not put domain behavior directly inside argument parsing code.
+- Do not call `std::process::exit` deep inside reusable functions.
+- Do not write vague errors like `failed` without naming the operation and likely cause.
+- Do not add new CLI dependencies without naming the implementation problem they solve.
+- Do not make stdout/stderr text unstable if tests, scripts, or users depend on it.

--- a/plugins/rust-skills/skills/build-cli-project/SKILL.md
+++ b/plugins/rust-skills/skills/build-cli-project/SKILL.md
@@ -107,7 +107,7 @@ Return:
 3. `Dependencies`: reused, added, or intentionally avoided dependencies.
 4. `Tests`: unit, integration, or process-level coverage added or recommended.
 5. `Validation`: exact Cargo commands run or skipped with the concrete reason.
-6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or future `rust:package-workflow`.
+6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or `rust:package-workflow`.
 
 ## Guardrails
 

--- a/plugins/rust-skills/skills/build-library-crate/SKILL.md
+++ b/plugins/rust-skills/skills/build-library-crate/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: build-library-crate
+description: Implement reusable Rust library crates after the project shape is chosen, including public API design, module visibility, error types, feature flags, documentation examples, unit tests, integration tests, doctests, and Cargo validation. Use for Rust library implementation, API refactors, crate-boundary cleanup, or package-facing behavior.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-implementation
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Build Rust Library Crate
+
+## Purpose
+
+Implement reusable Rust library behavior with a small public API, clear module visibility, and tests at the boundary users actually call.
+
+The practical goal is a crate that is easy to use from downstream code, easy to test inside the repository, and honest about compatibility, features, and errors.
+
+## Source Check
+
+Use official Rust and Cargo documentation first:
+
+- [The Rust Programming Language](https://doc.rust-lang.org/book/)
+- [The Cargo Book](https://doc.rust-lang.org/cargo/)
+- [Cargo package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [Cargo features reference](https://doc.rust-lang.org/cargo/reference/features.html)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
+
+Use the repository's existing API style before introducing a new pattern.
+
+## Workflow
+
+1. Inspect the crate shape:
+   - `Cargo.toml`
+   - `src/lib.rs`
+   - modules under `src/`
+   - `tests/`
+   - public examples and documentation comments
+   - features and optional dependencies
+   - package metadata if the crate is publishable
+2. Identify the caller:
+   - internal binary
+   - sibling workspace crate
+   - external library user
+   - FFI or generated-code caller
+   - tests and examples only
+3. Shape the public API:
+   - expose the smallest set of types and functions users need
+   - keep implementation modules private by default
+   - re-export stable public types deliberately from `lib.rs`
+   - prefer explicit inputs and outputs over hidden global state
+   - make ownership and borrowing convenient for likely callers
+4. Shape errors:
+   - use concrete error types when callers need to match variants
+   - use opaque errors only when callers only need display/debug behavior
+   - include operation context in error messages
+   - preserve source errors when that helps diagnostics
+5. Add tests and docs at the right boundary.
+
+## Module And Visibility Guidance
+
+Prefer private modules with explicit public re-exports:
+
+```rust
+mod parser;
+
+pub use parser::{ParseError, parse_document};
+```
+
+Use `pub(crate)` for shared internal behavior that crosses modules inside one crate. Avoid `pub` just to make tests easy; use unit tests in the module for private behavior and integration tests for public behavior.
+
+Split modules when a file starts owning unrelated jobs such as parsing, validation, rendering, and I/O.
+
+## Feature Guidance
+
+Use Cargo features for real optional behavior:
+
+- optional dependencies
+- format or backend support
+- `std` versus `no_std`
+- expensive integrations
+
+Do not add feature flags for uncertain future work. Every feature should have tests or at least a documented validation path.
+
+## Testing Strategy
+
+Use unit tests for private transformations and edge cases.
+
+Use integration tests under `tests/` when the public API should be exercised like a downstream caller:
+
+```rust
+use my_crate::parse_document;
+
+#[test]
+fn parses_empty_document() {
+    let document = parse_document("").unwrap();
+    assert!(document.items().is_empty());
+}
+```
+
+Use doctests when examples in public documentation should stay compiling and accurate.
+
+## Validation
+
+Choose the narrowest command that proves the change:
+
+```bash
+cargo test -p package-name
+cargo test -p package-name --doc
+cargo clippy -p package-name --all-targets --all-features
+cargo fmt --check
+```
+
+For publishable crates, defer packaging details to future `rust:package-workflow`.
+
+## Output Shape
+
+Return:
+
+1. `Library surface`: public types, functions, modules, features, and errors changed.
+2. `Caller impact`: who uses the API and what becomes easier or safer.
+3. `Visibility`: what is public, `pub(crate)`, or private and why.
+4. `Tests`: unit, integration, doctest, or feature coverage added or recommended.
+5. `Validation`: exact Cargo commands run or skipped with the concrete reason.
+6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or future `rust:package-workflow`.
+
+## Guardrails
+
+- Do not expose implementation modules as public API by accident.
+- Do not add feature flags without a real optional behavior and validation path.
+- Do not hide compatibility changes to MSRV, edition, or public API.
+- Do not use local path dependencies in shared or publishable crate surfaces.
+- Do not make test convenience the reason for broad public visibility.

--- a/plugins/rust-skills/skills/build-library-crate/SKILL.md
+++ b/plugins/rust-skills/skills/build-library-crate/SKILL.md
@@ -113,7 +113,7 @@ cargo clippy -p package-name --all-targets --all-features
 cargo fmt --check
 ```
 
-For publishable crates, defer packaging details to future `rust:package-workflow`.
+For publishable crates, defer packaging details to `rust:package-workflow`.
 
 ## Output Shape
 
@@ -124,7 +124,7 @@ Return:
 3. `Visibility`: what is public, `pub(crate)`, or private and why.
 4. `Tests`: unit, integration, doctest, or feature coverage added or recommended.
 5. `Validation`: exact Cargo commands run or skipped with the concrete reason.
-6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or future `rust:package-workflow`.
+6. `Next skill`: usually `rust:testing-workflow`, `rust:tooling-style-workflow`, or `rust:package-workflow`.
 
 ## Guardrails
 

--- a/plugins/rust-skills/skills/choose-project-shape/SKILL.md
+++ b/plugins/rust-skills/skills/choose-project-shape/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: choose-project-shape
+description: Choose the right Rust project shape before implementation, including crate type, Cargo package or workspace layout, edition and MSRV checks, validation commands, package boundaries, and documentation updates. Use when a user wants to start, restructure, or extend a Rust project and the binary, library, workspace, CLI, service, proc macro, FFI, embedded, no_std, or maintenance shape is not already settled.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-planning
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Choose Rust Project Shape
+
+## Purpose
+
+Pick the smallest correct Rust project shape before code changes begin.
+
+The practical decision is what kind of crate or workspace the user needs, where package boundaries should sit, whether MSRV or edition policy already exists, and which validation commands should prove the work.
+
+## Source Check
+
+Use official Rust documentation first before making claims about Rust, Cargo, rustup, formatting, linting, testing, or package behavior:
+
+- [Rust documentation](https://doc.rust-lang.org/)
+- [The Cargo Book](https://doc.rust-lang.org/cargo/)
+- [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html)
+- [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
+- [Cargo continuous integration guide](https://doc.rust-lang.org/cargo/guide/continuous-integration.html)
+- [The rustup book](https://rust-lang.github.io/rustup/)
+- [Clippy documentation](https://doc.rust-lang.org/clippy/)
+
+Translate any documentation rule into the concrete repository decision it changes.
+
+## Classification Workflow
+
+1. Inspect the repository shape:
+   - `Cargo.toml`
+   - `Cargo.lock`
+   - `rust-toolchain.toml` or `rust-toolchain`
+   - `.cargo/config.toml`
+   - `rustfmt.toml` or `.rustfmt.toml`
+   - `clippy.toml`
+   - `src/main.rs`
+   - `src/lib.rs`
+   - `tests/`
+   - `examples/`
+   - `benches/`
+   - `crates/`
+   - existing CI commands
+2. Identify the user-visible job:
+   - binary crate
+   - library crate
+   - CLI tool
+   - service or daemon
+   - Cargo workspace
+   - proc macro
+   - FFI boundary
+   - embedded or `no_std` target
+   - package maintenance or upgrade pass
+3. Choose the project boundary intentionally:
+   - use one package for a small app or library
+   - use a workspace when multiple packages need shared dependency and validation behavior
+   - split a library from a binary when reusable API and executable concerns are meaningfully separate
+   - split proc macros into their own crate
+   - keep FFI boundaries explicit and narrow
+4. Check compatibility policy:
+   - preserve existing Rust edition unless the task is an edition migration
+   - preserve existing MSRV unless the user approves changing it
+   - read CI before recommending toolchain or feature matrix changes
+5. Choose validation:
+   - `cargo fmt --check` for formatting-sensitive changes
+   - `cargo clippy --all-targets --all-features` when lint coverage matters
+   - `cargo test` for behavior
+   - `cargo build` for compile checks without tests
+   - `cargo package` for publishable crate surfaces
+
+## Recommendations
+
+### Binary Crate Or CLI
+
+Use a single binary package for small command-line tools. Add a library target only when the CLI has reusable logic that tests or downstream callers should exercise directly.
+
+Handoff:
+
+- `rust:bootstrap-cargo-project` for new project creation
+- `rust:testing-workflow` for behavior coverage
+- `rust:tooling-style-workflow` for formatting, linting, and toolchain alignment
+
+### Library Crate
+
+Use a library package when the primary output is an API consumed by tests, examples, binaries, or downstream users. Keep public API surface small and document package validation if publishing is expected.
+
+Handoff:
+
+- `rust:testing-workflow` for unit, integration, and doctest coverage
+- future `rust:package-workflow` when crate metadata or publication matters
+
+### Cargo Workspace
+
+Use a workspace only when more than one package needs shared dependency resolution, coordinated tests, or separate crate boundaries.
+
+Good reasons include a library plus CLI package, a proc macro companion crate, integration-test support crates, or multiple crates that ship together. Avoid a workspace when a module split inside one crate would be enough.
+
+### Proc Macro
+
+Use a dedicated proc macro crate. Keep parsing and code generation tests explicit because failures are often easier to understand with fixture-style coverage.
+
+### FFI, Embedded, Or `no_std`
+
+Treat these as explicit constraint-driven shapes. Check existing target, build script, linker, feature, and CI configuration before changing layout.
+
+## Output Shape
+
+Return:
+
+1. `Chosen shape`: binary crate, library crate, CLI, service, workspace, proc macro, FFI, embedded or `no_std`, or maintenance pass.
+2. `Project boundary`: package, crate, workspace member, or module split.
+3. `Compatibility policy`: edition, MSRV, toolchain, and feature constraints.
+4. `Validation path`: exact format, lint, build, test, or package commands.
+5. `Documentation updates`: README, roadmap, package notes, or repo-local guidance.
+6. `Next skill`: the next Rust skill to use.
+
+## Guardrails
+
+- Do not create a workspace when one package and clear modules are enough.
+- Do not invent or raise MSRV without evidence and user intent.
+- Do not add local path dependencies to public or shared package surfaces.
+- Do not publish packages by default.
+- Do not use nightly-only features unless the repo already depends on nightly or the user approves that constraint.

--- a/plugins/rust-skills/skills/choose-project-shape/SKILL.md
+++ b/plugins/rust-skills/skills/choose-project-shape/SKILL.md
@@ -93,7 +93,7 @@ Use a library package when the primary output is an API consumed by tests, examp
 Handoff:
 
 - `rust:testing-workflow` for unit, integration, and doctest coverage
-- future `rust:package-workflow` when crate metadata or publication matters
+- `rust:package-workflow` when crate metadata or publication matters
 
 ### Cargo Workspace
 

--- a/plugins/rust-skills/skills/ci-workflow/SKILL.md
+++ b/plugins/rust-skills/skills/ci-workflow/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ci-workflow
+description: Design, inspect, and align Rust CI workflows with local Cargo validation, including cargo fmt, cargo clippy, cargo test, cargo build, cargo doc, cargo package, workspace package selection, feature matrices, MSRV checks, rustup toolchain setup, Clippy warnings-as-errors policy, caches, artifacts, and GitHub Actions-style automation.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-ci
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Rust CI Workflow
+
+## Purpose
+
+Align Rust CI with the validation that actually protects the project.
+
+The practical goal is to make CI prove the same behavior maintainers care about locally: formatting, linting, build, tests, docs, package readiness, MSRV, and feature or workspace matrices where those are real compatibility surfaces.
+
+## Source Check
+
+Use official documentation first:
+
+- [Cargo continuous integration guide](https://doc.rust-lang.org/cargo/guide/continuous-integration.html)
+- [Cargo workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
+- [Cargo features reference](https://doc.rust-lang.org/cargo/reference/features.html)
+- [`cargo test`](https://doc.rust-lang.org/cargo/commands/cargo-test.html)
+- [`cargo package`](https://doc.rust-lang.org/cargo/commands/cargo-package.html)
+- [Clippy CI documentation](https://doc.rust-lang.org/clippy/continuous_integration/)
+- [The rustup book](https://rust-lang.github.io/rustup/)
+
+Translate CI advice into the exact workflow jobs, commands, package selection, feature selection, and failure policy that match the repository.
+
+## Repository Inspection
+
+Inspect:
+
+- `.github/workflows/`
+- `Cargo.toml`
+- workspace root `Cargo.toml`
+- `Cargo.lock`
+- `rust-toolchain.toml` or `rust-toolchain`
+- `rustfmt.toml` or `.rustfmt.toml`
+- `clippy.toml`
+- README, CONTRIBUTING, AGENTS, or release docs
+- Makefile, justfile, xtask, or repo scripts
+
+## CI Shape Decisions
+
+Pick jobs by the behavior they protect:
+
+- format: `cargo fmt --check`
+- lint: `cargo clippy --all-targets --all-features -- -D warnings`
+- test: `cargo test --all-targets --all-features`
+- build: `cargo build` when compile coverage is needed separately
+- docs: `cargo doc --no-deps` when public docs matter
+- package: `cargo package --dry-run` for publishable crates
+- MSRV: run selected checks on the declared minimum supported Rust version
+
+Do not add every job by default. Choose the smallest CI matrix that protects the repo's real support promise.
+
+## Toolchain Setup
+
+Prefer the repo's existing setup. If adding setup from scratch, install the channel and components the commands require:
+
+```bash
+rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+```
+
+Use `rust-toolchain.toml` when local and CI contributors should share the same channel/components. Do not pin nightly unless the project truly depends on nightly behavior.
+
+## Workspace And Feature Matrices
+
+Use package selection intentionally:
+
+```bash
+cargo test -p package-name
+cargo test --workspace
+```
+
+Use feature matrices only when features are part of the public compatibility surface:
+
+```bash
+cargo test -p package-name --no-default-features
+cargo test -p package-name --all-features
+```
+
+If the project has many feature combinations, use a documented helper such as `cargo hack` only when the repo already uses it or the added dependency is justified.
+
+## Warnings-As-Errors Policy
+
+Clippy's CI guidance recommends `-Dwarnings`, but apply that deliberately.
+
+Good default for maintained crates:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Avoid turning all compiler warnings into hard failures unless the repo wants that stricter contract. If CI is newly adopting warnings-as-errors, call out the maintenance cost.
+
+## Cache And Artifact Boundaries
+
+Use caches to speed CI, not to define correctness. CI should still pass from a cold cache.
+
+Only upload artifacts when users or maintainers need them, such as release binaries, generated docs, coverage, or package tarballs.
+
+## Output Shape
+
+Return:
+
+1. `CI intent`: what the workflow is meant to protect.
+2. `Local parity`: local commands and matching CI commands.
+3. `Toolchain`: channel, components, rustup or rust-toolchain behavior, and MSRV checks.
+4. `Matrix`: workspace packages, features, targets, OSes, and whether each is necessary.
+5. `Changes`: workflow files or scripts changed.
+6. `Validation`: commands run locally and any CI checks that still need remote confirmation.
+
+## Guardrails
+
+- Do not add broad CI matrices without naming the compatibility promise they protect.
+- Do not make nightly a required lane unless the repo depends on nightly.
+- Do not hide local validation behind CI-only scripts.
+- Do not add warnings-as-errors casually to unstable or noisy repos.
+- Do not treat cache hits as proof that CI is correct.

--- a/plugins/rust-skills/skills/package-workflow/SKILL.md
+++ b/plugins/rust-skills/skills/package-workflow/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: package-workflow
+description: Prepare and validate Rust Cargo package surfaces, including Cargo.toml metadata, rust-version and MSRV policy, license/readme/repository fields, include and exclude rules, path dependency restrictions, Cargo.lock policy, cargo package dry runs, and publish versus no-publish decisions. Use for publishable crates, package metadata cleanup, crates.io readiness, or release-adjacent Rust package checks.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-packaging
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Rust Package Workflow
+
+## Purpose
+
+Prepare a Cargo package surface so it is honest, fetchable, and ready for the user's intended distribution path.
+
+The practical goal is to catch package metadata drift, local-only dependencies, missing compatibility policy, and accidental publishing before a release or publication step.
+
+## Source Check
+
+Use official Cargo documentation first:
+
+- [Cargo manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html)
+- [`cargo package`](https://doc.rust-lang.org/cargo/commands/cargo-package.html)
+- [`cargo publish`](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)
+- [Cargo workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
+- [Cargo features reference](https://doc.rust-lang.org/cargo/reference/features.html)
+- [Cargo SemVer compatibility](https://doc.rust-lang.org/cargo/reference/semver.html)
+
+Translate packaging rules into the exact package field, dependency, command, or release decision they affect.
+
+## Repository Inspection
+
+Inspect:
+
+- `Cargo.toml`
+- `Cargo.lock`
+- workspace root `Cargo.toml`
+- `README.md`
+- `LICENSE` or `LICENSE-*`
+- package docs and examples
+- `.cargo/config.toml`
+- CI workflows
+- git status and ignored files if package inclusion matters
+
+## Manifest Checks
+
+For publishable crates, check the relevant `[package]` fields:
+
+- `name`
+- `version`
+- `edition`
+- `rust-version`
+- `description`
+- `license` or `license-file`
+- `repository`
+- `homepage` or `documentation` when appropriate
+- `readme`
+- `keywords`
+- `categories`
+- `include` or `exclude` when package contents need curation
+- `publish` when publication should be restricted or disabled
+
+Do not invent metadata. If a package is not meant to publish, prefer an explicit `publish = false` or equivalent repo policy instead of polishing crates.io metadata for a private crate.
+
+## Dependency Checks
+
+Cargo package validation is especially useful because publishable packages cannot rely on local-only dependency paths unless version metadata makes the registry dependency usable.
+
+Check for:
+
+- path dependencies
+- git dependencies that cannot be fetched by intended users
+- optional dependencies tied to features
+- dev-dependencies that are only needed for tests/examples
+- workspace-inherited dependency versions
+- unpublished sibling crates
+
+Do not commit machine-local dependency paths in public or shared packages.
+
+## Lockfile Policy
+
+Preserve the repo's existing lockfile policy.
+
+General guidance:
+
+- commit `Cargo.lock` for binaries, applications, examples that must reproduce, and most workspaces with executable surfaces
+- library-only crates may choose not to commit `Cargo.lock`, but follow existing repo policy
+- do not delete or regenerate `Cargo.lock` as package cleanup unless dependency resolution is part of the task
+
+## Validation Commands
+
+Use dry-run package validation before publishing or release-adjacent package changes:
+
+```bash
+cargo package --dry-run
+```
+
+Package one workspace member:
+
+```bash
+cargo package -p package-name --dry-run
+```
+
+Validate publish-facing behavior with selected features when needed:
+
+```bash
+cargo package -p package-name --all-features --dry-run
+```
+
+Run normal validation before or alongside package checks:
+
+```bash
+cargo test -p package-name
+cargo clippy -p package-name --all-targets --all-features
+cargo fmt --check
+```
+
+Do not run `cargo publish` unless the user explicitly asks to publish and the repository release process is ready.
+
+## Output Shape
+
+Return:
+
+1. `Package intent`: publishable crate, private crate, binary distribution, workspace member, or no-publish package.
+2. `Manifest state`: metadata, license, repository, readme, rust-version, publish, include, and exclude findings.
+3. `Dependency state`: registry, git, path, optional, dev, and workspace dependency concerns.
+4. `Lockfile policy`: observed policy and whether it changed.
+5. `Validation`: exact package, test, lint, and format commands run or skipped.
+6. `Release impact`: whether publishing, SemVer, MSRV, or downstream compatibility is affected.
+
+## Guardrails
+
+- Do not publish by default.
+- Do not invent crates.io metadata for private crates.
+- Do not hide local path dependencies behind package docs.
+- Do not raise MSRV or change SemVer meaning silently.
+- Do not remove lockfiles without checking repo policy and executable surfaces.

--- a/plugins/rust-skills/skills/testing-workflow/SKILL.md
+++ b/plugins/rust-skills/skills/testing-workflow/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: testing-workflow
+description: Plan, run, and triage Rust tests with Cargo, including unit tests, integration tests, documentation tests, examples compiled by cargo test, targeted reruns, feature matrices, workspace package selection, and failure explanation. Use when adding tests, running Rust validation, or diagnosing cargo test failures.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-testing
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Rust Testing Workflow
+
+## Purpose
+
+Run the narrowest useful Rust tests, explain failures clearly, and keep test layout aligned with Cargo's model.
+
+Cargo test behavior matters because one command can compile and run unit tests, integration tests, documentation tests, and examples. The skill should make that scope explicit instead of treating `cargo test` as a black box.
+
+## Source Check
+
+Use official Rust documentation first:
+
+- [Cargo tests guide](https://doc.rust-lang.org/cargo/guide/tests.html)
+- [`cargo test`](https://doc.rust-lang.org/cargo/commands/cargo-test.html)
+- [The Rust book testing chapter](https://doc.rust-lang.org/book/ch11-00-testing.html)
+- [Cargo features reference](https://doc.rust-lang.org/cargo/reference/features.html)
+
+Translate test behavior into the concrete command and failure mode in the repository.
+
+## Test Layout
+
+- Put unit tests near implementation when they need private module access.
+- Put integration tests under `tests/` when they should use the crate like an external caller.
+- Use documentation tests when examples in public API docs should compile and run.
+- Use `examples/` when sample binaries should compile as part of validation.
+- Use feature-gated tests only when the crate's feature matrix is part of the public behavior.
+
+## Command Selection
+
+Start narrow, then widen:
+
+```bash
+cargo test
+```
+
+Target one package in a workspace:
+
+```bash
+cargo test -p package-name
+```
+
+Run all workspace tests:
+
+```bash
+cargo test --workspace
+```
+
+Run all targets and features when feature interactions matter:
+
+```bash
+cargo test --all-targets --all-features
+```
+
+Filter by test name:
+
+```bash
+cargo test some_test_name
+```
+
+Show test output:
+
+```bash
+cargo test some_test_name -- --nocapture
+```
+
+Run documentation tests only when public docs are the focus:
+
+```bash
+cargo test --doc
+```
+
+## Failure Triage
+
+Classify failures by the first concrete break:
+
+- compile failure: source, dependency, feature, target, or MSRV problem
+- unit test failure: internal behavior changed
+- integration test failure: public behavior or crate boundary changed
+- doctest failure: public example or documentation drifted
+- feature failure: optional dependency or cfg path broke
+- workspace failure: package selection, shared dependency, or target matrix issue
+
+Read the first relevant compiler or test error before changing code. Rust output is usually precise; preserve that precision in the user-facing explanation.
+
+## Implementation Guidance
+
+- Add tests at the same boundary the user cares about.
+- Prefer deterministic tests over sleeps, timing assumptions, or network calls.
+- Use temporary directories for filesystem behavior.
+- Avoid snapshot tests unless the repo already uses them or the output is intentionally broad.
+- Keep error-message assertions focused on stable, user-visible text.
+
+## Output Shape
+
+Return:
+
+1. `Test scope`: package, workspace, target, feature, or doc-test boundary.
+2. `Commands`: exact commands run or recommended.
+3. `Result`: pass, fail, or skipped with the concrete reason.
+4. `Failure mode`: compile, unit, integration, doctest, feature, or workspace issue.
+5. `Fix direction`: the smallest code, test, dependency, or docs change that addresses the failure.
+
+## Guardrails
+
+- Do not run broad feature or workspace matrices first when a targeted command proves the change.
+- Do not hide compile failures behind test summaries.
+- Do not weaken tests to match broken behavior unless the user explicitly approves the behavior change.
+- Do not add network-dependent tests without a repo-owned test strategy for them.

--- a/plugins/rust-skills/skills/tooling-style-workflow/SKILL.md
+++ b/plugins/rust-skills/skills/tooling-style-workflow/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: tooling-style-workflow
+description: Align Rust formatting, linting, toolchain, and CI behavior with repository policy, including cargo fmt, rustfmt style edition, cargo clippy, rust-toolchain.toml, MSRV checks, warnings-as-errors decisions, and validation command selection. Use when configuring or fixing Rust style, lint, toolchain, or CI workflows.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: rust-tooling
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(cargo:*) Bash(rustc:*) Bash(rustup:*)
+---
+
+# Rust Tooling And Style Workflow
+
+## Purpose
+
+Keep Rust formatting, linting, toolchain, and CI behavior explicit and consistent with the repository.
+
+The practical goal is to avoid accidental formatter churn, surprise MSRV changes, lint strictness jumps, or CI commands that do not match local validation.
+
+## Source Check
+
+Use official documentation first:
+
+- [`cargo fmt`](https://doc.rust-lang.org/cargo/commands/cargo-fmt.html)
+- [`cargo clippy`](https://doc.rust-lang.org/cargo/commands/cargo-clippy.html)
+- [Rustfmt 2024 style edition guide](https://doc.rust-lang.org/stable/edition-guide/rust-2024/rustfmt-style-edition.html)
+- [The rustup book](https://rust-lang.github.io/rustup/)
+- [Cargo continuous integration guide](https://doc.rust-lang.org/cargo/guide/continuous-integration.html)
+
+Treat rustfmt and Clippy as toolchain components. If they are missing locally, report the missing component and the likely install command instead of guessing at style by hand.
+
+## Repository Inspection
+
+Before changing tooling, inspect:
+
+- `Cargo.toml`
+- `Cargo.lock`
+- `rust-toolchain.toml` or `rust-toolchain`
+- `rustfmt.toml` or `.rustfmt.toml`
+- `clippy.toml`
+- `.cargo/config.toml`
+- `.github/workflows/`
+- existing Makefile, justfile, xtask, or scripts
+- README, CONTRIBUTING, AGENTS, or package docs for validation commands
+
+## Formatting
+
+Use Cargo's formatter command by default:
+
+```bash
+cargo fmt --check
+```
+
+Apply formatting only when the user asked for implementation or formatting work:
+
+```bash
+cargo fmt
+```
+
+For Rust 2024 projects, check whether the repo needs an explicit `rustfmt.toml` with `style_edition = "2024"` so editor format-on-save and CI use the same style behavior. Do not add this file to older-edition projects without a conscious style decision.
+
+## Linting
+
+Use Clippy when lint behavior matters:
+
+```bash
+cargo clippy --all-targets --all-features
+```
+
+Use warnings-as-errors only when the repo already expects it or the task is explicitly tightening CI:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Do not silence lints broadly. Prefer a local code fix, then a narrow `allow` with a concrete reason when the lint is intentionally wrong for that code.
+
+## Toolchain And MSRV
+
+Use `rust-toolchain.toml` when contributors or CI need a pinned channel or components:
+
+```toml
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+```
+
+Preserve existing MSRV. If the task needs a newer compiler, make that compatibility change explicit in docs, CI, and release notes.
+
+Check local toolchain state only when implementation needs it:
+
+```bash
+rustc --version
+cargo --version
+rustup show
+```
+
+## CI Alignment
+
+Local and CI validation should name the same meaningful commands. A normal Rust CI baseline is:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features
+```
+
+Narrow this for small crates or widen it for published libraries with feature matrices, MSRV checks, or platform-specific behavior.
+
+## Output Shape
+
+Return:
+
+1. `Tooling state`: formatter, linter, toolchain, MSRV, and CI policy observed.
+2. `Commands`: exact commands run or recommended.
+3. `Changes`: files or settings changed, if any.
+4. `Validation`: pass, fail, or skipped with the concrete reason.
+5. `Compatibility impact`: whether edition, style edition, MSRV, lint strictness, or CI behavior changed.
+
+## Guardrails
+
+- Do not add warnings-as-errors as a casual cleanup.
+- Do not add or change `rust-toolchain.toml` without a reproducibility or CI reason.
+- Do not raise MSRV silently.
+- Do not hand-format Rust when `cargo fmt` is available.
+- Do not overwrite repo-local style, lint, or CI policy with a generic template.

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.10.2"
+version = "6.11.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.10.2"
+version = "6.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.10.2",
+  "version": "6.11.0",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.10.2"
+version = "6.11.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Turn `rust-skills` from a placeholder into an installable Socket child plugin.
- Add Rust skills for project shape, Cargo bootstrap, CLI/library implementation, testing, tooling/style, package readiness, and CI alignment.
- Prepare the shared Socket minor release version `6.11.0` and align marketplace ordering with the README catalog order.

## Verification

- `uv run mypy`
- `uv run scripts/validate_socket_metadata.py`
- `uv run /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/rust-skills/skills/*`
- `git diff --check origin/main...HEAD`
- Isolated local Socket marketplace smoke test with temporary `CODEX_HOME`

## Release Notes

What changed:
- `rust-skills` now ships real Codex skill content and is available from the Socket marketplace.
- Socket shared version surfaces are prepared for `6.11.0`.

Breaking changes:
- None.

Migration/upgrade notes:
- After merge and release publication, run `codex plugin marketplace upgrade socket` to refresh installed Socket marketplaces.

Remaining release gate:
- `scripts/release.sh release-ready 6.11.0` must run from local `main` after the PR is merged, because the script refuses release-ready checks on feature branches.