### PR TITLE
plugin: add Swift OpenAPI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Current Socket catalog shape:
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
-- `server-side-swift`: server-side Swift, Vapor, Hummingbird, and persistence workflows with SwiftPM-first build, run, test, framework-specific migration, database, and diagnostics guidance
+- `server-side-swift`: server-side Swift, Vapor, Hummingbird, persistence, OpenAPI, and RPC-fit workflows with SwiftPM-first build, run, test, framework-specific migration, database, generated transport, and diagnostics guidance
 - `rust-skills`: Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, test, lint, and format workflow guidance
 - `speak-swiftly`: Git-backed Speak Swiftly plugin from the standalone SpeakSwiftlyServer repository
 - `swiftasb-skills`: SwiftASB companion guidance

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Apple Dev Skills keeps its own roadmap because it is the remaining subtree-manag
 Current Socket catalog shape:
 
 - `agent-plugin-skills`: maintainer skills for skills-export and plugin-export repositories
-- `apple-dev-skills`: Apple, Swift, SwiftUI, Xcode, and DocC workflows with its own roadmap
+- `apple-dev-skills`: Apple, Swift, SwiftUI, Xcode, Swift OpenAPI client, Safari, and DocC workflows with its own roadmap
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `productivity-skills`: general-purpose maintainer and documentation workflow baseline

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,16 +149,16 @@ In Progress
 - [x] Wire `server-side-swift` into the root Socket marketplace as a normal local child plugin.
 - [x] Add `server-side-swift:hummingbird-server-workflow` for Hummingbird services, including route composition, middleware, request/response modeling, local run commands, tests, and SwiftPM-first validation.
 - [x] Add `server-side-swift:persistence-workflow` for server-side Swift persistence, including Fluent models, database migrations, query design, Hummingbird database handoffs, tests, and docs routing through official docs, GitHub sources, or checked Dash docsets.
-- [ ] Add an OpenAPI workflow for generating, serving, validating, or consuming OpenAPI descriptions in server-side Swift services without tying the skill to one web framework by default.
-- [ ] Add an RPC workflow for Swift service boundaries that may use JSON-RPC, gRPC, MCP-like transports, or framework-specific client/server contracts, with explicit guidance for when plain HTTP routes are the simpler fit.
+- [x] Add an OpenAPI workflow for generating, serving, validating, or consuming OpenAPI descriptions in server-side Swift services without tying the skill to one web framework by default.
+- [x] Add an RPC workflow for Swift service boundaries that may use JSON-RPC, gRPC, MCP-like transports, or framework-specific client/server contracts, with explicit guidance for when plain HTTP routes are the simpler fit.
 - [ ] Add a SwiftNIO workflow for lower-level event-loop, channel, bootstrap, byte-buffer, back-pressure, and nonblocking-I/O work when a service needs NIO directly instead of a higher-level framework.
 - [ ] Add Swift observability and tracing guidance that covers Swift Logging, Metrics, Distributed Tracing, and OpenTelemetry-style instrumentation for service diagnostics.
 - [ ] Add a server authentication and authorization workflow covering Vapor and Hummingbird auth boundaries, sessions, JWT, OAuth/OIDC handoffs, password storage, middleware placement, and security-sensitive testing without duplicating client Keychain guidance.
 - [ ] Add a server app-sync workflow covering sync contracts, conflict handling, incremental change feeds, idempotent writes, cursor/token semantics, background job handoffs, and API-shape coordination without absorbing the separate OpenAPI or RPC workflow.
 - [ ] Add a Docker workflow for server-side Swift packages, including Dockerfile shape, Compose-local development, Linux image concerns, environment configuration, and build/test handoffs.
 - [ ] Add an Apple Containerization workflow for Apple's container tooling, keeping it distinct from generic Docker guidance and tied to current official Apple documentation.
-- [ ] Update plugin metadata prompts and keywords as new server-side Swift skill surfaces ship.
-- [ ] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` after each metadata or marketplace-facing update.
+- [x] Update plugin metadata prompts and keywords as new server-side Swift skill surfaces ship.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py` after each metadata or marketplace-facing update.
 
 ### Exit Criteria
 

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-dev-skills",
   "version": "6.12.0",
-  "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, and DocC authoring guidance.",
+  "description": "Apple development workflows for Codex, including SwiftUI architecture, Safari extensions, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -19,6 +19,8 @@
     "mcp",
     "swiftui",
     "safari",
+    "openapi",
+    "urlsession",
     "ios",
     "macos"
   ],
@@ -26,8 +28,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Apple Dev Skills",
-    "shortDescription": "Apple, Swift, Xcode, SwiftUI, Safari, and DocC workflows for Codex.",
-    "longDescription": "Bundle Apple-platform development skills for Swift, SwiftUI architecture, Safari extension, Safari Web Inspector, and SafariServices integration, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling. Most workflows work standalone; bootstrap and guidance-sync workflows that install or refresh repo-maintenance files require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
+    "shortDescription": "Apple, Swift, Xcode, SwiftUI, Safari, OpenAPI client, and DocC workflows for Codex.",
+    "longDescription": "Bundle Apple-platform development skills for Swift, SwiftUI architecture, Safari extension, Safari Web Inspector, SafariServices integration, generated Swift OpenAPI clients with URLSession transport, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling. Most workflows work standalone; bootstrap and guidance-sync workflows that install or refresh repo-maintenance files require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -38,6 +40,7 @@
     "defaultPrompt": [
       "Explore the relevant Apple docs first, then explain the right SwiftUI or Xcode path for this repository.",
       "Choose the right Safari extension, Safari Web Inspector, SafariServices, messaging, content blocker, or automation fallback path for this Mac app.",
+      "Add or diagnose a generated Swift OpenAPI client in this Apple app using OpenAPIURLSession and current Apple docs.",
       "Help me build, test, or debug this Swift or Xcode project using the repo's Apple workflows.",
       "Write or review DocC symbol comments, articles, extension files, and landing-page structure for this Swift repository.",
       "Sync the Apple project guidance in this repo without hand-editing Xcode project files, using Productivity Skills when repo-maintenance files must be installed or refreshed."

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -1,6 +1,6 @@
 # apple-dev-skills
 
-Apple, Swift, SwiftUI, Safari, Xcode, DocC, and `Dash.app` workflows for Codex.
+Apple, Swift, SwiftUI, Safari, Xcode, Swift OpenAPI client, DocC, and `Dash.app` workflows for Codex.
 
 ![Codex plugin directory filtered to the Socket marketplace, showing Apple Dev Skills listed alongside companion plugins below a Productivity Skills suggestion.](./docs/media/codex-plugin-directory-socket-apple-dev-skills.png)
 
@@ -58,6 +58,7 @@ Use Apple Dev Skills when an agent is helping with:
 - Swift and SwiftUI implementation
 - Xcode build, run, test, and project workflows
 - Safari extension and SafariServices integration choices
+- Swift OpenAPI client generation and `URLSession` transport integration
 - Swift package bootstrap, build, and testing
 - Apple UI accessibility work
 - DocC comments, articles, and documentation catalogs
@@ -119,6 +120,7 @@ uv run pytest
 - `format-swift-sources`
 - `safari-extension-control-workflow`
 - `structure-swift-sources`
+- `swift-openapi-client-workflow`
 - `swift-package-build-run-workflow`
 - `swift-package-testing-workflow`
 - `swift-package-workflow`

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -19,6 +19,7 @@
 - [Milestone 41: Swift Package Extension Workflow](#milestone-41-swift-package-extension-workflow)
 - [Milestone 42: Safari Extension And Control Workflow](#milestone-42-safari-extension-and-control-workflow)
 - [Milestone 43: Client Auth, Keychain, and App Sync Workflow](#milestone-43-client-auth-keychain-and-app-sync-workflow)
+- [Milestone 44: Swift OpenAPI Client Workflow](#milestone-44-swift-openapi-client-workflow)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -51,6 +52,7 @@
 - Milestone 41: Swift Package Extension Workflow - Planned
 - Milestone 42: Safari Extension And Control Workflow - Completed
 - Milestone 43: Client Auth, Keychain, and App Sync Workflow - Planned
+- Milestone 44: Swift OpenAPI Client Workflow - Completed
 
 ## Milestone 21: Swift Cleanup Automation Exploration
 
@@ -446,6 +448,30 @@ Planned
 
 - [ ] The repository ships an Apple client auth and app-sync workflow skill with clear Keychain, authentication, credential-refresh, and sync-state guidance.
 - [ ] The workflow clearly separates client responsibilities from server authentication, persistence, OpenAPI, and RPC concerns.
+
+## Milestone 44: Swift OpenAPI Client Workflow
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add an Apple-platform client-side workflow for generated Swift OpenAPI clients, keeping app integration separate from server-side Vapor and Hummingbird transports.
+- [x] Require Apple and Swift docs checks for `URLSession`, SwiftPM plugins, Xcode package integration, app lifecycle, and UI-state behavior before making design or implementation claims.
+- [x] Keep server API contract and transport changes handed off to the server-side Swift plugin instead of making Apple Dev Skills own backend behavior.
+
+### Tickets
+
+- [x] Add `swift-openapi-client-workflow` with guidance for `swift-openapi-generator`, `OpenAPIRuntime`, `OpenAPIURLSession`, `URLSessionTransport`, generated `Client`, response handling, cancellation, and app-facing service boundaries.
+- [x] Add skill interface metadata for the plugin directory.
+- [x] Update Apple Dev Skills plugin metadata, README active skill inventory, and roadmap status.
+
+### Exit Criteria
+
+- [x] Apple app agents have a first stop for generated OpenAPI clients.
+- [x] The workflow keeps generated client code out of UI views when a small app-facing service is the cleaner boundary.
+- [x] The workflow names server-side OpenAPI/RPC, Xcode build/run, Xcode testing, Swift package, and docs-exploration handoffs.
 
 ## Backlog Candidates
 

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.12.0"
+version = "6.13.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/swift-openapi-client-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/swift-openapi-client-workflow/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: swift-openapi-client-workflow
+description: Build, integrate, test, and diagnose Swift OpenAPI Generator clients in Apple-platform apps and Swift packages using OpenAPIURLSession, OpenAPIRuntime, URLSessionTransport, SwiftPM plugins, Apple docs, Dash docsets, and clear handoffs to server-side Swift OpenAPI workflows when the API contract or server transport changes.
+license: Apache-2.0
+metadata:
+  owner: gaelic-ghost
+  repo: apple-dev-skills
+  category: apple-swift-openapi-client
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(find:*) Bash(sqlite3:*) Bash(curl:*)
+---
+
+# Swift OpenAPI Client Workflow
+
+## Purpose
+
+Add or diagnose generated Swift OpenAPI clients in Apple-platform code without confusing app-side networking with server-side transport work.
+
+The practical decision is where the OpenAPI document lives, which app or package target runs Swift OpenAPI Generator, how the generated `Client` is configured with `OpenAPIURLSession`, how calls are isolated from UI state, and which tests prove request, response, auth, cancellation, and error behavior.
+
+## When To Use
+
+- Use this skill when an iOS, macOS, watchOS, tvOS, visionOS, or Swift package client should call an HTTP API from an OpenAPI description.
+- Use this skill when adding or changing `swift-openapi-generator`, `swift-openapi-runtime`, or `swift-openapi-urlsession` dependencies for client generation.
+- Use this skill when wiring `openapi.yaml`, `openapi.json`, or `openapi-generator-config.yaml` into an app-supporting package or target.
+- Use this skill when diagnosing generated client symbols such as `Client`, `APIProtocol`, `Operations`, `Components`, response enums, content-type cases, undocumented responses, or transport errors.
+- Use this skill when integrating generated calls into SwiftUI, AppKit, UIKit, Observation, async tasks, app services, or test doubles.
+- Do not use this skill for generated server handlers, Vapor transport, Hummingbird transport, JSON-RPC, gRPC, or MCP-style service contracts. Hand that to `server-side-swift:openapi-rpc-workflow` when available.
+- Do not use this skill for ordinary `URLSession` networking with no OpenAPI contract.
+
+## Source Check
+
+Start with the Apple and Swift docs gate:
+
+- Use `explore-apple-swift-docs` for Apple framework behavior, `URLSession`, Foundation networking, Xcode package integration, Swift concurrency, Observation, SwiftUI, UIKit, AppKit, or platform lifecycle behavior.
+- Use local Dash or official docs before claiming current Apple or Swift API behavior.
+- Look in Dash Swift docsets for `appleswiftopenapigenerator`, `appleswiftopenapiruntime`, `appleswiftopenapiurlsession`, `swiftlangswiftpackagemanager`, and Apple Foundation or platform docs when available.
+- Use [Introducing Swift OpenAPI Generator](https://www.swift.org/blog/introducing-swift-openapi-generator/) for the official client/server overview, generated `Client`, `APIProtocol`, `ClientTransport`, and `URLSessionTransport` shape.
+- Use [apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator) for current generator behavior, plugin setup, examples, and supported OpenAPI features.
+- Use [apple/swift-openapi-runtime](https://github.com/apple/swift-openapi-runtime) for generated runtime types, middleware concepts, and shared abstractions.
+- Use [apple/swift-openapi-urlsession](https://github.com/apple/swift-openapi-urlsession) for the `OpenAPIURLSession` transport and platform support.
+- Use [Swift Package Manager documentation](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/) for package plugin, target, dependency, and build behavior.
+
+Do not claim current generator, URLSession transport, package-plugin, or Apple framework behavior from memory when current docs can be checked.
+
+## Planning Workflow
+
+1. Inspect project shape:
+   - `Package.swift`
+   - `.xcodeproj`, `.xcworkspace`, package dependencies, and target membership when present
+   - OpenAPI document path
+   - `openapi-generator-config.yaml`
+   - app target, shared client package target, generated-code target, and test targets
+   - networking service or API client owner
+   - SwiftUI, Observation, AppKit, UIKit, or other UI entry points that call the client
+2. Identify the client ownership shape:
+   - app target owns generated client directly
+   - shared Swift package owns generated client for one or more apps
+   - generated client wraps a server-side Swift service in the same workspace
+   - existing hand-written client is being replaced or wrapped
+3. Confirm the generator stack:
+   - Swift OpenAPI Generator package plugin
+   - OpenAPIRuntime runtime dependency
+   - OpenAPIURLSession transport for Apple-platform URL loading
+   - client generation in `openapi-generator-config.yaml`
+4. Keep generated transport code away from UI views. Views should call a small app-facing service, model, environment value, or dependency shape that can be tested.
+5. Keep the OpenAPI document and generator config reviewable, because they define the generated Swift symbols and response cases.
+6. Validate through build, focused client tests, and app or package tests before recommending runtime manual checks.
+
+## Client Integration
+
+When adding Swift OpenAPI client generation:
+
+- add fetchable package dependencies for `swift-openapi-generator`, `swift-openapi-runtime`, and `swift-openapi-urlsession`
+- add the `OpenAPIGenerator` plugin to the target that owns the OpenAPI document
+- add `OpenAPIRuntime` and `OpenAPIURLSession` products to the generated-client target
+- configure `openapi-generator-config.yaml` to generate `types` and `client`
+- instantiate generated `Client` with a documented server URL and `URLSessionTransport`
+- keep base URL, auth tokens, and environment selection outside generated types
+- keep secrets out of source control
+
+For Xcode app projects, preserve project ownership. If package dependency or target membership changes require Xcode-aware mutation, hand off to `xcode-build-run-workflow` rather than editing `.pbxproj` casually.
+
+For Swift package clients, keep `Package.swift` readable and intentional. Prefer SwiftPM commands or focused manifest edits that match the existing package style.
+
+## App-Side Behavior
+
+When connecting generated clients to app code:
+
+- isolate generated response enums from UI views with a small app-facing API when the UI would otherwise switch over transport details everywhere
+- handle documented response cases explicitly
+- handle `.undocumented` responses with a readable error path
+- preserve task cancellation; do not hide `CancellationError` behind generic networking failures
+- keep authentication, retry, logging, and metrics in a transport or app-service boundary instead of scattering them across views
+- map generated schemas into local app models only when the app needs persistence, editing, identity, or UI-specific state
+- avoid using generated types as SwiftData, Core Data, or UI state models unless the generated schema is intentionally stable enough for that job
+
+When an API contract change is needed, stop and surface that as server or contract work. Do not quietly patch the generated client around a mismatched server contract.
+
+## Testing And Validation
+
+Choose the smallest useful check:
+
+- `swift build` to force package-plugin generation and type checking
+- `swift test` for package-level client wrappers, request mapping, response handling, and fake transport behavior
+- Xcode build or test workflow when the app target, scheme, simulator, or package integration is the real risk
+- local HTTP checks only when integration with a real server, auth header, TLS, cookie, redirect, or streaming behavior must be proven end to end
+
+Prefer fake `ClientTransport` or app-service seams for tests when the behavior does not require a real network. Use real `URLSessionTransport` checks only when Foundation networking behavior is the thing being verified.
+
+When validation fails, name the exact OpenAPI operation, generated symbol, target, package plugin, transport, response case, or Apple framework surface involved. Include the likely cause, such as a missing config file, wrong target plugin placement, stale operation ID, unsupported schema shape, missing `OpenAPIURLSession` dependency, target membership drift, or an app lifecycle call running from the wrong task boundary.
+
+## Output Shape
+
+Return:
+
+1. `Client shape`: OpenAPI document, generator config, target ownership, generated symbols, transport, and app-facing owner.
+2. `Docs used`: Apple, Swift, Dash, GitHub, or SwiftPM docs consulted.
+3. `Command path`: exact SwiftPM, Xcode, generator, validation, test, run, or HTTP commands run or recommended.
+4. `Behavior`: operations, inputs, outputs, auth, cancellation, errors, UI handoff, and contract-change decisions.
+5. `Validation`: build, test, app run, fake transport, real HTTP, or skipped checks.
+6. `Handoffs`: server-side OpenAPI/RPC, Xcode build/run, Xcode testing, Swift package, docs exploration, persistence, or observability follow-up when the task crosses this skill's boundary.
+
+## Guardrails
+
+- Do not turn an Apple app workflow into server-side transport work.
+- Do not hide API contract mismatches behind app-side adapters without saying the server contract needs attention.
+- Do not commit generated caches, secrets, local server URLs as production defaults, or machine-local dependency paths.
+- Do not hand-edit `Package.resolved`.
+- Do not edit Xcode project files casually; use Xcode-aware workflows when project membership or scheme behavior is part of the change.
+- Do not let generated response enums leak into every view when a small app-facing service would keep UI code readable and testable.

--- a/plugins/apple-dev-skills/skills/swift-openapi-client-workflow/agents/openai.yaml
+++ b/plugins/apple-dev-skills/skills/swift-openapi-client-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Swift OpenAPI Client Workflow"
+  short_description: "Integrate generated Swift OpenAPI clients into Apple apps"
+  default_prompt: "Use $swift-openapi-client-workflow to add, integrate, test, or diagnose Swift OpenAPI Generator client code in an Apple-platform app or Swift package with OpenAPIURLSession, OpenAPIRuntime, URLSessionTransport, Apple docs, and clear handoffs to server-side OpenAPI or Xcode workflows when the task crosses that boundary."

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.12.0"
+version = "6.13.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.12.0"
+version = "6.13.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Codex skills for building, running, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, Swift OpenAPI, RPC-fit decisions, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "server-side-swift",
   "version": "6.12.0",
-  "description": "Codex skills for building, running, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, and SwiftPM-first workflows.",
+  "description": "Codex skills for building, running, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, Swift OpenAPI, RPC-fit decisions, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -21,13 +21,15 @@
     "fluent",
     "database",
     "persistence",
+    "openapi",
+    "rpc",
     "swiftpm"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Server-Side Swift",
-    "shortDescription": "Server-side Swift, Vapor, Hummingbird, and persistence workflow guidance for Codex.",
-    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor and Hummingbird documentation, local run commands, app structure, routing, middleware, request contexts, Fluent models, database migrations, query design, environment configuration, tests, and deployment handoffs.",
+    "shortDescription": "Server-side Swift, Vapor, Hummingbird, persistence, OpenAPI, and RPC workflow guidance for Codex.",
+    "longDescription": "Guide Codex agents through server-side Swift projects with SwiftPM-first workflows, current Vapor, Hummingbird, and Swift OpenAPI documentation, local run commands, app structure, routing, middleware, request contexts, Fluent models, database migrations, query design, OpenAPI generation and transport wiring, RPC-fit decisions, environment configuration, tests, and deployment handoffs.",
     "developerName": "gaelic-ghost",
     "category": "Developer Tools",
     "capabilities": [
@@ -38,8 +40,11 @@
     "defaultPrompt": [
       "Create a Vapor service plan using current Vapor CLI and SwiftPM workflows.",
       "Create a Hummingbird service plan using current Hummingbird docs and SwiftPM workflows.",
+      "Add Swift OpenAPI Generator to a server-side Swift package and wire the generated API to Vapor or Hummingbird.",
+      "Decide whether this Swift service boundary should use OpenAPI, JSON-RPC, gRPC, MCP-style tools, or ordinary HTTP routes.",
       "Inspect this Vapor app and explain its routes, configuration, and run commands.",
       "Inspect this Hummingbird app and explain its router, middleware, request contexts, and run commands.",
+      "Inspect this OpenAPI-backed Swift service and explain its contract, generated symbols, transport, and validation commands.",
       "Add a Vapor route with tests while keeping domain logic outside handlers.",
       "Add a Hummingbird route with tests while keeping domain logic outside handlers.",
       "Plan a server-side Swift persistence change with models, migrations, queries, and tests.",

--- a/plugins/server-side-swift/skills/openapi-rpc-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/openapi-rpc-workflow/SKILL.md
@@ -42,7 +42,7 @@ Prefer current local docs first when available, then official online docs:
 - If querying Dash directly, inspect each docset's `Contents/Resources/docSet.dsidx` with `sqlite3` and search for symbols or guide titles before falling back to the web.
 - Use [apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator) for generator behavior, package plugin setup, examples, supported OpenAPI features, and links to generated-code documentation.
 - Use [apple/swift-openapi-runtime](https://github.com/apple/swift-openapi-runtime) for generated runtime types and middleware concepts.
-- Use [hummingbird-project/swift-openapi-hummingbird](https://github.com/hummingbird-project/swift-openapi-hummingbird) for Hummingbird server transport behavior.
+- Use [swift-server/swift-openapi-hummingbird](https://github.com/swift-server/swift-openapi-hummingbird) for Hummingbird server transport behavior.
 - Use [vapor/swift-openapi-vapor](https://github.com/vapor/swift-openapi-vapor) for Vapor server transport behavior.
 - Use [Swift Package Manager documentation](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/) for SwiftPM plugin, target, build, and test behavior.
 - Use [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator) only when the repository is intentionally using the Java-based OpenAPI Generator CLI instead of Apple's Swift package plugin.

--- a/plugins/server-side-swift/skills/openapi-rpc-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/openapi-rpc-workflow/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: openapi-rpc-workflow
+description: Design, generate, implement, test, and diagnose Swift OpenAPI and RPC-style server contracts using Swift OpenAPI Generator, OpenAPIRuntime, OpenAPIHummingbird, OpenAPIVapor, SwiftPM plugins, Dash docsets, official GitHub/SPI documentation, and clear handoffs to Vapor or Hummingbird workflows.
+license: Apache-2.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with Swift OpenAPI Generator, OpenAPIRuntime, Hummingbird, Vapor, SwiftPM, and server-side Swift services on macOS or Linux.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: server-side-swift-openapi-rpc
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(swift:*) Bash(find:*) Bash(sqlite3:*) Bash(curl:*)
+---
+
+# OpenAPI And RPC Workflow
+
+## Purpose
+
+Build or diagnose contract-first server-side Swift work without mixing up three different things:
+
+- the OpenAPI description, which is the HTTP API contract
+- Swift OpenAPI Generator, which generates Swift types, client calls, and server protocol stubs from that contract
+- the server transport, such as OpenAPIHummingbird or OpenAPIVapor, which registers a generated `APIProtocol` implementation on a real Hummingbird or Vapor app
+
+For RPC-style services, first identify whether the user really means OpenAPI-backed HTTP operations, JSON-RPC over HTTP, gRPC, MCP-style tool calls, or a framework-specific client/server contract. Keep plain HTTP routes as the default when the service does not need a stronger protocol contract.
+
+## When To Use
+
+- Use this skill when adding, editing, validating, or consuming an OpenAPI document in a Swift package.
+- Use this skill when wiring Swift OpenAPI Generator into `Package.swift`, `openapi-generator-config.yaml`, generated sources, or SwiftPM plugin commands.
+- Use this skill when implementing generated server stubs with `APIProtocol`, `Operations`, `Components`, `OpenAPIRuntime`, `OpenAPIHummingbird`, or `OpenAPIVapor`.
+- Use this skill when choosing between Hummingbird and Vapor as the server transport for a generated API.
+- Use this skill when diagnosing generated-code drift, operation ID changes, missing schemas, request/response typing, transport registration, or OpenAPI validation failures.
+- Use this skill when a user says "RPC" and the next decision is whether OpenAPI, JSON-RPC, gRPC, MCP, or ordinary routes fit the service boundary.
+- Do not use this skill for generic Vapor or Hummingbird route work that has no generated OpenAPI contract. Use the framework-specific workflow instead.
+- Do not use this skill for Apple-platform app, simulator, preview, or Xcode project membership work.
+
+## Source Check
+
+Prefer current local docs first when available, then official online docs:
+
+- Dash Swift docsets usually live under `~/Library/Application Support/Dash/Swift DocSets/`.
+- Look for `appleswiftopenapigenerator`, `appleswiftopenapiruntime`, `hummingbirdprojectswiftopenapihummingbird`, `vaporswiftopenapivapor`, `hummingbirdprojecthummingbird`, `vaporvapor`, and `swiftlangswiftpackagemanager`.
+- If querying Dash directly, inspect each docset's `Contents/Resources/docSet.dsidx` with `sqlite3` and search for symbols or guide titles before falling back to the web.
+- Use [apple/swift-openapi-generator](https://github.com/apple/swift-openapi-generator) for generator behavior, package plugin setup, examples, supported OpenAPI features, and links to generated-code documentation.
+- Use [apple/swift-openapi-runtime](https://github.com/apple/swift-openapi-runtime) for generated runtime types and middleware concepts.
+- Use [hummingbird-project/swift-openapi-hummingbird](https://github.com/hummingbird-project/swift-openapi-hummingbird) for Hummingbird server transport behavior.
+- Use [vapor/swift-openapi-vapor](https://github.com/vapor/swift-openapi-vapor) for Vapor server transport behavior.
+- Use [Swift Package Manager documentation](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/) for SwiftPM plugin, target, build, and test behavior.
+- Use [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator) only when the repository is intentionally using the Java-based OpenAPI Generator CLI instead of Apple's Swift package plugin.
+
+Do not claim current generator, transport, or package-plugin behavior from memory when current official docs or local Dash docsets can be checked.
+
+## Planning Workflow
+
+1. Inspect project shape:
+   - `Package.swift`
+   - OpenAPI document path, usually `openapi.yaml`, `openapi.yml`, or `openapi.json`
+   - `openapi-generator-config.yaml`
+   - generated source directories or build-plugin output assumptions
+   - executable target, library target, and test targets
+   - Hummingbird or Vapor app construction and route registration
+   - generated names such as `APIProtocol`, `Operations`, `Components`, `Client`, and transport imports
+2. Identify the contract owner:
+   - spec-first service where the OpenAPI document drives generated server stubs
+   - existing service where routes need an OpenAPI description
+   - shared client/server package
+   - internal RPC-like boundary where OpenAPI may or may not be the right shape
+3. Confirm the generator stack:
+   - Apple's Swift OpenAPI Generator package plugin for SwiftPM-first projects
+   - OpenAPIHummingbird for Hummingbird server registration
+   - OpenAPIVapor for Vapor server registration
+   - URLSession or AsyncHTTPClient transports for generated clients when needed
+   - OpenAPITools CLI only when the repo already chose that toolchain
+4. Keep generated code out of source control when the project uses SwiftPM build plugins, unless the repository explicitly commits generated sources.
+5. Keep the OpenAPI document and generator config reviewable, because they are the API contract and the generated Swift surface depends on them.
+6. Validate in the narrowest useful order: spec validity, generation/build, server registration tests, then runtime HTTP checks if needed.
+
+## Contract Design
+
+For OpenAPI-backed work:
+
+- give every operation a stable, readable `operationId`
+- model request bodies, response bodies, parameters, headers, and status codes explicitly
+- use shared schemas for values that cross more than one operation
+- keep error responses typed enough that clients can handle them predictably
+- avoid exposing internal database or framework types in the contract
+- treat operation ID or schema renames as API surface changes, because generated Swift symbol names may change
+
+For RPC-style work:
+
+- choose OpenAPI when the boundary is HTTP operations with typed requests and responses
+- choose JSON-RPC only when method-call semantics are actually part of the protocol
+- choose gRPC only when the project has protobuf, streaming, or interoperability reasons that justify the extra toolchain
+- choose MCP-style tools only when the caller is an agent/tool runtime rather than a normal HTTP API client
+- keep ordinary Hummingbird or Vapor routes when the API is small, local, or not ready for a shared generated contract
+
+## SwiftPM And Generator Setup
+
+When adding Apple's Swift OpenAPI Generator to an existing package:
+
+- add the generator package as a dependency in `Package.swift`
+- add the plugin to the target that owns the OpenAPI document
+- add `OpenAPIRuntime` and the selected transport product to the target dependencies
+- add or update `openapi-generator-config.yaml` for generated client, server, types, or access modifier choices
+- keep dependency URLs fetchable from GitHub or package registries, not local paths
+
+Before editing `Package.swift`, inspect the current package tools version, target names, dependency style, and whether the repo pins exact versions, branches, or ranges.
+
+## Hummingbird Transport
+
+Use OpenAPIHummingbird when the service already uses Hummingbird or when Hummingbird is the chosen server framework.
+
+Typical shape:
+
+- build the `Router`
+- create the handler type that conforms to generated `APIProtocol`
+- call generated `registerHandlers` on the Hummingbird router or documented transport
+- create and run the `Application` through the repository's existing Hummingbird lifecycle
+
+For request-context access from generated handlers, check current OpenAPIHummingbird docs before implementing. The transport documentation has used a task-local middleware pattern so generated endpoints can reach the Hummingbird request context without turning the generated protocol implementation into a generic dependency container.
+
+Hand off to `hummingbird-server-workflow` for route grouping, middleware order, request contexts, Hummingbird testing, service lifecycle, and deployment details that are not specific to OpenAPI generation.
+
+## Vapor Transport
+
+Use OpenAPIVapor when the service already uses Vapor or when Vapor is the chosen server framework.
+
+Typical shape:
+
+- create or reuse the Vapor `Application`
+- create `VaporTransport` with the app or routes builder
+- create the handler type that conforms to generated `APIProtocol`
+- call generated `registerHandlers` on the transport
+- run the app through the repository's existing `swift run App serve`, `app.execute()`, or documented command path
+
+For request access from generated handlers, check current OpenAPIVapor docs before implementing. The transport documentation includes a request-injection pattern using `swift-dependencies`; only add that dependency when the service genuinely needs direct Vapor `Request` access inside generated handlers.
+
+Hand off to `vapor-server-workflow` for controllers, middleware, Fluent migrations, environment setup, app commands, and deployment details that are not specific to OpenAPI generation.
+
+## Testing And Validation
+
+Prefer this order:
+
+1. Validate the OpenAPI document with the repository's existing validator when one exists.
+2. Run the smallest SwiftPM command that forces generation and type-checking, usually `swift build` or `swift test`.
+3. Add pure Swift tests for domain transformations that generated handlers call.
+4. Add Hummingbird or Vapor route tests for generated handler registration, request decoding, response encoding, status codes, and error bodies.
+5. Use `curl` only when runtime binding, headers, streaming, middleware, or end-to-end server behavior cannot be proven through tests.
+
+When validation fails, name the exact contract element, generated symbol, package target, or transport registration point that failed. Include the likely cause, such as a missing `operationId`, unsupported schema shape, stale generated output assumption, wrong target plugin configuration, missing transport dependency, or framework middleware order.
+
+## Output Shape
+
+Return:
+
+1. `Contract shape`: OpenAPI document path, generator config, generated Swift surface, selected transport, and handler owner.
+2. `Docs used`: Dash docsets, GitHub repositories, SPI docs, or official framework docs consulted.
+3. `Command path`: exact SwiftPM, generator, validation, test, run, or HTTP commands run or recommended.
+4. `Behavior`: operations, inputs, outputs, errors, transport registration, framework handoffs, and RPC-fit decision.
+5. `Validation`: spec checks, build, tests, server run, or HTTP check results.
+6. `Handoffs`: Vapor, Hummingbird, SwiftPM, gRPC, MCP, OpenAPITools CLI, client generation, deployment, or observability follow-up when the task crosses this skill's boundary.
+
+## Guardrails
+
+- Do not call all RPC-shaped work OpenAPI; make the protocol choice explicit.
+- Do not use OpenAPITools CLI when the Swift package is using Apple's Swift OpenAPI Generator plugin.
+- Do not commit machine-local dependency paths, generated cache directories, secrets, or local service credentials.
+- Do not silently rename operation IDs or shared schemas in public contracts.
+- Do not add Vapor request injection, Hummingbird task-local context access, gRPC, protobuf, or MCP runtime dependencies unless the project has a concrete need for that protocol behavior.
+- Do not treat generated handlers as the place for unrelated business rules; call tested domain code from the generated protocol implementation.

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.12.0"
+version = "6.13.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.12.0"
+version = "6.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Standalone plugin repository for future web-focused Codex skills.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.12.0"
+version = "6.13.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add server-side Swift OpenAPI/RPC workflow guidance
- add Apple Swift OpenAPI client workflow guidance
- bump Socket shared version surfaces to 6.13.0

## Verification
- uv run scripts/validate_socket_metadata.py
- bash .github/scripts/validate_repo_docs.sh
- uv run pytest
- local CODEX_HOME marketplace smoke check