### PR TITLE
docs: add Xcode workspace and audit planning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,12 @@ You can verify that baseline with:
 uv run scripts/validate_socket_metadata.py
 ```
 
+### Xcode Workspace
+
+The root [`Socket.xcworkspace`](./Socket.xcworkspace) is a browse-only workspace for maintainers who want to use Xcode's file navigator and Markdown editor, especially Xcode 27 beta's WYSIWYG Markdown surface. It references root docs, the marketplace file, `docs/`, `plugins/`, and `scripts/`, but it intentionally has no schemes, targets, package products, or root build settings.
+
+Do not add a generated `.xcodeproj`, root `Package.swift`, or workspace scheme only to improve documentation editing. If Socket later gains a real root build product, document that build surface separately and update the workspace guidance in [`docs/maintainers/socket-xcode-workspace.md`](./docs/maintainers/socket-xcode-workspace.md).
+
 ### Repo-Local Steward
 
 The repo-local Socket Steward prototype lives at [`.agents/socket-steward/`](./.agents/socket-steward/). It is a Python `uv` project built around the OpenAI Agents SDK, with deterministic read-only audits available without API credentials and an optional agent-backed `ask` command when `OPENAI_API_KEY` is available.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Placeholder directories for future plugins (not available for install):
 
 For setup, local workflow, validation, review, release, and maintainer expectations, see [CONTRIBUTING.md](./CONTRIBUTING.md). For the consolidated child backlog, see [TODO.md](./TODO.md). For agent-facing repo rules, see [AGENTS.md](./AGENTS.md).
 
+For Xcode 27 beta Markdown editing and repository browsing, open [`Socket.xcworkspace`](./Socket.xcworkspace). It is a browse-only workspace for docs, plugin payloads, scripts, and marketplace metadata; it is not a root build surface.
+
 ## Repo Structure
 
 ```text
@@ -148,6 +150,7 @@ For setup, local workflow, validation, review, release, and maintainer expectati
 ├── AGENTS.md
 ├── CONTRIBUTING.md
 ├── README.md
+├── Socket.xcworkspace
 ├── TODO.md
 └── ROADMAP.md
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,7 @@
 - [Milestone 16: Server-Side JVM skills plugin](#milestone-16-server-side-jvm-skills-plugin)
 - [Milestone 17: Cross-agent skill and plugin portability](#milestone-17-cross-agent-skill-and-plugin-portability)
 - [Milestone 18: Swift Lang shared language plugin](#milestone-18-swift-lang-shared-language-plugin)
+- [Milestone 19: Project audit skills plugin](#milestone-19-project-audit-skills-plugin)
 - [Small Tickets](#small-tickets)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
@@ -51,6 +52,7 @@
 - Milestone 16: Server-Side JVM skills plugin - In Progress
 - Milestone 17: Cross-agent skill and plugin portability - Planned
 - Milestone 18: Swift Lang shared language plugin - Implemented
+- Milestone 19: Project audit skills plugin - Planned
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -553,10 +555,42 @@ Planned
 
 Implemented Milestone 18 by adding the `swift-lang` child plugin with five shared Swift language skills, wiring it into the Socket marketplace, documenting the Swift language ownership split, preserving Apple Dev's standalone formatting and structure skills, and validating the plugin, skill metadata, root marketplace, and Apple Dev docs.
 
+## Milestone 19: Project audit skills plugin
+
+### Status
+
+Planned
+
+### Scope
+
+- [x] Record the first plugin plan in [`docs/maintainers/project-audit-skills-plugin-plan.md`](./docs/maintainers/project-audit-skills-plugin-plan.md).
+- [ ] Decide whether unfamiliar-project exploration, architecture mapping, quality grading, adoption-risk evaluation, and slop-risk review belong in a dedicated `project-audit-skills` child plugin or as a focused `productivity-skills` expansion.
+- [ ] Keep the first version guidance-only unless repeated use proves that a runtime scanner, MCP server, or structured report generator is worth the additional surface.
+- [ ] Route stack-specific findings to the existing language and platform plugins instead of duplicating Swift, Python, Rust, JVM, Android, web, or reverse-engineering guidance.
+
+### Tickets
+
+- [ ] Create `plugins/project-audit-skills/` only after the plugin boundary is approved.
+- [ ] Add `project-audit:explore-project` for read-only project intake maps.
+- [ ] Add `project-audit:audit-project-quality` for evidence-backed quality, maintainability, and slop-risk grading.
+- [ ] Add later skills for architecture mapping, adoption-risk decisions, and remediation planning after the first two workflows prove useful.
+- [ ] Wire the plugin into the root marketplace as `NOT_AVAILABLE` while it is a placeholder, then switch it to installable only after real skill content exists.
+- [ ] Update root README and TODO when the plugin becomes installable.
+- [ ] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+### Exit Criteria
+
+- [ ] Socket has a clear ownership decision for unfamiliar-project intake and quality grading.
+- [ ] The first workflows produce evidence-backed maps and grades without making repository changes by default.
+- [ ] Stack-specific implementation advice routes to owning Socket plugins.
+- [ ] Root Socket docs, marketplace wiring, and validation agree on the exported project-audit surface.
+
 ## Small Tickets
 
 - [ ] Record issue-sized fixes, TODO/FIXME imports, and cleanup work that is too small or too unplanned for a milestone.
 
+- [x] Add a browse-only root `Socket.xcworkspace` for Xcode 27 beta Markdown editing and repository navigation without introducing a root build surface.
+- [x] Record Gale's coordinator-shaped, MVVM-C-adjacent Swift app-structure alignment plan for future Apple Dev Skills guidance updates.
 - [x] GitHub #61: Teach repo-maintenance prerelease GitHub metadata ([#61](https://github.com/gaelic-ghost/socket/issues/61))
 - [x] GitHub #60: Apple Dev Skills workflow helper is missing PyYAML runtime dependency ([#60](https://github.com/gaelic-ghost/socket/issues/60))
 - [x] Hardened `web-dev-skills:expo-inline-native-modules-workflow` with native-shape decision and validation reference tables.

--- a/Socket.xcworkspace/contents.xcworkspacedata
+++ b/Socket.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:README.md">
+   </FileRef>
+   <FileRef
+      location = "group:CONTRIBUTING.md">
+   </FileRef>
+   <FileRef
+      location = "group:ROADMAP.md">
+   </FileRef>
+   <FileRef
+      location = "group:TODO.md">
+   </FileRef>
+   <FileRef
+      location = "group:AGENTS.md">
+   </FileRef>
+   <FileRef
+      location = "group:ACCESSIBILITY.md">
+   </FileRef>
+   <FileRef
+      location = "group:.agents/plugins/marketplace.json">
+   </FileRef>
+   <FileRef
+      location = "group:docs">
+   </FileRef>
+   <FileRef
+      location = "group:plugins">
+   </FileRef>
+   <FileRef
+      location = "group:scripts">
+   </FileRef>
+</Workspace>

--- a/TODO.md
+++ b/TODO.md
@@ -65,12 +65,14 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 - [ ] Forward-test `design-agent-automation-workflow` and `design-agent-eval-workflow` against real agent, automation, and eval planning requests before adding deterministic scaffolding scripts.
 - [ ] Add lightweight validation tooling for `SKILL.md`, frontmatter, and `agents/openai.yaml` alignment.
 - [ ] Add validation checks for README layout and active skill inventory consistency.
+- [ ] Decide whether unfamiliar-project intake, architecture mapping, quality grading, and slop-risk evaluation belong in a new `project-audit-skills` child plugin or as a focused `productivity-skills` expansion.
 
 ### apple-dev-skills
 
 - [x] Publish the Phase 1 standalone compatibility release so `gaelic-ghost/apple-dev-skills` points at the Socket-hosted plugin payload while preserving `codex plugin marketplace upgrade apple-dev-skills`.
 - [x] Complete Phase 2 of the Socket migration: make `plugins/apple-dev-skills` monorepo-owned, remove subtree release gates, update Socket docs and duplicate-install guidance, add compatibility marketplace smoke coverage, validate, and publish the Socket release.
 - [ ] Add the Xcode 27 agentic tooling workflows from [`docs/maintainers/xcode-27-agentic-tooling-plan.md`](./docs/maintainers/xcode-27-agentic-tooling-plan.md), starting with `xcode-coding-intelligence-workflow`.
+- [ ] Align SwiftUI and Xcode project guidance with Gale's coordinator-shaped, MVVM-C-adjacent structure preferences from [`docs/maintainers/apple-swift-structure-guidance-alignment.md`](./docs/maintainers/apple-swift-structure-guidance-alignment.md).
 
 ### python-skills
 
@@ -167,6 +169,13 @@ This file is the Socket-level backlog for child plugins that no longer keep thei
 - [x] Install-test and publish the changed marketplace metadata with the new license surface.
 
 ## Placeholder Child Plugins
+
+### project-audit-skills
+
+- [ ] Decide whether to create a dedicated `project-audit-skills` child plugin or fold the intake/audit surface into `productivity-skills`.
+- [ ] Use [`docs/maintainers/project-audit-skills-plugin-plan.md`](./docs/maintainers/project-audit-skills-plugin-plan.md) as the first scope record.
+- [ ] Add `project-audit:explore-project` and `project-audit:audit-project-quality` as the first real skills if a dedicated plugin is approved.
+- [ ] Keep any marketplace entry `NOT_AVAILABLE` until real skill content exists.
 
 ### spotify
 

--- a/docs/maintainers/apple-swift-structure-guidance-alignment.md
+++ b/docs/maintainers/apple-swift-structure-guidance-alignment.md
@@ -1,0 +1,84 @@
+# Apple Swift Structure Guidance Alignment
+
+This note records the first alignment pass for Gale's preferred Swift and
+Apple-platform project structure across Socket's Swift-related skills.
+
+## Current Fit
+
+The existing guidance is already close to the preferred shape:
+
+- `swift-lang` owns shared Swift language choices: API ergonomics, functional
+  data pipelines, formatting, source organization, and modernization cleanup.
+- `apple-dev-skills` owns Apple-platform structure: Xcode, SwiftUI app and
+  scene ownership, AppKit app architecture, project guidance sync, and
+  Apple-docs-first workflow.
+- `server-side-swift` owns SwiftPM-first server work and should keep app,
+  scene, preview, simulator, and Xcode-specific concerns delegated away.
+
+The useful next move is to make the preferred app structure more explicit
+inside Apple app guidance, not to rename the whole stack to MVVM-C.
+
+## Preferred Structure
+
+Use a coordinator-shaped, MVVM-C-adjacent model only where it removes real
+ownership confusion:
+
+- `App` declares app entry, app-wide lifecycle, and the top-level scene list.
+- `Scene` owns per-window, per-document, or managed scene lifecycle and context.
+- Small controller or coordinator objects own navigation, presentation, command,
+  focus, and workflow state for a view cluster or scene boundary.
+- SwiftUI views stay component UI: render state, expose local interactions, and
+  avoid becoming broad app coordinators.
+- View models are typed view-driving state when they clarify a real view or
+  view-cluster boundary; they are not mandatory wrappers around every model.
+- Coordinators are useful for scene, command, workflow, navigation, or
+  presentation ownership; they should not become a second hidden scene graph.
+- Models preserve source-of-truth naming and raw persistence or wire shape until
+  a real semantic boundary requires mapping.
+- Data transformation should prefer small composable functions and functional
+  pipelines when that keeps flow readable.
+
+## Guidance Changes To Consider
+
+### `apple-dev-skills:swiftui-app-architecture-workflow`
+
+Add a focused reference or section for "coordinator-shaped SwiftUI" that:
+
+- describes controllers/coordinators as local ownership tools, not mandatory
+  architecture ceremony
+- routes app lifecycle to `App`, scene lifecycle to `Scene`, and component
+  rendering to `View`
+- distinguishes view-driving state from navigation or workflow coordination
+- warns against environment-object dumping and hidden router state
+- keeps native SwiftUI scene actions, focused values, and selection-driven
+  `NavigationSplitView` as the first choices when they fit
+
+### `apple-dev-skills:sync-xcode-project-guidance`
+
+Update the reusable Xcode project guidance snippet so downstream app repos can
+name this preference directly:
+
+- small focused controller or coordinator classes are encouraged when they own
+  a real view cluster, scene, command, or workflow boundary
+- broad global coordinators, mandatory view-model wrappers, and duplicate
+  mapping layers remain anti-patterns
+
+### `apple-dev-skills:sync-swift-package-guidance`
+
+Keep package guidance focused on SwiftPM and Swift language quality. Add only a
+handoff note for app architecture when a package contains app-facing SwiftUI or
+AppKit modules.
+
+### `swift-lang`
+
+Keep the shared Swift layer focused on source organization and functional data
+flow. It should not learn Apple scene, command, or navigation ownership details.
+
+## Validation For A Future Implementation Slice
+
+- Run the Apple Dev child validation added for the touched skill references.
+- Run `uv run scripts/validate_socket_metadata.py` from the Socket root after
+  metadata, marketplace, or exported skill descriptions change.
+- Review generated or copied guidance text for consistent vocabulary:
+  `controller`, `coordinator`, `view-driving state`, `scene`, `view cluster`,
+  and `component UI`.

--- a/docs/maintainers/project-audit-skills-plugin-plan.md
+++ b/docs/maintainers/project-audit-skills-plugin-plan.md
@@ -1,0 +1,145 @@
+# Project Audit Skills Plugin Plan
+
+This plan records a possible Socket child plugin for exploring, mapping,
+auditing, grading, and evaluating unfamiliar projects.
+
+Working name: `project-audit-skills`.
+
+The playful internal motivation is "evaluate this project for slop," but the
+installable plugin should use professional outward-facing language such as
+project audit, intake, quality map, risk grade, and remediation plan.
+
+## Intent
+
+The plugin should help an agent enter a new repository or project and produce a
+useful map before making changes.
+
+It should answer:
+
+- What is this project?
+- How is it structured?
+- What are the real entry points, build commands, tests, docs, and release
+  surfaces?
+- Which parts look healthy, stale, risky, overcomplicated, underdocumented, or
+  likely to waste future work?
+- What should Gale do first if they want to maintain, refactor, adopt, migrate,
+  rescue, or discard it?
+
+## Scope
+
+The first version should be a guidance plugin, not a runtime scanner.
+
+It may use existing repo tools, language-specific skills, and validation
+commands, but it should not bundle a daemon, MCP server, static-analysis engine,
+or language-specific parser framework until repeated use proves that one is
+worth the extra surface.
+
+## Relationship To Existing Plugins
+
+`productivity-skills` already owns ongoing project maintenance workflows such as
+README, contributing, roadmap, accessibility, repo maintenance, GitHub settings,
+automation design, and eval design.
+
+`project-audit-skills` should own the earlier intake phase:
+
+- unknown or newly inherited projects
+- "tell me what this is" exploration
+- quality and risk grading before implementation
+- adoption or rescue decisions
+- slop or overengineering detection before committing to a fix
+
+Language and stack details should be delegated:
+
+- Swift and Apple platform details to `swift-lang`, `apple-dev-skills`, or
+  `server-side-swift`
+- Python details to `python-skills`
+- Rust details to `rust-skills`
+- JVM details to `server-side-jvm`
+- Android details to `android-dev-skills`
+- web and Expo details to `web-dev-skills`
+- binary artifact details to `reverse-engineering-skills`
+
+## Proposed Skill Inventory
+
+### `project-audit:explore-project`
+
+Map a project without changing it.
+
+Output should include repo shape, languages, package managers, entry points,
+important docs, validation commands, external services, secrets boundaries, and
+unknowns.
+
+### `project-audit:map-architecture`
+
+Describe how the project is put together.
+
+Output should include modules, ownership boundaries, dependency direction,
+runtime flows, data flows, UI or API boundaries, persistence, background work,
+and places where the structure hides behavior.
+
+### `project-audit:audit-project-quality`
+
+Grade maintainability and implementation quality.
+
+Output should separate evidence from judgment and cover structure, naming,
+tests, docs, validation, dependency health, dead code, generated code, secrets,
+accessibility, observability, and release readiness.
+
+### `project-audit:evaluate-adoption-risk`
+
+Support go/no-go decisions.
+
+Output should name adoption risk, maintenance cost, likely first fixes, blocked
+validation, dependency or licensing concerns, and the smallest proof needed
+before investing more time.
+
+### `project-audit:plan-remediation`
+
+Turn an audit into an ordered cleanup plan.
+
+Output should group work into small coherent slices, identify validation for
+each slice, route stack-specific work to owning skills, and stop before making
+changes unless the user asks to implement.
+
+## Grading Model
+
+Use explicit grades only when they help the decision.
+
+Recommended grade axes:
+
+- discoverability
+- build and test readiness
+- architecture clarity
+- dependency and toolchain hygiene
+- data and state-flow clarity
+- risk concentration
+- documentation usefulness
+- release or deployment readiness
+- "slop risk" as an internal shorthand for needless complexity, copy-pasted
+  wrappers, unclear ownership, stale generated output, vague logs, or brittle
+  automation
+
+Grades should always include evidence and concrete next actions. Never return a
+score without explaining which files, commands, or observations justify it.
+
+## First Implementation Slice
+
+- Create `plugins/project-audit-skills/` with `.codex-plugin/plugin.json`,
+  `AGENTS.md`, and authored `skills/`.
+- Add `project-audit:explore-project` and
+  `project-audit:audit-project-quality` first.
+- Keep the root marketplace entry `NOT_AVAILABLE` until at least those two real
+  skills exist and validation passes.
+- Update root README, TODO, and this plan when the plugin becomes installable.
+- Run `uv run scripts/validate_socket_metadata.py` after wiring the marketplace
+  entry.
+
+## Open Questions
+
+- Should the long-term home be a new child plugin or a focused expansion of
+  `productivity-skills`?
+- Should grading output be a Markdown report only, or should it also support a
+  small JSON shape for future Socket Steward ingestion?
+- Should "slop risk" remain internal wording, or should there be a user-facing
+  "complexity risk" grade with the same practical meaning?
+- Which existing Socket Steward audit outputs should seed the first examples?

--- a/docs/maintainers/socket-xcode-workspace.md
+++ b/docs/maintainers/socket-xcode-workspace.md
@@ -1,0 +1,52 @@
+# Socket Xcode Workspace
+
+This document records the browse-only Xcode workspace at the root of the
+`socket` superproject.
+
+## Purpose
+
+`Socket.xcworkspace` exists so maintainers can open the repository in Xcode,
+use Xcode's file navigator, and edit Markdown through Xcode 27 beta's WYSIWYG
+Markdown editor.
+
+The workspace is not a build surface. It does not create schemes, targets,
+package products, generated projects, or root-level Xcode build settings.
+
+## Shape
+
+The workspace references the root maintainer files plus the main authored
+source directories:
+
+- root docs such as `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `TODO.md`,
+  `AGENTS.md`, and `ACCESSIBILITY.md`
+- the root marketplace file at `.agents/plugins/marketplace.json`
+- `docs/`
+- `plugins/`
+- `scripts/`
+
+This keeps Xcode useful for browsing and editing without implying that Socket
+itself is an Apple app, Swift package, or generated Xcode project.
+
+## Maintenance Rules
+
+- Keep the workspace browse-only until Socket has a concrete root build product
+  that needs an Xcode scheme.
+- Do not add generated `.xcodeproj` files, schemes, or package manifests just to
+  improve Markdown editing.
+- If a child plugin gains its own Xcode project, keep that child project owned
+  by the child plugin and add a workspace reference only when it helps root
+  maintainers browse the superproject.
+- If the workspace starts carrying build behavior, update this document,
+  `CONTRIBUTING.md`, and any affected validation guidance in the same pass.
+
+## Validation
+
+For a browse-only workspace change, validate that Xcode can parse the workspace
+metadata:
+
+```bash
+xcodebuild -list -workspace Socket.xcworkspace
+```
+
+The command is expected to report no schemes unless a future approved change
+adds buildable project references.


### PR DESCRIPTION
## Summary
- Add a browse-only Socket Xcode workspace for Xcode 27 beta Markdown editing and repo navigation
- Document the workspace as non-buildable maintainer surface
- Record Swift app-structure alignment and project-audit plugin planning

## Verification
- xcodebuild -list -workspace Socket.xcworkspace
- uv run scripts/validate_socket_metadata.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browse-only Xcode workspace for easier repository navigation and Markdown editing in Xcode beta.
  * Introduced new maintainer guidance on project structure and workspace usage.

* **Documentation**
  * Expanded setup, repository structure, and roadmap docs with clearer guidance for maintainers.
  * Added planning docs for a proposed project-audit skills plugin and related workflow notes.

* **Chores**
  * Updated task lists and milestone tracking to reflect the new planning items and completed workspace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->