### PR TITLE
plugin: add server-side Swift ecosystem guidance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -240,6 +240,7 @@ Decision note: the root marketplace entry is installable now that `web-dev-skill
 - [x] GitHub #61: Teach repo-maintenance prerelease GitHub metadata ([#61](https://github.com/gaelic-ghost/socket/issues/61))
 - [x] GitHub #60: Apple Dev Skills workflow helper is missing PyYAML runtime dependency ([#60](https://github.com/gaelic-ghost/socket/issues/60))
 - [x] Hardened `web-dev-skills:expo-inline-native-modules-workflow` with native-shape decision and validation reference tables.
+- [x] Added Server-Side Swift ecosystem package preference guidance for Vapor, Vapor Community, and Hummingbird-aligned packages.
 
 ## Backlog Candidates
 

--- a/plugins/agent-plugin-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-plugin-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-plugin-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Installable maintainer skills for skills-export repositories.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-plugin-skills/pyproject.toml
+++ b/plugins/agent-plugin-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-plugin-skills-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 description = "Maintainer-only Python tooling baseline for agent-plugin-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-plugin-skills/uv.lock
+++ b/plugins/agent-plugin-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agent-plugin-skills-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Placeholder plugin repository for future Android, Kotlin, and Java Codex skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Apple development workflows for Codex, including SwiftUI architecture, Icon Composer app icons, Safari extensions, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "6.15.0"
+version = "6.15.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.9"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "6.15.0"
+version = "6.15.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -93,7 +93,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "6.15.0"
+version = "6.15.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Codex skills for building, running, containerizing, and maintaining server-side Swift services, including Vapor, Hummingbird, persistence, Swift OpenAPI, RPC-fit decisions, Docker, Apple Containerization, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -44,6 +44,8 @@
     "defaultPrompt": [
       "Create a Vapor service plan using current Vapor CLI and SwiftPM workflows.",
       "Create a Hummingbird service plan using current Hummingbird docs and SwiftPM workflows.",
+      "Choose a Vapor-aligned package from the Vapor or Vapor Community ecosystem for this service need.",
+      "Choose a Hummingbird-aligned package from the Hummingbird ecosystem for this service need.",
       "Add Swift OpenAPI Generator to a server-side Swift package and wire the generated API to Vapor or Hummingbird.",
       "Decide whether this Swift service boundary should use OpenAPI, JSON-RPC, gRPC, MCP-style tools, or ordinary HTTP routes.",
       "Add a Dockerfile and Compose workflow for this server-side Swift package.",

--- a/plugins/server-side-swift/skills/hummingbird-server-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/hummingbird-server-workflow/SKILL.md
@@ -40,6 +40,8 @@ Use official Hummingbird documentation first:
 - [Request Contexts](https://docs.hummingbird.codes/2.0/documentation/hummingbird/requestcontexts/)
 - [Error Handling](https://docs.hummingbird.codes/2.0/documentation/hummingbird/errorhandling/)
 - [Hummingbird Testing](https://docs.hummingbird.codes/2.0/documentation/hummingbird/testing/)
+- [Hummingbird ecosystem](https://hummingbird.codes/ecosystem/)
+- [Hummingbird GitHub organization](https://github.com/hummingbird-project)
 
 Use Swift.org, Swift Package Manager, Swift Service Lifecycle, SwiftNIO, or Swift server package documentation for toolchain, package, lifecycle, event-loop, deployment, or observability behavior when Hummingbird docs do not own the rule being used.
 
@@ -73,6 +75,28 @@ Use Swift.org, Swift Package Manager, Swift Service Lifecycle, SwiftNIO, or Swif
 6. Keep request and response models typed and small enough to test directly.
 7. Keep request context additions deliberate, because they become per-request data that middleware and handlers depend on.
 8. Validate with the narrowest useful SwiftPM, Hummingbird testing, or HTTP check.
+
+## Hummingbird Ecosystem Package Preference
+
+When a Hummingbird service needs framework-adjacent behavior, prefer maintained packages from the `hummingbird-project` GitHub organization when they fit the need and match the project's Hummingbird major version.
+
+Check Hummingbird-aligned packages first for:
+
+- authentication: Hummingbird Auth
+- persistence and migrations: Hummingbird Fluent, Hummingbird Postgres, Postgres migrations, Valkey or Redis integration, and Swift Jobs drivers
+- background jobs and durable work: Swift Jobs and Swift Jobs Workflows
+- transport and API surfaces: OpenAPI Hummingbird, WebSocket support, SSE, compression, and Lambda runtime support
+- rendering and examples: Swift Mustache, the Hummingbird template, and Hummingbird examples
+
+Use the official Hummingbird ecosystem page for closely aligned packages outside the core organization when the project needs observability, JWT, WebAuthn, APNS, AWS, MQTT, or another Swift server integration that Hummingbird documents as ecosystem-fit.
+
+Before recommending or adding any package:
+
+- verify current documentation or source, repository maintenance status, and package version compatibility
+- inspect the existing `Package.swift` dependency style, exact-version policy, and target ownership
+- choose the package that fits the current Hummingbird app shape instead of copying Vapor patterns
+- explain why the aligned Hummingbird package fits better than a generic Swift package or custom code
+- avoid archived packages, stale Hummingbird-major-version packages, or packages that turn request context into a generic dependency container
 
 ## Project Creation
 

--- a/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/persistence-workflow/SKILL.md
@@ -72,7 +72,8 @@ Use Swift Package Manager and Swift.org documentation for package, target, depen
    - read model or reporting query
    - test fixture or ephemeral database setup
 3. Choose the narrowest fitting data-access path:
-   - Fluent for Vapor projects already using Fluent models, migrations, and `req.db`
+   - official Vapor Fluent and Vapor database drivers first for Vapor projects already using Fluent models, migrations, and `req.db`
+   - Hummingbird-specific persistence packages first for Hummingbird services before direct drivers or generic database clients
    - a documented direct database client when the service needs SQL-specific behavior or does not use Fluent
    - a small repository or query helper when route handlers are accumulating duplicated database code
    - existing repo conventions when a project already has a tested persistence boundary
@@ -85,6 +86,7 @@ Use Swift Package Manager and Swift.org documentation for package, target, depen
 
 For Vapor projects that use Fluent:
 
+- check the official Vapor Fluent docs, Fluent package, and Vapor-maintained database drivers before adding community or generic persistence packages
 - keep models, migrations, and database configuration aligned with current Vapor Fluent docs
 - register database drivers and migrations in app configuration
 - run migrations with the documented app command, usually `swift run App migrate`
@@ -102,7 +104,7 @@ For Hummingbird projects:
 
 - do not assume Fluent or any ORM is already part of the service
 - inspect how the `Application`, router, service lifecycle, and dependencies are currently constructed
-- check Hummingbird's persistent-data docs and ecosystem packages before choosing PostgresNIO, HummingbirdFluent, a direct driver, or another package
+- check Hummingbird's persistent-data docs and Hummingbird-specific packages such as HummingbirdPostgres, HummingbirdFluent, PostgresMigrations, and Valkey or Redis integrations before choosing PostgresNIO, a direct driver, or a generic database package
 - choose a database client or repository shape that fits the existing Hummingbird service instead of copying Vapor app structure
 - keep database clients, pools, or repositories created at app startup and passed into the handlers or context path already used by the project
 - keep request context values per-request; do not turn request context into a generic dependency container

--- a/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
+++ b/plugins/server-side-swift/skills/vapor-server-workflow/SKILL.md
@@ -38,6 +38,8 @@ Use official Vapor documentation first:
 - [Vapor commands](https://docs.vapor.codes/advanced/commands/)
 - [Vapor environment](https://docs.vapor.codes/basics/environment/)
 - [Vapor Fluent migrations](https://docs.vapor.codes/fluent/migration/)
+- [Vapor GitHub organization](https://github.com/vapor)
+- [Vapor Community GitHub organization](https://github.com/vapor-community)
 
 Use Swift.org or Swift Package Manager documentation for Swift toolchain and package behavior when Vapor docs do not own the rule being used.
 
@@ -68,6 +70,30 @@ Use Swift.org or Swift Package Manager documentation for Swift toolchain and pac
 6. Keep configuration explicit and environment-safe.
 7. Add tests at the smallest level that proves behavior.
 8. Validate with the narrowest useful SwiftPM, Vapor app, or HTTP check.
+
+## Vapor Ecosystem Package Preference
+
+When a Vapor service needs framework-adjacent behavior, prefer maintained packages from the official `vapor` GitHub organization when they fit the need and match the project's Vapor major version.
+
+Check official Vapor packages first for:
+
+- ORM, migrations, and database drivers: Fluent, Fluent drivers, FluentKit, SQLKit, Postgres, MySQL, SQLite, and MongoDB packages
+- authentication and tokens: Authentication, JWT, and JWTKit
+- background jobs: Queues and official queue drivers
+- cache or ephemeral state: Redis or the repository's existing cache choice
+- templating and HTML: Leaf and LeafKit
+- OpenAPI-backed servers: OpenAPIVapor
+- WebSocket, multipart, routing, console, APNS, templates, and Vapor Toolbox support
+
+Check `vapor-community` next when official Vapor packages do not cover the need and the community package is maintained, current, and a better fit than a generic third-party package. Common examples include HTML rendering, OAuth or identity flows, Stripe, SendGrid, Mailgun, Wallet, CSRF, SQLKit extras, Valkey support, Lambda runtime support, and service-specific providers.
+
+Before recommending or adding any package:
+
+- verify current documentation or source, repository maintenance status, and package version compatibility
+- inspect the existing `Package.swift` dependency style, exact-version policy, and target ownership
+- choose the narrowest package that fits the service behavior instead of adding a broad framework around one feature
+- explain why the aligned Vapor or Vapor Community package fits better than a generic Swift package or custom code
+- avoid archived packages, stale Vapor-major-version packages, or packages that force unrelated architecture changes
 
 ## Vapor Toolbox Usage
 

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "6.15.0"
+version = "6.15.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "6.15.0"
+version = "6.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "6.15.0",
+  "version": "6.15.1",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "6.15.0"
+version = "6.15.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add Vapor ecosystem package preference guidance for official Vapor and Vapor Community packages.
- Add Hummingbird ecosystem package preference guidance for Hummingbird-aligned packages and ecosystem-listed integrations.
- Align persistence guidance and bump Socket to 6.15.1.

## Verification
- uv run scripts/validate_socket_metadata.py
- git diff --check
- scripts/release.sh inventory
- local checkout Socket marketplace smoke test with temporary CODEX_HOME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced guidance for selecting Server-Side Swift ecosystem packages, with improved recommendations for Vapor-aligned and Hummingbird-aligned frameworks and their ecosystem packages.
  * Added package preference checklists covering documentation verification, maintenance status, version compatibility, and dependency alignment.

* **Chores**
  * Version bumped to 6.15.1 across all plugins and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->