### PR TITLE
plugin: add Apple game development skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -226,6 +226,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "game-dev-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/game-dev-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,7 @@ The installable local child entries currently point at:
 - `./plugins/cardhop-app`
 - `./plugins/codex-utilities`
 - `./plugins/dotnet-skills`
+- `./plugins/game-dev-skills`
 - `./plugins/productivity-skills`
 - `./plugins/python-skills`
 - `./plugins/reverse-engineering-skills`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Currently available from the catalog:
 - `cardhop-app`
 - `codex-utilities`
 - `dotnet-skills`
+- `game-dev-skills`
 - `productivity-skills`
 - `python-skills`
 - `reverse-engineering-skills`
@@ -112,6 +113,7 @@ Current Socket catalog shape:
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `codex-utilities`: local Codex runtime utilities, starting with hooks that prefix generated Codex thread titles with the project directory name
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
+- `game-dev-skills`: Apple platform game development workflows for SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, game-stack routing, and device-aware validation handoffs
 - `productivity-skills`: general-purpose maintainer, documentation, Dice MCP job-search with bundled remote MCP config, Codex GUI worktree workflow, and automation-design workflows plus source-bundled docs-audit and code-tracing custom-agent definitions
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
 - `reverse-engineering-skills`: binary inspection, artifact triage, and reproducible reverse-engineering note workflows

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Current Socket catalog shape:
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `codex-utilities`: local Codex runtime utilities, starting with hooks that prefix generated Codex thread titles with the project directory name
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
-- `game-dev-skills`: Apple platform game development workflows for SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, game-stack routing, and device-aware validation handoffs
+- `game-dev-skills`: Apple platform game development workflows for SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics feedback, Xcode game profiling, game-stack routing, and device-aware validation handoffs
 - `productivity-skills`: general-purpose maintainer, documentation, Dice MCP job-search with bundled remote MCP config, Codex GUI worktree workflow, and automation-design workflows plus source-bundled docs-audit and code-tracing custom-agent definitions
 - `python-skills`: Python runtime and tooling workflows for Python-based projects; see the [Python skills expansion plan](./docs/maintainers/python-skills-plugin-plan.md) for maintainer details
 - `reverse-engineering-skills`: binary inspection, artifact triage, and reproducible reverse-engineering note workflows

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,7 @@
 - [Milestone 17: Cross-agent skill and plugin portability](#milestone-17-cross-agent-skill-and-plugin-portability)
 - [Milestone 18: Swift Lang shared language plugin](#milestone-18-swift-lang-shared-language-plugin)
 - [Milestone 19: Project audit skills plugin](#milestone-19-project-audit-skills-plugin)
+- [Milestone 20: Game Dev Skills plugin](#milestone-20-game-dev-skills-plugin)
 - [Small Tickets](#small-tickets)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
@@ -53,6 +54,7 @@
 - Milestone 17: Cross-agent skill and plugin portability - Planned
 - Milestone 18: Swift Lang shared language plugin - Completed
 - Milestone 19: Project audit skills plugin - Planned
+- Milestone 20: Game Dev Skills plugin - In Progress
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -588,6 +590,39 @@ Planned
 - [ ] The first workflows produce evidence-backed maps and grades without making repository changes by default.
 - [ ] Stack-specific implementation advice routes to owning Socket plugins.
 - [ ] Root Socket docs, marketplace wiring, and validation agree on the exported project-audit surface.
+
+## Milestone 20: Game Dev Skills plugin
+
+### Status
+
+In Progress
+
+### Scope
+
+- [x] Add a Socket-hosted `game-dev-skills` child plugin for game-specific authoring, rendering-stack choice, input, haptics, profiling handoffs, and validation guidance.
+- [x] Keep the first slice Apple-platform-first rather than a broad engine plugin: SpriteKit, SceneKit, Game Controller input, Core Haptics game feedback, and Apple game-stack routing.
+- [x] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle a game engine, template feed, simulator wrapper, profiler automation, MCP server, or local game runtime.
+- [x] Keep generic Swift, Xcode project integrity, simulator, signing, asset-catalog mechanics, and Apple docs exploration delegated to `apple-dev-skills` and shared Swift language guidance delegated to `swift-lang`.
+
+### Tickets
+
+- [x] Record the detailed plan in [`docs/maintainers/game-dev-skills-plugin-plan.md`](./docs/maintainers/game-dev-skills-plugin-plan.md).
+- [x] Create `plugins/game-dev-skills/` with `.codex-plugin/plugin.json`, `AGENTS.md`, and authored `skills/` source.
+- [x] Add `game-dev-skills:choose-apple-game-stack`.
+- [x] Add `game-dev-skills:spritekit-game-workflow`.
+- [x] Add `game-dev-skills:scenekit-game-workflow`.
+- [x] Add `game-dev-skills:game-controller-input-workflow`.
+- [x] Add `game-dev-skills:core-haptics-game-feedback-workflow`.
+- [x] Wire `game-dev-skills` into the root Socket marketplace as an installable child plugin.
+- [x] Update root README and ROADMAP so users understand the new plugin surface.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+### Exit Criteria
+
+- [x] The Socket marketplace exposes `game-dev-skills` as an installable child plugin.
+- [x] The first skill slice can route and guide Apple game work across SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, and Apple Dev Skills handoffs.
+- [x] The plugin boundary is clear enough that reverse-engineering Unity artifacts stay with `reverse-engineering-skills`, generic Apple mechanics stay with `apple-dev-skills`, and game-specific authoring/profiling work stays here.
+- [x] Root Socket docs, marketplace wiring, and validation agree on the exported game-dev skill surface.
 
 ## Small Tickets
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@
 - Milestone 17: Cross-agent skill and plugin portability - Planned
 - Milestone 18: Swift Lang shared language plugin - Completed
 - Milestone 19: Project audit skills plugin - Planned
-- Milestone 20: Game Dev Skills plugin - In Progress
+- Milestone 20: Game Dev Skills plugin - Completed
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -595,7 +595,7 @@ Planned
 
 ### Status
 
-In Progress
+Completed
 
 ### Scope
 
@@ -615,6 +615,7 @@ In Progress
 - [x] Add `game-dev-skills:core-haptics-game-feedback-workflow`.
 - [x] Wire `game-dev-skills` into the root Socket marketplace as an installable child plugin.
 - [x] Update root README and ROADMAP so users understand the new plugin surface.
+- [x] Run skill-folder validation and plugin-manifest validation for the new child plugin.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
 
 ### Exit Criteria
@@ -623,6 +624,8 @@ In Progress
 - [x] The first skill slice can route and guide Apple game work across SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, and Apple Dev Skills handoffs.
 - [x] The plugin boundary is clear enough that reverse-engineering Unity artifacts stay with `reverse-engineering-skills`, generic Apple mechanics stay with `apple-dev-skills`, and game-specific authoring/profiling work stays here.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the exported game-dev skill surface.
+
+Completed Milestone 20 by adding the `game-dev-skills` child plugin, shipping the first Apple-platform game-development workflow slice, wiring the Socket marketplace entry, documenting the plugin boundary, and validating skill metadata, plugin metadata, and root marketplace wiring.
 
 ## Small Tickets
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -599,8 +599,8 @@ Completed
 
 ### Scope
 
-- [x] Add a Socket-hosted `game-dev-skills` child plugin for game-specific authoring, rendering-stack choice, input, haptics, profiling handoffs, and validation guidance.
-- [x] Keep the first slice Apple-platform-first rather than a broad engine plugin: SpriteKit, SceneKit, Game Controller input, Core Haptics game feedback, and Apple game-stack routing.
+- [x] Add a Socket-hosted `game-dev-skills` child plugin for game-specific authoring, rendering-stack choice, simulation, input, haptics, profiling handoffs, and validation guidance.
+- [x] Keep the first slices Apple-platform-first rather than a broad engine plugin: SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics game feedback, Xcode game profiling, and Apple game-stack routing.
 - [x] Keep the plugin as a companion guidance surface rather than a runtime plugin: do not bundle a game engine, template feed, simulator wrapper, profiler automation, MCP server, or local game runtime.
 - [x] Keep generic Swift, Xcode project integrity, simulator, signing, asset-catalog mechanics, and Apple docs exploration delegated to `apple-dev-skills` and shared Swift language guidance delegated to `swift-lang`.
 
@@ -611,8 +611,11 @@ Completed
 - [x] Add `game-dev-skills:choose-apple-game-stack`.
 - [x] Add `game-dev-skills:spritekit-game-workflow`.
 - [x] Add `game-dev-skills:scenekit-game-workflow`.
+- [x] Add `game-dev-skills:gameplaykit-simulation-workflow`.
 - [x] Add `game-dev-skills:game-controller-input-workflow`.
 - [x] Add `game-dev-skills:core-haptics-game-feedback-workflow`.
+- [x] Add `game-dev-skills:xcode-game-profiling-workflow`.
+- [x] Keep `game-dev-skills:metal-game-rendering-workflow` on the roadmap for a later shader and Metal rendering architecture slice.
 - [x] Wire `game-dev-skills` into the root Socket marketplace as an installable child plugin.
 - [x] Update root README and ROADMAP so users understand the new plugin surface.
 - [x] Run skill-folder validation and plugin-manifest validation for the new child plugin.
@@ -621,11 +624,11 @@ Completed
 ### Exit Criteria
 
 - [x] The Socket marketplace exposes `game-dev-skills` as an installable child plugin.
-- [x] The first skill slice can route and guide Apple game work across SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, and Apple Dev Skills handoffs.
+- [x] The first skill slices can route and guide Apple game work across SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics feedback, Xcode game profiling, and Apple Dev Skills handoffs.
 - [x] The plugin boundary is clear enough that reverse-engineering Unity artifacts stay with `reverse-engineering-skills`, generic Apple mechanics stay with `apple-dev-skills`, and game-specific authoring/profiling work stays here.
 - [x] Root Socket docs, marketplace wiring, and validation agree on the exported game-dev skill surface.
 
-Completed Milestone 20 by adding the `game-dev-skills` child plugin, shipping the first Apple-platform game-development workflow slice, wiring the Socket marketplace entry, documenting the plugin boundary, and validating skill metadata, plugin metadata, and root marketplace wiring.
+Completed Milestone 20 by adding the `game-dev-skills` child plugin, shipping the Apple-platform game-development workflow slices, wiring the Socket marketplace entry, documenting the plugin boundary, and validating skill metadata, plugin metadata, and root marketplace wiring. Metal rendering and shader architecture remain planned as a later dedicated slice.
 
 ## Small Tickets
 
@@ -651,6 +654,7 @@ Completed Milestone 20 by adding the `game-dev-skills` child plugin, shipping th
 
 ## Backlog Candidates
 
+- [ ] Add `game-dev-skills:metal-game-rendering-workflow` for a later shader and Metal rendering architecture slice. Scope it after concrete use cases decide whether it owns shader code, render-pass architecture, command encoding, resource layout, Metal debugger workflow, GPU counters, or all of those.
 - [x] Add the first repo-local Socket Steward prototype as a Python `uv` project under `.agents/socket-steward`, using deterministic read-only audits plus an optional OpenAI Agents SDK `ask` path before any write, LaunchAgent, or app behavior.
 - [x] Expand Socket Steward with a docs-sync planning command that emits structured recommended edits for README, CONTRIBUTING, AGENTS, ROADMAP, marketplace metadata, and child plugin guidance without applying them.
 - [x] Add `docs/agents/` as the repo-local report surface and let Socket Steward write reviewable docs-sync proposal reports there without applying the proposed documentation edits.

--- a/docs/maintainers/game-dev-skills-plugin-plan.md
+++ b/docs/maintainers/game-dev-skills-plugin-plan.md
@@ -90,6 +90,7 @@ Guide Core Haptics and game-controller haptic feedback design, capability checks
 - [x] Add first-slice Apple game-development workflow skills.
 - [x] Wire `game-dev-skills` into the root Socket marketplace as installable.
 - [x] Update README and ROADMAP so users understand the new plugin surface.
+- [x] Run skill-folder validation and plugin-manifest validation for the new child plugin.
 - [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
 
 ## Open Questions

--- a/docs/maintainers/game-dev-skills-plugin-plan.md
+++ b/docs/maintainers/game-dev-skills-plugin-plan.md
@@ -6,7 +6,7 @@ This plan records the first durable shape for a Socket-hosted game development s
 
 The `game-dev-skills` plugin should help agents choose and maintain game-specific project surfaces without turning `apple-dev-skills` into a catch-all for rendering, input, haptics, asset pipelines, profiling, and gameplay architecture.
 
-The first release is Apple-platform-first. It covers SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, and rendering-stack choice across SpriteKit, SceneKit, RealityKit, Metal, and existing Apple app workflows.
+The first release is Apple-platform-first. It covers SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics feedback, Xcode game profiling, and rendering-stack choice across SpriteKit, SceneKit, RealityKit, Metal, and existing Apple app workflows.
 
 This is a companion guidance plugin, not a runtime plugin. The first version does not bundle a game engine, template feed, asset pipeline, simulator wrapper, profiler automation, MCP server, or local game runtime.
 
@@ -66,6 +66,10 @@ Guide SpriteKit scene, node, action, physics, camera, resource, GameplayKit inte
 
 Guide SceneKit scene, node graph, camera, lighting, material, animation, physics, asset, RealityKit migration, and Xcode validation work.
 
+### `game-dev-skills:gameplaykit-simulation-workflow`
+
+Guide GameplayKit entities, components, component systems, state machines, pathfinding, agents, randomization, renderer synchronization, and simulation validation.
+
 ### `game-dev-skills:game-controller-input-workflow`
 
 Guide Game Controller framework work for physical controllers, virtual controllers, keyboard and mouse game input, mappings, connection lifecycle, haptics handoffs, and device-aware validation.
@@ -74,11 +78,13 @@ Guide Game Controller framework work for physical controllers, virtual controlle
 
 Guide Core Haptics and game-controller haptic feedback design, capability checks, pattern ownership, audio-haptic boundaries, fallback behavior, accessibility, and physical-device validation.
 
+### `game-dev-skills:xcode-game-profiling-workflow`
+
+Guide Apple game profiling across frame pacing, stutter, CPU/GPU overlap, Game Performance and Game Memory templates, Metal Performance HUD routing, `xctrace`, trace evidence, and handoffs to rendering or shader work.
+
 ## Proposed Follow-Up Skill Inventory
 
-- `game-dev-skills:gameplaykit-simulation-workflow`
 - `game-dev-skills:metal-game-rendering-workflow`
-- `game-dev-skills:xcode-game-profiling-workflow`
 - `game-dev-skills:game-asset-pipeline-workflow`
 - `game-dev-skills:gamekit-game-center-workflow`
 - `game-dev-skills:unity-authoring-workflow`
@@ -88,6 +94,7 @@ Guide Core Haptics and game-controller haptic feedback design, capability checks
 - [x] Create `plugins/game-dev-skills/` with `.codex-plugin/plugin.json` and `AGENTS.md`.
 - [x] Add this maintainer plan.
 - [x] Add first-slice Apple game-development workflow skills.
+- [x] Add `gameplaykit-simulation-workflow` and `xcode-game-profiling-workflow` as the second Apple game-development skill slice.
 - [x] Wire `game-dev-skills` into the root Socket marketplace as installable.
 - [x] Update README and ROADMAP so users understand the new plugin surface.
 - [x] Run skill-folder validation and plugin-manifest validation for the new child plugin.
@@ -95,6 +102,5 @@ Guide Core Haptics and game-controller haptic feedback design, capability checks
 
 ## Open Questions
 
-- Should the next slice prioritize `GameplayKit` as its own simulation workflow, or should it remain a routing section inside SpriteKit and stack-choice guidance until more real use proves the split?
-- Should Metal game rendering be a game-dev skill first, or should the first version be a narrower profiling and shader-build handoff that leans on `apple-dev-skills` Xcode execution workflows?
+- What concrete scope should `metal-game-rendering-workflow` own beyond profiling triage: shader code, render-pass architecture, command encoding, resource layout, Metal debugger workflow, GPU counters, or all of those?
 - Should Unity authoring live in this plugin, or should a later engine-specific plugin own Unity once the authoring scope is concrete?

--- a/docs/maintainers/game-dev-skills-plugin-plan.md
+++ b/docs/maintainers/game-dev-skills-plugin-plan.md
@@ -1,0 +1,99 @@
+# Game Dev Skills Plugin Plan
+
+This plan records the first durable shape for a Socket-hosted game development skills plugin.
+
+## Intent
+
+The `game-dev-skills` plugin should help agents choose and maintain game-specific project surfaces without turning `apple-dev-skills` into a catch-all for rendering, input, haptics, asset pipelines, profiling, and gameplay architecture.
+
+The first release is Apple-platform-first. It covers SpriteKit, SceneKit, Game Controller input, Core Haptics feedback, and rendering-stack choice across SpriteKit, SceneKit, RealityKit, Metal, and existing Apple app workflows.
+
+This is a companion guidance plugin, not a runtime plugin. The first version does not bundle a game engine, template feed, asset pipeline, simulator wrapper, profiler automation, MCP server, or local game runtime.
+
+## Packaging Direction
+
+Package the guidance as an independent child plugin under:
+
+```text
+plugins/game-dev-skills/
+```
+
+The child plugin owns its Codex-facing guidance surface:
+
+- `.codex-plugin/plugin.json`
+- `skills/`
+- plugin metadata, skill metadata, `AGENTS.md`, and maintainer notes that explain the plugin's role
+- any validation scripts needed for the plugin's own authored guidance
+
+The root Socket marketplace lists `game-dev-skills` as installable now that first-slice skill content exists. If the plugin ever loses its exported skill content, switch the marketplace entry back to `NOT_AVAILABLE` in the same pass.
+
+## Boundaries With Existing Plugins
+
+- Use `game-dev-skills` for game-specific authoring, input, haptics, rendering-stack choice, frame pacing, game-loop shape, gameplay architecture, and game profiling handoffs.
+- Use `apple-dev-skills` for general Swift, SwiftUI, AppKit, UIKit, Xcode project integrity, simulator, signing, asset-catalog integration, Apple docs routing, DocC, and Apple-platform validation mechanics.
+- Use `swift-lang` for Swift language style, API shape, concurrency, error handling, source layout, and non-game-specific cleanup.
+- Use `reverse-engineering-skills` when the central input is a compiled artifact, binary, Unity build output, symbol file, crash log, decompiled output, or disassembler output.
+- Use future engine-specific skills only when Unity, Godot, Unreal, or another engine-authoring workflow earns a dedicated owner.
+
+Unity belongs here when the task is authoring, maintaining, profiling, or packaging a Unity project. Unity compiled-artifact analysis stays with `reverse-engineering-skills`.
+
+## Documentation And Tool Sources
+
+Use local Xcode documentation, Dash Apple API Reference docsets, and official Apple documentation before making framework-specific claims. Current first-slice source anchors include:
+
+- [SpriteKit](https://developer.apple.com/documentation/spritekit)
+- [SceneKit](https://developer.apple.com/documentation/scenekit)
+- [GameplayKit](https://developer.apple.com/documentation/gameplaykit)
+- [Game Controller](https://developer.apple.com/documentation/gamecontroller)
+- [Core Haptics](https://developer.apple.com/documentation/corehaptics)
+- [RealityKit game development](https://developer.apple.com/documentation/realitykit#Game-development)
+- [Metal developer workflows](https://developer.apple.com/documentation/xcode/metal-developer-workflows)
+- [Designing for games](https://developer.apple.com/design/human-interface-guidelines/designing-for-games)
+
+Translate documentation into the concrete project, framework, validation, or handoff decision it changes.
+
+## Shipped Skill Inventory
+
+### `game-dev-skills:choose-apple-game-stack`
+
+Choose the smallest correct Apple game-development shape before implementation. This skill routes between SpriteKit, SceneKit, RealityKit, Metal, SwiftUI/AppKit/UIKit host surfaces, Game Controller input, Core Haptics feedback, GameKit/Game Center, and existing Apple Dev Skills workflows.
+
+### `game-dev-skills:spritekit-game-workflow`
+
+Guide SpriteKit scene, node, action, physics, camera, resource, GameplayKit integration, and Xcode validation work.
+
+### `game-dev-skills:scenekit-game-workflow`
+
+Guide SceneKit scene, node graph, camera, lighting, material, animation, physics, asset, RealityKit migration, and Xcode validation work.
+
+### `game-dev-skills:game-controller-input-workflow`
+
+Guide Game Controller framework work for physical controllers, virtual controllers, keyboard and mouse game input, mappings, connection lifecycle, haptics handoffs, and device-aware validation.
+
+### `game-dev-skills:core-haptics-game-feedback-workflow`
+
+Guide Core Haptics and game-controller haptic feedback design, capability checks, pattern ownership, audio-haptic boundaries, fallback behavior, accessibility, and physical-device validation.
+
+## Proposed Follow-Up Skill Inventory
+
+- `game-dev-skills:gameplaykit-simulation-workflow`
+- `game-dev-skills:metal-game-rendering-workflow`
+- `game-dev-skills:xcode-game-profiling-workflow`
+- `game-dev-skills:game-asset-pipeline-workflow`
+- `game-dev-skills:gamekit-game-center-workflow`
+- `game-dev-skills:unity-authoring-workflow`
+
+## First Slice
+
+- [x] Create `plugins/game-dev-skills/` with `.codex-plugin/plugin.json` and `AGENTS.md`.
+- [x] Add this maintainer plan.
+- [x] Add first-slice Apple game-development workflow skills.
+- [x] Wire `game-dev-skills` into the root Socket marketplace as installable.
+- [x] Update README and ROADMAP so users understand the new plugin surface.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+## Open Questions
+
+- Should the next slice prioritize `GameplayKit` as its own simulation workflow, or should it remain a routing section inside SpriteKit and stack-choice guidance until more real use proves the split?
+- Should Metal game rendering be a game-dev skill first, or should the first version be a narrower profiling and shader-build handoff that leans on `apple-dev-skills` Xcode execution workflows?
+- Should Unity authoring live in this plugin, or should a later engine-specific plugin own Unity once the authoring scope is concrete?

--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Apple development workflows for Codex, including media and audio repair, Xcode coding intelligence, SwiftUI animation and architecture, Core Animation, Apple typography, SF Symbols, AppKit architecture, Icon Composer app icons, Safari extensions, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "7.8.0"
+version = "7.9.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "7.8.0"
+version = "7.9.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/codex-utilities/.codex-plugin/plugin.json
+++ b/plugins/codex-utilities/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-utilities",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,0 +1,49 @@
+{
+  "name": "game-dev-skills",
+  "version": "7.8.0",
+  "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, controller input, haptics, and game-stack routing.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "homepage": "https://github.com/gaelic-ghost/socket/tree/main/plugins/game-dev-skills",
+  "repository": "https://github.com/gaelic-ghost/socket",
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "keywords": [
+    "game-development",
+    "apple",
+    "spritekit",
+    "scenekit",
+    "gameplaykit",
+    "game-controller",
+    "core-haptics",
+    "realitykit",
+    "metal",
+    "xcode",
+    "codex",
+    "plugin",
+    "skills"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Game Dev Skills",
+    "shortDescription": "Apple game development workflow skills for Codex.",
+    "longDescription": "Guide Codex agents through Apple platform game development decisions and implementation work across SpriteKit, SceneKit, GameplayKit handoffs, Game Controller input, Core Haptics game feedback, RealityKit and Metal routing, assets, profiling, and device-aware validation.",
+    "developerName": "Gale",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/game-dev-skills",
+    "defaultPrompt": [
+      "Choose the right Apple game stack before we start implementing.",
+      "Build or repair this SpriteKit scene, game loop, physics, or resource flow.",
+      "Build or repair this SceneKit scene, node graph, camera, lighting, or asset flow.",
+      "Wire game controller, keyboard, mouse, or virtual-controller input for this Apple game.",
+      "Design or debug Core Haptics feedback for a game while keeping device validation honest."
+    ],
+    "brandColor": "#28D7FF"
+  }
+}

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "game-dev-skills",
   "version": "7.8.0",
-  "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, controller input, haptics, and game-stack routing.",
+  "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -20,6 +20,9 @@
     "core-haptics",
     "realitykit",
     "metal",
+    "instruments",
+    "xctrace",
+    "profiling",
     "xcode",
     "codex",
     "plugin",
@@ -29,7 +32,7 @@
   "interface": {
     "displayName": "Game Dev Skills",
     "shortDescription": "Apple game development workflow skills for Codex.",
-    "longDescription": "Guide Codex agents through Apple platform game development decisions and implementation work across SpriteKit, SceneKit, GameplayKit handoffs, Game Controller input, Core Haptics game feedback, RealityKit and Metal routing, assets, profiling, and device-aware validation.",
+    "longDescription": "Guide Codex agents through Apple platform game development decisions and implementation work across SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics game feedback, Xcode game profiling, RealityKit and Metal routing, assets, and device-aware validation.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -41,8 +44,10 @@
       "Choose the right Apple game stack before we start implementing.",
       "Build or repair this SpriteKit scene, game loop, physics, or resource flow.",
       "Build or repair this SceneKit scene, node graph, camera, lighting, or asset flow.",
+      "Design or repair this GameplayKit entity, component, state-machine, pathfinding, or agent system.",
       "Wire game controller, keyboard, mouse, or virtual-controller input for this Apple game.",
-      "Design or debug Core Haptics feedback for a game while keeping device validation honest."
+      "Design or debug Core Haptics feedback for a game while keeping device validation honest.",
+      "Profile this Apple game for frame pacing, stutter, CPU/GPU overlap, memory pressure, or trace evidence without turning profiling into shader architecture."
     ],
     "brandColor": "#28D7FF"
   }

--- a/plugins/game-dev-skills/AGENTS.md
+++ b/plugins/game-dev-skills/AGENTS.md
@@ -21,7 +21,7 @@ This file is the Game Dev Skills child-repo override for work done from `socket`
 ## Validation
 
 ```bash
-python3 /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/<skill-name>
+uv run python "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" skills/<skill-name>
 ```
 
 Run the root Socket metadata validator after plugin metadata, marketplace wiring, or root docs change:

--- a/plugins/game-dev-skills/AGENTS.md
+++ b/plugins/game-dev-skills/AGENTS.md
@@ -5,7 +5,7 @@ This file is the Game Dev Skills child-repo override for work done from `socket`
 ## Scope
 
 - `game-dev-skills` is a monorepo-owned Socket child source for Codex game development workflow skills.
-- The first shipped scope is Apple platform game development: SpriteKit, SceneKit, GameplayKit routing, Game Controller input, Core Haptics game feedback, and related Xcode validation handoffs.
+- The shipped scope is Apple platform game development: SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics game feedback, Xcode game profiling, and related Xcode validation handoffs.
 - Root [`skills/`](./skills/) is the authored workflow surface.
 - The repo root is the Codex plugin root through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
 

--- a/plugins/game-dev-skills/AGENTS.md
+++ b/plugins/game-dev-skills/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+This file is the Game Dev Skills child-repo override for work done from `socket`. Follow the root `socket` guidance for general git, docs, release, branch, dependency-provenance, and maintainer workflow rules.
+
+## Scope
+
+- `game-dev-skills` is a monorepo-owned Socket child source for Codex game development workflow skills.
+- The first shipped scope is Apple platform game development: SpriteKit, SceneKit, GameplayKit routing, Game Controller input, Core Haptics game feedback, and related Xcode validation handoffs.
+- Root [`skills/`](./skills/) is the authored workflow surface.
+- The repo root is the Codex plugin root through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+
+## Local Rules
+
+- Keep Apple framework behavior grounded in Xcode-local docs, Dash Apple API Reference docsets, or official Apple Developer documentation before making framework-specific claims.
+- Use `apple-dev-skills` for general Swift, SwiftUI, AppKit, UIKit, Xcode project integrity, simulator, signing, asset-catalog, DocC, and Apple docs-routing work.
+- Use `swift-lang` for shared Swift language style, API design, concurrency, error handling, and source-organization guidance that is not game-specific.
+- Use `reverse-engineering-skills` when the central input is a compiled game artifact, Unity build output, binary, symbol file, crash log, decompiler output, or disassembler output.
+- Keep this plugin focused on game-specific authoring, maintenance, input, feedback, rendering-stack choice, profiling, and validation handoffs.
+- Treat device feel, controller behavior, haptic sensation, frame pacing, latency, thermal behavior, and GPU timing as hardware-sensitive evidence. Do not claim those are verified unless they were observed on a suitable simulator, device, controller, trace, or local tool.
+
+## Validation
+
+```bash
+python3 /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/<skill-name>
+```
+
+Run the root Socket metadata validator after plugin metadata, marketplace wiring, or root docs change:
+
+```bash
+uv run scripts/validate_socket_metadata.py
+```

--- a/plugins/game-dev-skills/skills/choose-apple-game-stack/SKILL.md
+++ b/plugins/game-dev-skills/skills/choose-apple-game-stack/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: choose-apple-game-stack
+description: Choose the right Apple platform game-development stack before implementation. Use when Codex needs to route a game task across SpriteKit, SceneKit, RealityKit, Metal, GameplayKit, Game Controller, Core Haptics, GameKit, SwiftUI/AppKit/UIKit host surfaces, assets, profiling, or Apple Dev Skills handoffs.
+---
+
+# Choose Apple Game Stack
+
+## Overview
+
+Use this skill before implementing Apple game work when the correct owner is not obvious. The goal is to choose the smallest game-specific stack that fits the project instead of turning a rendering, input, haptics, or profiling task into a generic Apple app change.
+
+## Source Check
+
+Use repo-local files, Xcode-local documentation, Dash Apple API Reference docsets, and official Apple documentation before making framework-specific claims. Useful Apple anchors:
+
+- [SpriteKit](https://developer.apple.com/documentation/spritekit)
+- [SceneKit](https://developer.apple.com/documentation/scenekit)
+- [GameplayKit](https://developer.apple.com/documentation/gameplaykit)
+- [Game Controller](https://developer.apple.com/documentation/gamecontroller)
+- [Core Haptics](https://developer.apple.com/documentation/corehaptics)
+- [RealityKit game development](https://developer.apple.com/documentation/realitykit#Game-development)
+- [Designing for games](https://developer.apple.com/design/human-interface-guidelines/designing-for-games)
+
+State the documented behavior that changes the recommendation. If local docs and current code disagree, stop and surface that conflict.
+
+## Classification Workflow
+
+1. Inspect the repository shape:
+   - Xcode project, workspace, XcodeGen `project.yml`, Swift package, or mixed app-plus-package layout
+   - imports such as `SpriteKit`, `SceneKit`, `RealityKit`, `Metal`, `GameplayKit`, `GameController`, `CoreHaptics`, `GameKit`, `AVFAudio`, or `SwiftUI`
+   - asset catalogs, `.sks`, `.scn`, `.scnassets`, `.usdz`, `.reality`, `.metal`, texture atlases, audio files, and controller or haptic code
+   - tests, manual validation checklists, profiling traces, Instruments artifacts, and CI scripts
+2. Identify the game job:
+   - 2D scene, animation, physics, or particle work
+   - 3D scene, camera, lighting, material, animation, or asset work
+   - immersive RealityKit or visionOS game work
+   - custom GPU rendering, shader, or Metal performance work
+   - entity-component, state machine, pathfinding, agents, or procedural rules work
+   - physical or virtual controller input, keyboard, mouse, or stylus game input
+   - haptic, audio-haptic, or controller-rumble feedback
+   - Game Center, achievements, leaderboard, multiplayer, or save-state work
+   - profiling, frame pacing, latency, memory, thermal, or GPU timing work
+3. Choose the owner:
+   - SpriteKit for most 2D games, `SKScene`, nodes, actions, particles, 2D physics, tile maps, and SpriteKit resources.
+   - SceneKit for existing 3D SceneKit projects, scene graphs, cameras, lights, materials, animations, and 3D physics where RealityKit is not the chosen migration target.
+   - RealityKit for modern entity-component 3D, spatial, AR, or visionOS game work when project requirements and platform support fit.
+   - Metal for custom rendering, shader pipelines, GPU-driven workloads, or performance questions that SpriteKit, SceneKit, and RealityKit do not own cleanly.
+   - GameplayKit for game rules, state machines, entity-component modeling, pathfinding, agents, and randomization services that should not be buried in view code.
+   - Game Controller for physical controllers, virtual controllers, keyboard/mouse game input, controller lifecycle, mappings, and controller haptics handoffs.
+   - Core Haptics for custom haptic patterns and audio-haptic feedback when hardware support and device validation are explicit.
+4. Route non-game work away:
+   - Use `apple-dev-skills` for generic Xcode project integrity, signing, simulator, asset-catalog mechanics, SwiftUI/AppKit/UIKit host views, DocC, and Apple documentation exploration.
+   - Use `swift-lang` for Swift API shape, concurrency, errors, formatting, and source structure when the issue is not game-specific.
+   - Use `reverse-engineering-skills` for compiled game artifacts, Unity build outputs, binaries, crash logs, or decompiler/disassembler output.
+
+## Validation Choice
+
+Choose validation based on the claim being made:
+
+- Build or project-integrity claims: use the relevant Xcode or SwiftPM validation workflow from `apple-dev-skills`.
+- Rendering behavior: validate with a running app, preview, simulator, device, screenshot, or trace when possible.
+- Controller input: validate with the relevant hardware, virtual controller, keyboard, mouse, or explicit fallback path.
+- Haptics and physical feel: require device or controller evidence; otherwise report a manual validation gap.
+- Performance and frame pacing: prefer Release builds and Instruments or `xctrace` evidence.
+
+## Output Shape
+
+Return:
+
+1. `Chosen stack`: SpriteKit, SceneKit, RealityKit, Metal, GameplayKit, Game Controller, Core Haptics, GameKit, Apple Dev Skills handoff, or mixed.
+2. `Game owner`: scene, renderer, simulation, input, haptics, assets, host app, profiling, or service boundary.
+3. `Why`: the concrete framework behavior or project evidence that drove the choice.
+4. `Handoffs`: next skill or plugin to use.
+5. `Validation`: exact build, run, trace, hardware, or manual-check path.
+6. `Open decisions`: only decisions that block a correct implementation.

--- a/plugins/game-dev-skills/skills/choose-apple-game-stack/SKILL.md
+++ b/plugins/game-dev-skills/skills/choose-apple-game-stack/SKILL.md
@@ -63,6 +63,12 @@ Choose validation based on the claim being made:
 - Haptics and physical feel: require device or controller evidence; otherwise report a manual validation gap.
 - Performance and frame pacing: prefer Release builds and Instruments or `xctrace` evidence.
 
+## Follow-Up Skill Routing
+
+- Use `gameplaykit-simulation-workflow` when game rules, entity-component modeling, state machines, agents, pathfinding, randomization, or simulation update order own the problem.
+- Use `xcode-game-profiling-workflow` when frame pacing, stutter, CPU/GPU overlap, memory pressure, thermal state, trace capture, or profiling evidence owns the problem.
+- Keep Metal rendering and shader architecture as a future handoff when the work requires shader code, render-pass architecture, command encoding, resource layout, GPU counters, or Metal debugger workflow beyond profiling triage.
+
 ## Output Shape
 
 Return:

--- a/plugins/game-dev-skills/skills/choose-apple-game-stack/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/choose-apple-game-stack/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Choose Apple Game Stack"
+  short_description: "Choose an Apple game stack."
+  default_prompt: "Use $choose-apple-game-stack to inspect an Apple game project or idea, choose the smallest correct rendering, input, haptics, asset, and validation shape, and hand off to narrower game-dev or Apple Dev Skills workflows."

--- a/plugins/game-dev-skills/skills/core-haptics-game-feedback-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/core-haptics-game-feedback-workflow/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: core-haptics-game-feedback-workflow
+description: Guide Core Haptics and game feedback work for Apple games. Use when Codex designs, implements, repairs, or validates CHHapticEngine, CHHapticPattern, audio-haptic feedback, controller haptics, capability checks, fallback behavior, accessibility-sensitive feedback, or physical-device haptic validation.
+---
+
+# Core Haptics Game Feedback Workflow
+
+## Overview
+
+Use this skill when game feedback depends on haptics, audio-haptic patterns, or controller rumble. Keep physical sensation claims behind real device or controller evidence.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making Core Haptics or controller-haptics claims:
+
+- [Core Haptics](https://developer.apple.com/documentation/corehaptics)
+- [Playing Haptics on Game Controllers](https://developer.apple.com/documentation/corehaptics/playing-haptics-on-game-controllers)
+- [Game Controller haptics](https://developer.apple.com/documentation/gamecontroller/gcdevicehaptics)
+- [Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+
+Apple sample guidance for controller haptics requires a physical device and Bluetooth-connected controller. Treat that as the evidence standard for controller haptic validation.
+
+## Workflow
+
+1. Inspect feedback ownership:
+   - `import CoreHaptics`
+   - `CHHapticEngine`, `CHHapticPattern`, `CHHapticEvent`, `CHHapticParameter`, `CHHapticAdvancedPatternPlayer`
+   - `GCDeviceHaptics`, controller localities, and Game Controller integration
+   - audio-session, audio-engine, or sound-effect code that must synchronize with feedback
+2. Check capabilities before design commitments:
+   - Device haptic support
+   - Controller haptic localities
+   - Audio-haptic needs
+   - Interruptions, engine reset, app lifecycle, and background behavior
+   - Accessibility, reduced motion, user settings, and alternate feedback paths
+3. Design patterns from gameplay meaning:
+   - Impact, charge, rhythm, confirmation, warning, surface texture, failure, and reward feedback should be named by gameplay purpose.
+   - Keep haptic pattern creation testable and data-driven when a game has many feedback events.
+   - Avoid firing haptics from hidden side effects that make input or gameplay hard to reason about.
+4. Validate honestly:
+   - Compile and run with the relevant Apple Dev execution workflow.
+   - Use physical iPhone, iPad, Mac trackpad, or game controller evidence for sensation claims.
+   - Report simulator-only or unsupported-device checks as compile/API validation, not physical haptic validation.
+
+## Handoffs
+
+- `game-controller-input-workflow` when controller lifecycle, mappings, or input events own the issue.
+- `apple-dev-skills:avfaudio-session-workflow` when audio session configuration owns the failure.
+- `apple-dev-skills:avaudio-engine-workflow` when AVAudioEngine graph behavior owns synchronized audio.
+- `apple-dev-skills:xcode-build-run-workflow` for project membership, build, run, and device execution mechanics.
+
+## Output Shape
+
+Return the gameplay feedback purpose, haptic owner, capability checks, fallback or accessibility path, validation device/controller, and any sensation evidence that remains manual.

--- a/plugins/game-dev-skills/skills/core-haptics-game-feedback-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/core-haptics-game-feedback-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Core Haptics Game Feedback"
+  short_description: "Game haptics feedback guidance."
+  default_prompt: "Use $core-haptics-game-feedback-workflow for Core Haptics, controller haptics, game feedback patterns, audio-haptic design, capability checks, and device-only validation handoffs."

--- a/plugins/game-dev-skills/skills/game-controller-input-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/game-controller-input-workflow/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: game-controller-input-workflow
+description: Guide Apple Game Controller framework input work for games. Use when Codex works on GCController, GCDevice, extended gamepad mappings, virtual controllers, keyboard and mouse game input, controller connection lifecycle, controller haptics handoffs, input evidence, accessibility alternatives, or device-aware validation.
+---
+
+# Game Controller Input Workflow
+
+## Overview
+
+Use this skill for game input that belongs to the Game Controller framework or to controller-adjacent keyboard and mouse game controls. Keep rendering work in SpriteKit, SceneKit, RealityKit, or Metal owner skills.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making Game Controller-specific claims:
+
+- [Game Controller](https://developer.apple.com/documentation/gamecontroller)
+- [Supporting Game Controllers](https://developer.apple.com/documentation/gamecontroller/supporting-game-controllers)
+- [GCController](https://developer.apple.com/documentation/gamecontroller/gccontroller)
+- [GCKeyboard](https://developer.apple.com/documentation/gamecontroller/gckeyboard)
+- [GCMouse](https://developer.apple.com/documentation/gamecontroller/gcmouse)
+
+## Workflow
+
+1. Inspect input ownership:
+   - `import GameController`
+   - `GCController`, `GCDevice`, `GCExtendedGamepad`, `GCMicroGamepad`, `GCKeyboard`, `GCMouse`, `GCVirtualController`, `GCDeviceHaptics`
+   - controller connection and disconnection notifications
+   - polling, value-changed handlers, input snapshots, or custom input abstraction
+   - renderer-specific input bridges in SpriteKit, SceneKit, RealityKit, or host views
+2. Preserve evidence shape:
+   - Keep button press/release, analog values, directional values, repeat state, timestamps, modifiers, and device identity visible where the project needs diagnostics.
+   - Do not normalize discrete keyboard events into fake continuous geometry.
+   - Do not claim hardware behavior was verified without the relevant controller, keyboard, mouse, Siri Remote, or virtual-controller evidence.
+3. Design mappings:
+   - Keep gameplay actions separate from raw controller elements.
+   - Provide keyboard or touch alternatives when controller input is optional.
+   - Make remapping, dead zones, inversion, and accessibility choices explicit when they are part of the requested work.
+4. Validate:
+   - Verify compile/build through the Apple Dev execution workflow.
+   - Run a manual or automated input checklist on the relevant hardware or simulator surface.
+   - Record missing hardware as a validation gap instead of pretending the sandbox proved controller feel.
+
+## Handoffs
+
+- `core-haptics-game-feedback-workflow` for haptics, rumble, audio-haptic patterns, and capability checks.
+- `spritekit-game-workflow` or `scenekit-game-workflow` when the work becomes scene or gameplay integration.
+- `apple-dev-skills:xcode-build-run-workflow` for build, run, simulator, and project membership mechanics.
+- `apple-dev-skills:apple-ui-accessibility-workflow` for broader accessibility review when control alternatives, labels, focus, or assistive interaction become central.
+
+## Output Shape
+
+Return the input devices, raw input owner, gameplay-action mapping, accessibility alternatives, validation hardware or simulator path, and missing evidence.

--- a/plugins/game-dev-skills/skills/game-controller-input-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/game-controller-input-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Game Controller Input"
+  short_description: "Game controller input guidance."
+  default_prompt: "Use $game-controller-input-workflow for Game Controller framework input, keyboard and mouse game input, virtual controllers, controller discovery, mappings, haptics handoffs, and device validation."

--- a/plugins/game-dev-skills/skills/gameplaykit-simulation-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/gameplaykit-simulation-workflow/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: gameplaykit-simulation-workflow
+description: Guide GameplayKit simulation and gameplay-architecture work. Use when Codex works on GKEntity, GKComponent, GKComponentSystem, GKState, GKStateMachine, GKGraph, GKAgent, GKGoal, GKBehavior, GKRandom, SpriteKit or SceneKit integration, pathfinding, agents, state machines, reusable gameplay logic, or game simulation validation.
+---
+
+# GameplayKit Simulation Workflow
+
+## Overview
+
+Use this skill when the problem is gameplay logic rather than rendering. GameplayKit is the owner when entities, components, systems, states, agents, pathfinding, or reproducible gameplay services need to stay separate from SpriteKit, SceneKit, RealityKit, SwiftUI, or ad hoc view code.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making GameplayKit-specific claims:
+
+- [GameplayKit](https://developer.apple.com/documentation/gameplaykit)
+- [GameplayKit entities and components](https://developer.apple.com/documentation/gameplaykit#Entities-and-Components)
+- [GameplayKit state machines](https://developer.apple.com/documentation/gameplaykit#State-Machines)
+- [GameplayKit agents, goals, and behaviors](https://developer.apple.com/documentation/gameplaykit#Agents-Goals-and-Behaviors)
+- [GKScene](https://developer.apple.com/documentation/gameplaykit/gkscene)
+- [GKComponentSystem](https://developer.apple.com/documentation/gameplaykit/gkcomponentsystem)
+
+Apple documents GameplayKit as a framework for organizing game logic and providing reusable gameplay features such as random number generation, AI, pathfinding, and agent behavior. Use that boundary to keep simulation out of renderer-specific code unless the project intentionally couples them.
+
+## Workflow
+
+1. Inspect the gameplay model:
+   - `import GameplayKit`
+   - `GKEntity`, `GKComponent`, `GKComponentSystem`
+   - `GKState`, `GKStateMachine`
+   - `GKGraph`, `GKGraphNode`, `GKGridGraph`
+   - `GKAgent`, `GKAgent2D`, `GKAgent3D`, `GKGoal`, `GKBehavior`, `GKPath`
+   - `GKRandomSource`, `GKRandomDistribution`, `GKRuleSystem`
+   - `GKScene`, `GKSKNodeComponent`, and SpriteKit scene-editor integration
+2. Choose the GameplayKit surface:
+   - Use entities and components when several gameplay objects need reusable behaviors without deep inheritance.
+   - Use component systems when components need ordered per-frame updates across many entities.
+   - Use state machines when the game or object behavior has explicit state transitions and invalid transitions should be prevented.
+   - Use graphs and pathfinding when navigation rules are more important than renderer-specific movement.
+   - Use agents, goals, and behaviors when autonomous movement should be expressed as goals and constraints.
+   - Use GameplayKit random sources when reproducibility, seeded behavior, or distribution shape matters.
+3. Keep renderers thin:
+   - SpriteKit and SceneKit nodes can present gameplay state, but they should not become the only source of gameplay truth unless the project already owns that pattern.
+   - Use `GKSKNodeComponent` or explicit adapter components when SpriteKit nodes and GameplayKit entities need to stay synchronized.
+   - For SceneKit, keep 3D node synchronization explicit rather than burying game rules in node lookup code.
+4. Validate simulation honestly:
+   - Unit-test pure gameplay rules where practical.
+   - Test state-machine transitions, seeded random behavior, pathfinding outcomes, and component update order without requiring a rendered scene when possible.
+   - Use renderer or device validation only for integration behavior that pure tests cannot prove.
+
+## Handoffs
+
+- `spritekit-game-workflow` when SpriteKit scene, node, action, physics, or `.sks` behavior owns the work.
+- `scenekit-game-workflow` when SceneKit scene graph, assets, camera, lighting, or 3D physics owns the work.
+- `xcode-game-profiling-workflow` when per-frame component updates, pathfinding, agents, or renderer synchronization become performance-sensitive.
+- `swift-lang` for general Swift API design, concurrency, error handling, source organization, or test style that is not game-specific.
+- `apple-dev-skills:xcode-testing-workflow` for Xcode test plans, UI tests, Instruments, `xctrace`, or test execution mechanics.
+
+## Output Shape
+
+Return the GameplayKit owner, selected GameplayKit surface, renderer synchronization boundary, files or systems changed, pure-test path, integration validation path, and remaining open gameplay decisions.

--- a/plugins/game-dev-skills/skills/gameplaykit-simulation-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/gameplaykit-simulation-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GameplayKit Simulation"
+  short_description: "GameplayKit simulation guidance."
+  default_prompt: "Use $gameplaykit-simulation-workflow for GameplayKit entities, components, component systems, state machines, pathfinding, agents, randomization, SpriteKit integration, and gameplay simulation validation."

--- a/plugins/game-dev-skills/skills/scenekit-game-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/scenekit-game-workflow/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: scenekit-game-workflow
+description: Guide SceneKit game implementation, repair, and maintenance. Use when Codex works on SCNScene, SCNView, SCNNode, cameras, lights, materials, geometry, animation, 3D physics, .scn files, .scnassets, model assets, SceneKit and SwiftUI/AppKit/UIKit integration, or RealityKit migration handoffs.
+---
+
+# SceneKit Game Workflow
+
+## Overview
+
+Use this skill for game-specific SceneKit work after SceneKit has been chosen or when maintaining an existing SceneKit project. Keep generic Apple app lifecycle, project-integrity mechanics, and Swift source cleanup with their owner skills.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making SceneKit-specific claims:
+
+- [SceneKit](https://developer.apple.com/documentation/scenekit)
+- [SCNScene](https://developer.apple.com/documentation/scenekit/scnscene)
+- [SCNNode](https://developer.apple.com/documentation/scenekit/scnnode)
+- [Bringing your SceneKit projects to RealityKit](https://developer.apple.com/documentation/realitykit/bringing-your-scenekit-projects-to-realitykit)
+
+When new work is really modern 3D, spatial, or visionOS game work, consider RealityKit before deepening SceneKit-specific architecture. When maintaining an existing SceneKit project, preserve SceneKit unless the user asks for a migration.
+
+## Workflow
+
+1. Inspect the SceneKit surface:
+   - `import SceneKit`
+   - `SCNScene`, `SCNView`, `SCNNode`, `SCNCamera`, `SCNLight`, `SCNMaterial`, `SCNGeometry`, `SCNPhysicsWorld`, `SCNPhysicsBody`, animation players, and delegates
+   - `.scn`, `.scnassets`, `.dae`, `.obj`, `.usdz`, textures, normal maps, environment maps, and animation assets
+   - host SwiftUI/AppKit/UIKit views and project-resource membership
+2. Keep the scene graph readable:
+   - Name node ownership explicitly.
+   - Keep camera, lighting, physics, material, and asset-loading changes close to the scene or game subsystem that owns them.
+   - Avoid opaque node-name lookups for core gameplay unless the existing project already uses them deliberately.
+3. Choose migration posture:
+   - Maintain SceneKit for existing projects when the request is repair, content, performance, or incremental gameplay work.
+   - Consider RealityKit when the request is new spatial or visionOS-first work, entity-component design, or an explicit SceneKit-to-RealityKit migration.
+   - Consider Metal only when the work needs custom rendering or shader-level ownership beyond SceneKit's model.
+4. Validate honestly:
+   - Build and run through the repo's Xcode workflow.
+   - Inspect visual behavior in a running app, simulator, device, screenshot, or recording when possible.
+   - Use Instruments or `xctrace` handoffs for frame pacing, CPU/GPU timing, memory, or asset-loading performance.
+
+## Handoffs
+
+- `choose-apple-game-stack` when SceneKit versus RealityKit versus Metal is still unclear.
+- `game-controller-input-workflow` for controller, keyboard, mouse, and virtual-controller input.
+- `core-haptics-game-feedback-workflow` for haptic feedback.
+- `apple-dev-skills:xcode-build-run-workflow` for project membership, schemes, build, run, resources, and simulator mechanics.
+- `apple-dev-skills:xcode-testing-workflow` for XCTest, UI tests, Instruments, `xctrace`, and trace interpretation.
+
+## Output Shape
+
+Return the SceneKit owner, changed or planned scene/assets, migration posture, validation path, and any manual visual, hardware, or profiling checks still required.

--- a/plugins/game-dev-skills/skills/scenekit-game-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/scenekit-game-workflow/SKILL.md
@@ -43,6 +43,8 @@ When new work is really modern 3D, spatial, or visionOS game work, consider Real
 ## Handoffs
 
 - `choose-apple-game-stack` when SceneKit versus RealityKit versus Metal is still unclear.
+- `gameplaykit-simulation-workflow` when entity-component modeling, state machines, pathfinding, agents, randomization, or simulation update order owns the work.
+- `xcode-game-profiling-workflow` when SceneKit frame pacing, CPU/GPU overlap, material/asset cost, memory pressure, or trace evidence owns the work.
 - `game-controller-input-workflow` for controller, keyboard, mouse, and virtual-controller input.
 - `core-haptics-game-feedback-workflow` for haptic feedback.
 - `apple-dev-skills:xcode-build-run-workflow` for project membership, schemes, build, run, resources, and simulator mechanics.

--- a/plugins/game-dev-skills/skills/scenekit-game-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/scenekit-game-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SceneKit Game Workflow"
+  short_description: "SceneKit game workflow guidance."
+  default_prompt: "Use $scenekit-game-workflow for SceneKit scenes, SCNView or SwiftUI integration, nodes, cameras, lighting, physics, assets, RealityKit handoffs, and Xcode validation routing."

--- a/plugins/game-dev-skills/skills/spritekit-game-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/spritekit-game-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: spritekit-game-workflow
+description: Guide SpriteKit game implementation, repair, and maintenance. Use when Codex works on SKScene, SKView, SKNode, actions, particles, cameras, constraints, 2D physics, tile maps, SpriteKit resources, .sks files, SpriteKit and GameplayKit integration, or SpriteKit validation in Apple game projects.
+---
+
+# SpriteKit Game Workflow
+
+## Overview
+
+Use this skill for game-specific SpriteKit work after SpriteKit has been chosen as the rendering and scene framework. Keep generic Xcode project mechanics, signing, simulator operation, and Swift language cleanup with the Apple Dev and Swift Lang owner skills.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making SpriteKit-specific claims:
+
+- [SpriteKit](https://developer.apple.com/documentation/spritekit)
+- [SKScene](https://developer.apple.com/documentation/spritekit/skscene)
+- [SKNode](https://developer.apple.com/documentation/spritekit/sknode)
+- [GameplayKit](https://developer.apple.com/documentation/gameplaykit)
+
+Apple documentation describes SpriteKit as a high-performance 2D framework for games and graphics-intensive apps that integrates with GameplayKit and SceneKit. Use that boundary when deciding whether SpriteKit or another stack owns the work.
+
+## Workflow
+
+1. Inspect the SpriteKit surface:
+   - `import SpriteKit`
+   - `SKScene`, `SKView`, `SKNode`, `SKSpriteNode`, `SKCameraNode`, `SKAction`, `SKPhysicsWorld`, `SKPhysicsBody`, `SKEmitterNode`, `SKTileMapNode`
+   - `.sks` files, texture atlases, particle files, tile sets, audio resources, and asset catalogs
+   - scene loading, scene transitions, update loops, input event routing, and host SwiftUI/AppKit/UIKit views
+2. Preserve scene ownership:
+   - Keep simulation, rendering, input, and resource-loading responsibilities explicit.
+   - Avoid hiding game state in arbitrary node names or untyped `userData` unless the existing project already owns that convention.
+   - Use GameplayKit when entity-component modeling, state machines, pathfinding, agents, or randomization services are the real concern.
+3. Implement narrowly:
+   - Put per-frame behavior in the scene or a game-specific model layer the repo already owns.
+   - Use `SKAction` for node-local animation when it fits.
+   - Use SpriteKit physics for 2D collision and contact behavior when the project can express the gameplay in SpriteKit terms.
+   - Keep host SwiftUI/AppKit/UIKit code thin when it only embeds an `SKView`.
+4. Validate honestly:
+   - Build and run through the repo's Xcode or SwiftPM workflow.
+   - Use simulator or device evidence for visual behavior when possible.
+   - Use device evidence for touch, controller, haptic, and frame-pacing claims that the local environment cannot prove.
+   - Use Instruments or `xctrace` handoffs when the question is frame time, memory, CPU/GPU overlap, or stutter.
+
+## Handoffs
+
+- `choose-apple-game-stack` when the stack choice is still unclear.
+- `game-controller-input-workflow` for physical controllers, virtual controllers, keyboard, or mouse input.
+- `core-haptics-game-feedback-workflow` for custom haptics or controller rumble.
+- `apple-dev-skills:xcode-build-run-workflow` for project membership, scheme, build, run, simulator, and Metal-toolchain-aware execution mechanics.
+- `apple-dev-skills:xcode-testing-workflow` for XCTest, UI tests, Instruments, `xctrace`, or profiling evidence.
+- `swift-lang` for non-game-specific Swift style, API, concurrency, or source cleanup.
+
+## Output Shape
+
+Return the SpriteKit owner, files changed or planned, scene/resource impact, GameplayKit handoff if relevant, validation path, and any manual visual or hardware checks still required.

--- a/plugins/game-dev-skills/skills/spritekit-game-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/spritekit-game-workflow/SKILL.md
@@ -45,6 +45,8 @@ Apple documentation describes SpriteKit as a high-performance 2D framework for g
 ## Handoffs
 
 - `choose-apple-game-stack` when the stack choice is still unclear.
+- `gameplaykit-simulation-workflow` when entity-component modeling, state machines, pathfinding, agents, randomization, or simulation update order owns the work.
+- `xcode-game-profiling-workflow` when SpriteKit frame pacing, stutter, texture/resource churn, physics cost, or per-frame update cost needs evidence.
 - `game-controller-input-workflow` for physical controllers, virtual controllers, keyboard, or mouse input.
 - `core-haptics-game-feedback-workflow` for custom haptics or controller rumble.
 - `apple-dev-skills:xcode-build-run-workflow` for project membership, scheme, build, run, simulator, and Metal-toolchain-aware execution mechanics.

--- a/plugins/game-dev-skills/skills/spritekit-game-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/spritekit-game-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SpriteKit Game Workflow"
+  short_description: "SpriteKit game workflow guidance."
+  default_prompt: "Use $spritekit-game-workflow for SpriteKit scenes, SKScene lifecycle, nodes, physics, actions, SpriteKit resources, GameplayKit handoffs, and Xcode validation routing."

--- a/plugins/game-dev-skills/skills/xcode-game-profiling-workflow/SKILL.md
+++ b/plugins/game-dev-skills/skills/xcode-game-profiling-workflow/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: xcode-game-profiling-workflow
+description: Guide Apple game profiling and performance-evidence work in Xcode and Instruments. Use when Codex investigates frame pacing, stutter, FPS, CPU/GPU overlap, Time Profiler evidence, Game Performance or Game Memory templates, Metal Performance HUD routing, memory pressure, thermal state, trace capture, or profiling handoffs for SpriteKit, SceneKit, RealityKit, or Metal-backed games.
+---
+
+# Xcode Game Profiling Workflow
+
+## Overview
+
+Use this skill when the question is game performance evidence, not shader design. It helps agents choose the right Xcode or Instruments profiling path, interpret game-specific symptoms, and hand off Metal rendering or shader work without absorbing that future skill.
+
+## Source Check
+
+Use Xcode-local documentation, Dash Apple API Reference docsets, or official Apple documentation before making profiling-tool claims:
+
+- [Analyzing the performance of your Metal app](https://developer.apple.com/documentation/xcode/analyzing-the-performance-of-your-metal-app)
+- [Metal developer workflows](https://developer.apple.com/documentation/xcode/metal-developer-workflows)
+- [Monitoring your Metal app's graphics performance](https://developer.apple.com/documentation/xcode/monitoring-your-metal-apps-graphics-performance)
+- [Understanding the Metal Performance HUD metrics](https://developer.apple.com/documentation/xcode/understanding-the-metal-performance-hud-metrics)
+- [Analyzing the memory usage of your Metal app](https://developer.apple.com/documentation/xcode/analyzing-the-memory-usage-of-your-metal-app)
+
+Apple describes the Game Performance template as a way to profile frame time by combining threading, system-call, and Metal system trace information. Use that tool for evidence about smooth rendering, CPU/GPU overlap, stutters, memory pressure, display timing, and thermal state. Do not treat it as a substitute for a future Metal rendering or shader workflow.
+
+## Workflow
+
+1. Classify the symptom:
+   - low FPS
+   - intermittent stutter
+   - long frame interval
+   - CPU-bound update loop
+   - GPU-bound rendering
+   - poor CPU/GPU overlap
+   - memory growth, texture pressure, or resource churn
+   - thermal throttling
+   - input-to-visual or input-to-haptic latency
+2. Choose the evidence path:
+   - Game Performance template for frame pacing, CPU/GPU overlap, display timing, Time Profiler, thermal state, GPU events, and Metal resource events.
+   - Game Memory template for memory footprint, VM behavior, allocations, and Metal resource memory pressure.
+   - Metal Performance HUD for live FPS, GPU time, frame interval, memory, thermal, Game Mode, and capture-scope discovery.
+   - `xctrace` when the project needs repeatable CLI trace capture or shareable artifacts.
+   - Xcode Metal capture or debugger only when the next question is a Metal workload, resource, pass, or shader question.
+3. Preserve profiling integrity:
+   - Prefer Release builds when optimization, frame time, inlining, specialization, ARC behavior, or GPU workload shape matters.
+   - Record device, OS, Xcode, scheme, build configuration, display refresh rate, Game Mode state when relevant, and reproduction steps.
+   - Keep trace artifacts, screenshots, or summary exports named by scenario and timestamp when the repo has a diagnostics location.
+   - Do not claim haptic feel, physical controller latency, or thermal behavior without suitable device evidence.
+4. Interpret cautiously:
+   - CPU-heavy frames need call-tree or thread-state evidence before code changes.
+   - GPU-heavy frames need GPU timeline, resource, pass, or shader evidence before shader conclusions.
+   - Memory-heavy frames need allocation, VM, or Metal resource evidence before asset-pipeline changes.
+   - If the trace suggests shader or render-pass design issues, hand off to future Metal rendering guidance or current Apple Dev Xcode execution skills rather than inventing shader architecture here.
+
+## Handoffs
+
+- `spritekit-game-workflow` when the fix is SpriteKit scene, action, physics, texture, or node behavior.
+- `scenekit-game-workflow` when the fix is SceneKit scene graph, material, lighting, asset, or node behavior.
+- `gameplaykit-simulation-workflow` when component systems, state machines, agents, pathfinding, or randomization are on the hot path.
+- `apple-dev-skills:xcode-testing-workflow` for Instruments, `xctrace`, XCTest, UI test, or trace interpretation mechanics.
+- `apple-dev-skills:xcode-build-run-workflow` for schemes, build configurations, run destinations, and project settings.
+- Future `metal-game-rendering-workflow` when the fix requires shader code, render-pass architecture, Metal resource layout, command encoding, GPU counters, or Metal debugger workflow beyond profiling triage.
+
+## Output Shape
+
+Return the symptom, evidence path, build/run configuration, trace or HUD evidence collected, likely bottleneck class, recommended owner skill, and any manual device or profiling gaps.

--- a/plugins/game-dev-skills/skills/xcode-game-profiling-workflow/agents/openai.yaml
+++ b/plugins/game-dev-skills/skills/xcode-game-profiling-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Xcode Game Profiling"
+  short_description: "Xcode game profiling guidance."
+  default_prompt: "Use $xcode-game-profiling-workflow for Apple game profiling, frame pacing, stutter triage, Game Performance and Game Memory templates, Metal Performance HUD routing, xctrace evidence, and CPU/GPU handoffs."

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "7.8.0"
+version = "7.9.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "7.8.0"
+version = "7.9.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "7.8.0"
+version = "7.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "7.8.0"
+version = "7.9.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add the Socket-hosted game-dev-skills plugin with SpriteKit, SceneKit, GameplayKit, Game Controller, Core Haptics, profiling, and stack-selection workflows
- wire the plugin into the root marketplace, README, contributor guide, roadmap, and maintainer plan
- bump shared Socket release surfaces to 7.9.0

## Verification
- uv run python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/game-dev-skills/skills/gameplaykit-simulation-workflow
- uv run python /Users/galew/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/game-dev-skills/skills/xcode-game-profiling-workflow
- uv run python /Users/galew/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/game-dev-skills
- uv run scripts/validate_socket_metadata.py
- uv run mypy
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `game-dev-skills` catalog plugin with Apple game-development guidance, including workflow coverage for SpriteKit, SceneKit, GameplayKit, controller input, haptics, and profiling.
  * Expanded the catalog with a new maintainer plan and roadmap milestone for the game-dev skills plugin.

* **Documentation**
  * Updated contributor and README docs to include the new plugin in catalog and marketplace listings.

* **Chores**
  * Bumped package/plugin versions across multiple existing plugins to `7.9.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->