### PR TITLE
plugin: add Hummingbird server workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Current Socket catalog shape:
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
-- `server-side-swift`: server-side Swift and Vapor service workflows with SwiftPM-first build, run, test, migration, and diagnostics guidance
+- `server-side-swift`: server-side Swift, Vapor, and Hummingbird service workflows with SwiftPM-first build, run, test, framework-specific migration, and diagnostics guidance
 - `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, test, lint, and format workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,7 @@ In Progress
 - [x] Create `plugins/server-side-swift/` with its own `.codex-plugin/plugin.json`, `AGENTS.md`, and authored `skills/` source.
 - [x] Add `server-side-swift:vapor-server-workflow` as the first skill for Vapor service creation, route work, middleware, Fluent migrations, environment configuration, local run commands, tests, and deployment handoffs.
 - [x] Wire `server-side-swift` into the root Socket marketplace as a normal local child plugin.
-- [ ] Add `server-side-swift:hummingbird-server-workflow` for Hummingbird services, including route composition, middleware, request/response modeling, local run commands, tests, and SwiftPM-first validation.
+- [x] Add `server-side-swift:hummingbird-server-workflow` for Hummingbird services, including route composition, middleware, request/response modeling, local run commands, tests, and SwiftPM-first validation.
 - [ ] Add an OpenAPI workflow for generating, serving, validating, or consuming OpenAPI descriptions in server-side Swift services without tying the skill to one web framework by default.
 - [ ] Add an RPC workflow for Swift service boundaries that may use JSON-RPC, gRPC, MCP-like transports, or framework-specific client/server contracts, with explicit guidance for when plain HTTP routes are the simpler fit.
 - [ ] Add a SwiftNIO workflow for lower-level event-loop, channel, bootstrap, byte-buffer, back-pressure, and nonblocking-I/O work when a service needs NIO directly instead of a higher-level framework.

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.11.0"
+version = "6.11.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.11.0"
+version = "6.11.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.11.0"
+version = "6.11.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
-  "version": "6.11.0",
+  "name": "server-side-swift",
+  "version": "6.11.1",
   "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor, Hummingbird, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
-  "name": "server-side-swift",
   "version": "6.11.0",
-  "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor and SwiftPM-first workflows.",
+  "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor, Hummingbird, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -17,13 +16,14 @@
     "swift",
     "server-side-swift",
     "vapor",
+    "hummingbird",
     "swiftpm"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Server-Side Swift",
-    "shortDescription": "Server-side Swift and Vapor workflow guidance for Codex.",
-    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor documentation, Vapor Toolbox usage, local run commands, app structure, routing, middleware, Fluent migrations, environment configuration, tests, and deployment handoffs.",
+    "shortDescription": "Server-side Swift, Vapor, and Hummingbird workflow guidance for Codex.",
+    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor and Hummingbird documentation, local run commands, app structure, routing, middleware, request contexts, Fluent migrations, environment configuration, tests, and deployment handoffs.",
     "developerName": "gaelic-ghost",
     "category": "Developer Tools",
     "capabilities": [
@@ -33,10 +33,14 @@
     "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/server-side-swift",
     "defaultPrompt": [
       "Create a Vapor service plan using current Vapor CLI and SwiftPM workflows.",
+      "Create a Hummingbird service plan using current Hummingbird docs and SwiftPM workflows.",
       "Inspect this Vapor app and explain its routes, configuration, and run commands.",
+      "Inspect this Hummingbird app and explain its router, middleware, request contexts, and run commands.",
       "Add a Vapor route with tests while keeping domain logic outside handlers.",
+      "Add a Hummingbird route with tests while keeping domain logic outside handlers.",
       "Set up Fluent migrations and explain the migration commands.",
-      "Diagnose why this Vapor build, run, migrate, or local server command failed."
+      "Diagnose why this Vapor build, run, migrate, or local server command failed.",
+      "Diagnose why this Hummingbird build, run, route, or local server command failed."
     ],
     "brandColor": "#0EA5E9"
   }

--- a/plugins/server-side-swift/AGENTS.md
+++ b/plugins/server-side-swift/AGENTS.md
@@ -13,7 +13,7 @@ This file is the Server-Side Swift child-plugin override for work done from `soc
 
 - Match the `socket` shared semantic version exactly; use the Socket root release workflow for version inventory and bumps.
 - Prefer Swift Package Manager as the source of truth for server-side Swift package structure, dependencies, builds, tests, and run commands.
-- Use official framework documentation first for server-side Swift libraries and tools. For Vapor work, use the official Vapor docs before proposing CLI usage, app structure, migrations, deployment, or runtime changes.
+- Use official framework documentation first for server-side Swift libraries and tools. For Vapor work, use the official Vapor docs before proposing CLI usage, app structure, migrations, deployment, or runtime changes. For Hummingbird work, use the official Hummingbird docs before proposing app setup, routes, middleware, request contexts, testing, service lifecycle, deployment, or runtime changes.
 - Treat the Vapor Toolbox as project-creation and convenience tooling, not as a replacement for SwiftPM. Prefer `swift build`, `swift test`, `swift run`, and `swift run App serve` after a project exists unless current Vapor documentation says otherwise for the specific task.
 - Keep server-side Swift examples portable across macOS and Linux unless the target repository documents an Apple-only service environment.
 - Keep dependencies fetchable from GitHub, package registries, package-manager URLs, or other real remote repositories. Do not commit machine-local package paths.

--- a/plugins/server-side-swift/skills/hummingbird-server-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/hummingbird-server-workflow/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: hummingbird-server-workflow
+description: Plan, build, run, test, and diagnose Hummingbird server-side Swift services using current Hummingbird documentation, SwiftPM-first commands, routing, middleware, request contexts, typed request and response models, service lifecycle, and deployment handoffs.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with Hummingbird, SwiftPM, and server-side Swift projects on macOS or Linux.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: server-side-swift-hummingbird
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(curl:*)
+---
+
+# Hummingbird Server Workflow
+
+## Purpose
+
+Build, modify, run, or diagnose a Hummingbird service without confusing Hummingbird-specific server behavior with generic Swift package work, Vapor app structure, or Apple-platform Xcode work.
+
+The practical decision is what the HTTP service exposes, which executable owns the `Application`, how routes and middleware are composed, what request context carries per-request data, how typed request and response models are encoded, and which command proves the service starts or behaves correctly.
+
+## When To Use
+
+- Use this skill when creating or modifying a Hummingbird service.
+- Use this skill when changing Hummingbird routes, route groups, middleware, request contexts, application configuration, persistent request data, file middleware, service lifecycle integration, or local server behavior.
+- Use this skill when diagnosing `swift build`, `swift test`, `swift run`, application startup, route matching, middleware, request decoding, response encoding, or local HTTP failures in a Hummingbird project.
+- Use this skill when deciding whether an existing Swift package should become a Hummingbird service or stay a library consumed by one.
+- Use this skill when comparing Hummingbird to Vapor only long enough to choose the correct framework-specific workflow.
+- Do not use this skill for generic Swift package work that has no Hummingbird-specific behavior. Hand that work to a SwiftPM package workflow when available.
+- Do not use this skill for Vapor services unless the task is a comparison or migration involving Hummingbird.
+- Do not use this skill for Apple-platform app, simulator, preview, or Xcode project membership work.
+
+## Source Check
+
+Use official Hummingbird documentation first:
+
+- [Hummingbird documentation](https://docs.hummingbird.codes/)
+- [Hummingbird framework overview](https://docs.hummingbird.codes/2.0/documentation/hummingbird/)
+- [Create a Hummingbird application](https://docs.hummingbird.codes/2.0/tutorials/hummingbird/todos-1-template/)
+- [Middleware](https://docs.hummingbird.codes/2.0/documentation/hummingbird/middlewareguide/)
+- [Request Contexts](https://docs.hummingbird.codes/2.0/documentation/hummingbird/requestcontexts/)
+- [Error Handling](https://docs.hummingbird.codes/2.0/documentation/hummingbird/errorhandling/)
+- [Hummingbird Testing](https://docs.hummingbird.codes/2.0/documentation/hummingbird/testing/)
+
+Use Swift.org, Swift Package Manager, Swift Service Lifecycle, SwiftNIO, or Swift server package documentation for toolchain, package, lifecycle, event-loop, deployment, or observability behavior when Hummingbird docs do not own the rule being used.
+
+## Planning Workflow
+
+1. Inspect project shape:
+   - `Package.swift`
+   - executable target name, often `App`
+   - application entry point and `Application` construction
+   - `Router` creation and route registration
+   - middleware registration and route groups
+   - custom `RequestContext` types
+   - request and response models
+   - tests using `HummingbirdTesting`, `swift test`, or local HTTP checks
+   - Docker, deployment, service lifecycle, or environment files when present
+2. Identify the service job:
+   - JSON API
+   - static file or website surface
+   - webhook receiver
+   - internal service
+   - background service with HTTP health or control routes
+   - OpenAPI-backed server transport
+3. Confirm the documented Hummingbird command and API path before running or recommending commands.
+4. Keep SwiftPM as the default execution surface:
+   - create from the Hummingbird template when the user wants the official template flow
+   - build with `swift build`
+   - test with `swift test`
+   - run locally with the package's documented `swift run` command
+   - inspect available executable commands with `swift run <executable> --help` when the package uses `AsyncParsableCommand`
+5. Keep domain logic outside route closures when it has meaningful behavior.
+6. Keep request and response models typed and small enough to test directly.
+7. Keep request context additions deliberate, because they become per-request data that middleware and handlers depend on.
+8. Validate with the narrowest useful SwiftPM, Hummingbird testing, or HTTP check.
+
+## Project Creation
+
+Hummingbird documents a template-based creation flow. Use it when the user wants a fresh Hummingbird app and accepts the official template as the starting point:
+
+```bash
+git clone https://github.com/hummingbird-project/template
+./template/configure.sh MyService
+cd MyService
+swift run
+```
+
+When adding Hummingbird to an existing package, edit `Package.swift` through normal SwiftPM dependency rules and follow current Hummingbird docs for package products. Do not copy a template over an existing service unless the user explicitly asks for replacement.
+
+## App Structure
+
+For typical Hummingbird 2 projects:
+
+- `Application` brings together the router and application configuration.
+- `Router` owns route registration and produces the responder path for requests.
+- Route groups are the right place to share path prefixes or scoped middleware.
+- Middleware is useful for cross-cutting request and response behavior such as logging, metrics, tracing, CORS, authentication, compression, or static files.
+- Request contexts carry per-request data such as logger, decoder, encoder, endpoint path, and project-specific context values.
+- Typed request and response models should carry API data instead of route handlers assembling ad hoc dictionaries.
+
+Do not introduce a service, repository, coordinator, or manager unless it removes a concrete duplication, testability problem, or dependency boundary issue in the current service.
+
+## Configuration And Secrets
+
+Do not commit secrets.
+
+Use environment variables or the repository's existing configuration conventions for deployment-sensitive values. When diagnosing configuration, state which value is missing, where the app reads it, which command was running, and what local or deployment setup likely needs correction.
+
+If a template-generated executable exposes hostname, port, or log-level options, preserve that command-line shape unless the user explicitly wants to change how the service is configured.
+
+## Routes, Middleware, Contexts, And Errors
+
+When adding or changing routes:
+
+- name the route method and path
+- describe request body, query, path parameters, response body, and status codes
+- keep validation errors explicit and user-readable
+- avoid blocking work on SwiftNIO event loops
+- use async route handlers when the project already uses async Hummingbird APIs
+- prefer typed request and response models over ad hoc dictionaries
+
+When adding middleware:
+
+- identify whether it is global, grouped, or route-specific
+- add middleware before the routes that should receive it
+- explain the request or response behavior it changes
+- include a small test or manual check that proves the middleware is active
+
+When adding request context data:
+
+- name who creates the context value
+- name which middleware or handler reads it
+- keep the stored value scoped to a real per-request need
+- avoid using request context as a generic dependency container
+
+When handling errors:
+
+- prefer Hummingbird's documented HTTP error surfaces
+- return useful status codes and human-readable messages
+- avoid leaking secrets, tokens, connection strings, or internal stack details in responses
+
+## Testing
+
+Choose the smallest test that proves the behavior:
+
+- pure Swift test for domain logic
+- Hummingbird testing helper for route, middleware, request, and response behavior
+- local HTTP check only when runtime binding, headers, streaming, service lifecycle, or network behavior matters
+
+Prefer `swift test` for normal validation. Use `curl` against a locally running server only when the user asked for runtime validation or the change cannot be proven through tests alone.
+
+## Deployment Handoffs
+
+Keep deployment guidance grounded in the repository's existing target first.
+
+When no target exists, distinguish:
+
+- local development run
+- Docker image or Compose workflow
+- Apple Containerization workflow
+- Linux process manager or system service
+- hosted platform deployment
+- database migration or background service timing
+
+Do not add Docker, CI, process-manager, cloud deployment, or Apple Containerization files as part of a route or local development change unless the user asked for deployment scope.
+
+## Output Shape
+
+Return:
+
+1. `Service shape`: package root, executable target, application construction, router owners, middleware, context types, and test surface.
+2. `Hummingbird docs used`: specific official docs relied on for app setup, routes, middleware, contexts, testing, or runtime behavior.
+3. `Command path`: exact commands run or recommended.
+4. `Behavior`: routes, inputs, outputs, errors, middleware, contexts, persistence, or configuration changes.
+5. `Validation`: build, test, run, or HTTP check results.
+6. `Handoffs`: SwiftPM, testing, Vapor, Apple-platform, OpenAPI, observability, deployment, or database follow-up when the task crosses this skill's boundary.
+
+## Guardrails
+
+- Do not treat Xcode as required for Hummingbird service work unless the repository already uses Xcode-specific workflow.
+- Do not let route closures accumulate unrelated business rules.
+- Do not commit secrets, machine-local paths, or deployment credentials.
+- Do not claim Hummingbird API behavior from memory when current official docs can be checked.
+- Do not use Hummingbird request context as a catch-all app dependency bag.
+- Do not add Docker, Apple Containerization, CI, or cloud deployment files without explicit deployment scope.

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.11.0"
+version = "6.11.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.11.0"
+version = "6.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.11.0"
+version = "6.11.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- add `server-side-swift:hummingbird-server-workflow`
- update Server-Side Swift plugin metadata and Socket catalog wording for Hummingbird
- bump shared Socket version surfaces to 6.11.1

## Verification

- `uv run scripts/validate_socket_metadata.py`
- `uv run pytest`
- branch-local Socket marketplace smoke check with temporary `CODEX_HOME`

## Release Notes

Adds Hummingbird workflow guidance to the Server-Side Swift plugin, covering official-docs-first app setup, routing, middleware, request contexts, tests, local run commands, and deployment handoffs.
