### PR TITLE
plugin: add server persistence workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Current Socket catalog shape:
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
-- `server-side-swift`: server-side Swift, Vapor, and Hummingbird service workflows with SwiftPM-first build, run, test, framework-specific migration, and diagnostics guidance
+- `server-side-swift`: server-side Swift, Vapor, Hummingbird, and persistence workflows with SwiftPM-first build, run, test, framework-specific migration, database, and diagnostics guidance
 - `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, test, lint, and format workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,6 +148,7 @@ In Progress
 - [x] Add `server-side-swift:vapor-server-workflow` as the first skill for Vapor service creation, route work, middleware, Fluent migrations, environment configuration, local run commands, tests, and deployment handoffs.
 - [x] Wire `server-side-swift` into the root Socket marketplace as a normal local child plugin.
 - [x] Add `server-side-swift:hummingbird-server-workflow` for Hummingbird services, including route composition, middleware, request/response modeling, local run commands, tests, and SwiftPM-first validation.
+- [x] Add `server-side-swift:persistence-workflow` for server-side Swift persistence, including Fluent models, database migrations, query design, Hummingbird database handoffs, tests, and docs routing through official docs, GitHub sources, or checked Dash docsets.
 - [ ] Add an OpenAPI workflow for generating, serving, validating, or consuming OpenAPI descriptions in server-side Swift services without tying the skill to one web framework by default.
 - [ ] Add an RPC workflow for Swift service boundaries that may use JSON-RPC, gRPC, MCP-like transports, or framework-specific client/server contracts, with explicit guidance for when plain HTTP routes are the simpler fit.
 - [ ] Add a SwiftNIO workflow for lower-level event-loop, channel, bootstrap, byte-buffer, back-pressure, and nonblocking-I/O work when a service needs NIO directly instead of a higher-level framework.
@@ -160,7 +161,7 @@ In Progress
 ### Exit Criteria
 
 - [ ] The Socket marketplace exposes `server-side-swift` as an installable child plugin with metadata that matches its shipped skill inventory.
-- [ ] The plugin gives agents clear framework-specific paths for Vapor and Hummingbird without duplicating generic SwiftPM or Apple-platform workflow guidance.
+- [ ] The plugin gives agents clear framework-specific paths for Vapor, Hummingbird, and persistence work without duplicating generic SwiftPM or Apple-platform workflow guidance.
 - [ ] Protocol, runtime, observability, tracing, Docker, and Apple Containerization guidance each has a clear owner skill or an explicit reason to stay backlog-only.
 - [ ] Root Socket docs, marketplace wiring, and validation agree on the plugin's install surface.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,6 +153,8 @@ In Progress
 - [ ] Add an RPC workflow for Swift service boundaries that may use JSON-RPC, gRPC, MCP-like transports, or framework-specific client/server contracts, with explicit guidance for when plain HTTP routes are the simpler fit.
 - [ ] Add a SwiftNIO workflow for lower-level event-loop, channel, bootstrap, byte-buffer, back-pressure, and nonblocking-I/O work when a service needs NIO directly instead of a higher-level framework.
 - [ ] Add Swift observability and tracing guidance that covers Swift Logging, Metrics, Distributed Tracing, and OpenTelemetry-style instrumentation for service diagnostics.
+- [ ] Add a server authentication and authorization workflow covering Vapor and Hummingbird auth boundaries, sessions, JWT, OAuth/OIDC handoffs, password storage, middleware placement, and security-sensitive testing without duplicating client Keychain guidance.
+- [ ] Add a server app-sync workflow covering sync contracts, conflict handling, incremental change feeds, idempotent writes, cursor/token semantics, background job handoffs, and API-shape coordination without absorbing the separate OpenAPI or RPC workflow.
 - [ ] Add a Docker workflow for server-side Swift packages, including Dockerfile shape, Compose-local development, Linux image concerns, environment configuration, and build/test handoffs.
 - [ ] Add an Apple Containerization workflow for Apple's container tooling, keeping it distinct from generic Docker guidance and tied to current official Apple documentation.
 - [ ] Update plugin metadata prompts and keywords as new server-side Swift skill surfaces ship.

--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,7 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 - [x] Add the first real Vapor-focused server-side Swift skill.
 - [x] Add a persistence workflow for Fluent, database migrations, query design, Hummingbird database handoffs, and docs routing.
 - [ ] Add validation coverage for skill metadata and exported skill inventory once central Socket child-skill validation exists.
-- [ ] Decide whether future server-side Swift skills should cover SwiftNIO, deployment, or additional database workflows as separate skills.
+- [ ] Decide whether future server-side Swift skills should cover SwiftNIO, deployment, authentication, app sync, or additional database workflows as separate skills.
 - [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
 
 ### rust-skills

--- a/TODO.md
+++ b/TODO.md
@@ -52,8 +52,9 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 
 - [x] Create the Socket-owned `server-side-swift` plugin surface.
 - [x] Add the first real Vapor-focused server-side Swift skill.
+- [x] Add a persistence workflow for Fluent, database migrations, query design, Hummingbird database handoffs, and docs routing.
 - [ ] Add validation coverage for skill metadata and exported skill inventory once central Socket child-skill validation exists.
-- [ ] Decide whether future server-side Swift skills should cover SwiftNIO, Hummingbird, deployment, or database workflows as separate skills.
+- [ ] Decide whether future server-side Swift skills should cover SwiftNIO, deployment, or additional database workflows as separate skills.
 - [ ] Decide whether the long-term home remains Socket-owned or becomes standalone.
 
 ### rust-skills

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -18,6 +18,7 @@
 - [Milestone 40: SwiftUI UI Architecture Workflow](#milestone-40-swiftui-ui-architecture-workflow)
 - [Milestone 41: Swift Package Extension Workflow](#milestone-41-swift-package-extension-workflow)
 - [Milestone 42: Safari Extension And Control Workflow](#milestone-42-safari-extension-and-control-workflow)
+- [Milestone 43: Client Auth, Keychain, and App Sync Workflow](#milestone-43-client-auth-keychain-and-app-sync-workflow)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -49,6 +50,7 @@
 - Milestone 40: SwiftUI UI Architecture Workflow - Completed
 - Milestone 41: Swift Package Extension Workflow - Planned
 - Milestone 42: Safari Extension And Control Workflow - Completed
+- Milestone 43: Client Auth, Keychain, and App Sync Workflow - Planned
 
 ## Milestone 21: Swift Cleanup Automation Exploration
 
@@ -418,6 +420,32 @@ Completed
 - [x] The repository ships `safari-extension-control-workflow` as the explicit owner for Safari extension and SafariServices integration-shape guidance.
 - [x] The workflow keeps WebExtension, Safari Web Inspector Extension, Safari App Extension, content blocker, authentication, and external automation paths distinct.
 - [x] The skill is covered by repo validation and targeted tests.
+
+## Milestone 43: Client Auth, Keychain, and App Sync Workflow
+
+### Status
+
+Planned
+
+### Scope
+
+- [ ] Add a dedicated Apple client workflow for app-side authentication, secure credential storage, and sync behavior in iOS, macOS, and related Apple-platform apps.
+- [ ] Keep Keychain, ASWebAuthenticationSession, Sign in with Apple, URLSession credential handling, token refresh, background refresh, and app-side sync guidance grounded in current Apple documentation.
+- [ ] Keep this client workflow separate from server-side authentication, server persistence, OpenAPI, and RPC guidance while documenting clear handoffs to those plugins when an app crosses that boundary.
+
+### Tickets
+
+- [ ] Define the skill boundary so it owns Apple client auth, Keychain storage, credential refresh, and app-side sync without duplicating server authentication or transport-contract workflow.
+- [ ] Gather Apple documentation anchors for Keychain Services, Authentication Services, Sign in with Apple, URLSession authentication, background tasks, push notification handoffs, and relevant data-protection behavior.
+- [ ] Add guidance for token storage, refresh timing, logout and credential revocation, multi-account behavior, app group or extension sharing, and operator-facing auth errors.
+- [ ] Add app-sync guidance for local cache shape, offline edits, conflict handling, change tokens or cursors, retry behavior, background refresh, and user-visible sync status.
+- [ ] Define handoffs to `server-side-swift` for backend auth and sync contracts, and to OpenAPI or RPC skills when generated clients or transport schemas are the primary concern.
+- [ ] Add tests and maintainer docs once the workflow shape is stable.
+
+### Exit Criteria
+
+- [ ] The repository ships an Apple client auth and app-sync workflow skill with clear Keychain, authentication, credential-refresh, and sync-state guidance.
+- [ ] The workflow clearly separates client responsibilities from server authentication, persistence, OpenAPI, and RPC concerns.
 
 ## Backlog Candidates
 

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.11.1"
+version = "6.12.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.11.1"
+version = "6.12.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.11.1"
+version = "6.12.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Codex skills for building, running, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "server-side-swift",
   "version": "6.11.1",
-  "description": "Codex skills for building, running, and maintaining server-side Swift services, starting with Vapor, Hummingbird, and SwiftPM-first workflows.",
+  "description": "Codex skills for building, running, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -18,13 +18,16 @@
     "server-side-swift",
     "vapor",
     "hummingbird",
+    "fluent",
+    "database",
+    "persistence",
     "swiftpm"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Server-Side Swift",
-    "shortDescription": "Server-side Swift, Vapor, and Hummingbird workflow guidance for Codex.",
-    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor and Hummingbird documentation, local run commands, app structure, routing, middleware, request contexts, Fluent migrations, environment configuration, tests, and deployment handoffs.",
+    "shortDescription": "Server-side Swift, Vapor, Hummingbird, and persistence workflow guidance for Codex.",
+    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor and Hummingbird documentation, local run commands, app structure, routing, middleware, request contexts, Fluent models, database migrations, query design, environment configuration, tests, and deployment handoffs.",
     "developerName": "gaelic-ghost",
     "category": "Developer Tools",
     "capabilities": [
@@ -39,9 +42,11 @@
       "Inspect this Hummingbird app and explain its router, middleware, request contexts, and run commands.",
       "Add a Vapor route with tests while keeping domain logic outside handlers.",
       "Add a Hummingbird route with tests while keeping domain logic outside handlers.",
-      "Set up Fluent migrations and explain the migration commands.",
+      "Plan a server-side Swift persistence change with models, migrations, queries, and tests.",
+      "Set up Fluent models and migrations and explain the migration commands.",
+      "Add database-backed behavior to a Hummingbird service without copying Vapor app structure.",
       "Diagnose why this Vapor build, run, migrate, or local server command failed.",
-      "Diagnose why this Hummingbird build, run, route, or local server command failed."
+      "Diagnose why this Hummingbird build, run, route, database, or local server command failed."
     ],
     "brandColor": "#0EA5E9"
   }

--- a/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
@@ -39,8 +39,11 @@ Primary sources:
 - [Vapor Fluent GitHub repository](https://github.com/vapor/fluent)
 - [Vapor GitHub organization](https://github.com/vapor)
 - [Hummingbird docs](https://docs.hummingbird.codes/)
+- [Hummingbird persistent data docs](https://docs.hummingbird.codes/2.0/documentation/hummingbird/persistentdata/)
 - [Hummingbird GitHub repository](https://github.com/hummingbird-project/hummingbird)
+- [Hummingbird Fluent package](https://github.com/hummingbird-project/hummingbird-fluent)
 - [Hummingbird GitHub organization](https://github.com/hummingbird-project)
+- [Swift.org database and persistence package catalog](https://www.swift.org/packages/database.html)
 
 For Dash.app:
 
@@ -99,6 +102,7 @@ For Hummingbird projects:
 
 - do not assume Fluent or any ORM is already part of the service
 - inspect how the `Application`, router, service lifecycle, and dependencies are currently constructed
+- check Hummingbird's persistent-data docs and ecosystem packages before choosing PostgresNIO, HummingbirdFluent, a direct driver, or another package
 - choose a database client or repository shape that fits the existing Hummingbird service instead of copying Vapor app structure
 - keep database clients, pools, or repositories created at app startup and passed into the handlers or context path already used by the project
 - keep request context values per-request; do not turn request context into a generic dependency container

--- a/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: persistence-workflow
+description: Plan, build, test, and diagnose server-side Swift persistence, database, ORM, model, migration, query, transaction, and repository work for Vapor, Hummingbird, Fluent, and SwiftPM services.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with server-side Swift persistence in SwiftPM projects on macOS or Linux.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: server-side-swift-persistence
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(curl:*)
+---
+
+# Server Persistence Workflow
+
+## Purpose
+
+Plan, build, modify, test, or diagnose database-backed behavior in a server-side Swift service.
+
+The practical decision is which persistence tool owns the data access, how models map to stored records, how schema changes are migrated, where query logic lives, how configuration reaches the database client, and which command proves the service can safely read or write data.
+
+## When To Use
+
+- Use this skill when adding or changing Fluent models, migrations, relations, queries, transactions, or database configuration.
+- Use this skill when a Vapor service needs database behavior that goes beyond route setup.
+- Use this skill when a Hummingbird service needs database access, repository boundaries, migration handoffs, or driver selection.
+- Use this skill when comparing Fluent, direct SQL, a package-specific database client, or a small repository/query helper for a Swift service.
+- Use this skill when diagnosing failed migrations, missing schema, broken relations, connection-pool problems, query errors, transaction behavior, or database-backed tests.
+- Do not use this skill for route, middleware, request-context, server startup, or deployment-only work unless persistence is the reason for the change.
+- Do not use this skill for Apple-platform client storage such as SwiftData, Core Data, Keychain, UserDefaults, or app-side sync. Hand that work to an Apple-platform workflow.
+
+## Source Check
+
+Use official framework and package documentation first. Check the current docs before claiming package names, APIs, migration commands, driver support, or CLI behavior.
+
+Primary sources:
+
+- [Vapor Fluent docs](https://docs.vapor.codes/fluent/overview/)
+- [Vapor migrations docs](https://docs.vapor.codes/fluent/migration/)
+- [Vapor Fluent GitHub repository](https://github.com/vapor/fluent)
+- [Vapor GitHub organization](https://github.com/vapor)
+- [Hummingbird docs](https://docs.hummingbird.codes/)
+- [Hummingbird GitHub repository](https://github.com/hummingbird-project/hummingbird)
+- [Hummingbird GitHub organization](https://github.com/hummingbird-project)
+
+For Dash.app:
+
+- Check the local Dash docsets before relying on them.
+- If a needed docset is missing, use official hosted docs and GitHub source first.
+- For docset availability or creation, use [Dash docset generation guidance](https://kapeli.com/docsets) and [Dash user-contributed docsets](https://github.com/Kapeli/Dash-User-Contributions). Do not claim a Vapor, Hummingbird, or Fluent Dash docset exists until the local Dash installation or the docset source has been checked.
+
+Use Swift Package Manager and Swift.org documentation for package, target, dependency, and toolchain behavior when the framework docs do not own the rule being used.
+
+## Planning Workflow
+
+1. Inspect project shape:
+   - `Package.swift`
+   - executable target and library targets
+   - route, controller, handler, or router owners
+   - existing model, migration, repository, query, and database-support files
+   - configuration, environment, Docker, Compose, or test database setup
+   - tests that create, migrate, seed, or reset storage
+2. Identify the persistence job:
+   - CRUD storage
+   - relational data model
+   - migration or schema evolution
+   - direct SQL query
+   - transaction boundary
+   - background job persistence
+   - read model or reporting query
+   - test fixture or ephemeral database setup
+3. Choose the narrowest fitting data-access path:
+   - Fluent for Vapor projects already using Fluent models, migrations, and `req.db`
+   - a documented direct database client when the service needs SQL-specific behavior or does not use Fluent
+   - a small repository or query helper when route handlers are accumulating duplicated database code
+   - existing repo conventions when a project already has a tested persistence boundary
+4. Keep schema changes explicit and reversible only when a safe revert really exists.
+5. Keep database credentials out of source control.
+6. Add or update tests at the smallest level that proves the data behavior.
+7. Validate with the narrowest useful SwiftPM, migration, database, or HTTP check.
+
+## Vapor And Fluent
+
+For Vapor projects that use Fluent:
+
+- keep models, migrations, and database configuration aligned with current Vapor Fluent docs
+- register database drivers and migrations in app configuration
+- run migrations with the documented app command, usually `swift run App migrate`
+- use `swift run App migrate --revert` only when the user accepts the data-loss and rollback risk
+- keep model types focused on stored fields and relations
+- avoid putting unrelated business rules in route closures or model types
+- use transactions when multiple writes must succeed or fail together
+- keep request/response DTOs separate from database models when API shape and stored shape differ
+
+When the work is mostly route, middleware, command, environment, or Vapor app structure, compose with `vapor-server-workflow`.
+
+## Hummingbird Services
+
+For Hummingbird projects:
+
+- do not assume Fluent or any ORM is already part of the service
+- inspect how the `Application`, router, service lifecycle, and dependencies are currently constructed
+- choose a database client or repository shape that fits the existing Hummingbird service instead of copying Vapor app structure
+- keep database clients, pools, or repositories created at app startup and passed into the handlers or context path already used by the project
+- keep request context values per-request; do not turn request context into a generic dependency container
+- keep typed request and response models at the HTTP boundary and persistence models at the storage boundary when they diverge
+
+When the work is mostly routing, middleware, request context, testing helpers, or Hummingbird app structure, compose with `hummingbird-server-workflow`.
+
+## Query And Migration Design
+
+When changing stored data behavior:
+
+- name the table, collection, schema, model, or aggregate being changed
+- describe the old shape, new shape, and migration path
+- state whether existing data must be backfilled, transformed, preserved, or dropped
+- keep operator-facing migration errors descriptive and tied to the schema or connection being changed
+- keep query helpers explicit about inputs, filters, ordering, paging, and returned shape
+- avoid stringly typed fallback paths when the project has typed model or query support
+- avoid hidden writes in read-looking helpers
+
+Use direct SQL only when it is simpler, more transparent, or required for the query. If direct SQL is introduced, keep it isolated, parameterized, tested, and named by the use case it serves.
+
+## Testing
+
+Choose the smallest test that proves the persistence behavior:
+
+- pure Swift test for mapping or validation logic
+- migration test for schema creation and upgrade behavior
+- repository or query test for database reads and writes
+- handler/controller test when the HTTP surface and database behavior must be proven together
+- local HTTP check only when runtime wiring, configuration, or connection behavior cannot be proven through tests alone
+
+Prefer `swift test` for normal validation. If the project uses a real database in tests, identify how the database is created, migrated, seeded, isolated, and cleaned up before adding new tests.
+
+## Output Shape
+
+Return:
+
+1. `Persistence shape`: database tool, model owners, migration owners, query/repository owners, and configuration source.
+2. `Docs used`: official docs, GitHub sources, or checked Dash docsets relied on for API, migration, or package behavior.
+3. `Command path`: exact build, test, migrate, run, or diagnostic commands run or recommended.
+4. `Data behavior`: schema changes, models, relations, queries, transactions, errors, or configuration changes.
+5. `Validation`: SwiftPM, migration, test database, or HTTP check results.
+6. `Handoffs`: Vapor, Hummingbird, SwiftPM, Apple-platform client, deployment, or observability follow-up when the task crosses this skill's boundary.
+
+## Guardrails
+
+- Do not commit secrets, credentials, connection strings, local database files, or machine-local dependency paths.
+- Do not run destructive migrations, reverts, truncates, drops, or data repairs without explicit user approval.
+- Do not claim a database driver, Dash docset, package API, or migration command from memory when current docs or local project files can be checked.
+- Do not introduce a repository, service, manager, or helper unless it removes concrete duplication, clarifies a real dependency boundary, or makes tests meaningfully simpler.
+- Do not move client-side Apple persistence guidance into this skill.

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.11.1"
+version = "6.12.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.11.1"
+version = "6.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.11.1",
+  "version": "6.12.0",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.11.1"
+version = "6.12.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add server-side Swift persistence workflow skill for Fluent, Vapor, Hummingbird, migrations, query design, testing, and docs routing
- add auth and app-sync roadmap items for server-side Swift and Apple client workflows
- bump shared Socket version surfaces to 6.12.0

## Validation
- uv run scripts/validate_socket_metadata.py
- bash .github/scripts/validate_repo_docs.sh from plugins/apple-dev-skills
- local temporary CODEX_HOME marketplace smoke test for server-side-swift

## Subtree
- pushed plugins/apple-dev-skills subtree state to apple-dev-skills/main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistence workflow skill for server-side Swift development
  * Planned new milestone for client authentication, keychain management, and app sync

* **Documentation**
  * Enhanced server-side Swift guidance with persistence and database workflows
  * Added roadmap entries for expanded skill coverage areas

* **Chores**
  * Released version 6.12.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaelic-ghost/socket/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->