### PR TITLE
plugin: add cloud deployment routing skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -54,6 +54,18 @@
       "category": "Productivity"
     },
     {
+      "name": "cloud-deployment-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cloud-deployment-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "dotnet-skills",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Currently available from the catalog:
 - `android-dev-skills`
 - `apple-dev-skills`
 - `cardhop-app`
+- `cloud-deployment-skills`
 - `codex-utilities`
 - `dotnet-skills`
 - `game-dev-skills`
@@ -111,6 +112,7 @@ Current Socket catalog shape:
 - `android-dev-skills`: Android, Kotlin, Java, Gradle, Android Gradle Plugin, Compose/XML UI, testing, lint, emulator-aware validation handoff, and release-readiness workflow guidance
 - `apple-dev-skills`: Apple, Swift, SwiftUI animation and architecture, Core Animation, Apple typography, SF Symbols, AppKit, Xcode, strict media type selection for AVFoundation, AVFAudio, Core Media, Core Audio, Audio Toolbox, Swift OpenAPI client, Safari, DocC workflows, and the source-bundled `swift-steward` custom-agent definition with its own roadmap
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
+- `cloud-deployment-skills`: cloud provider deployment routing, official provider plugin selection, credential and mutation boundary checks, and AWS handoff to the official AWS Agent Toolkit rather than duplicated AWS MCP, CLI, or SAM setup
 - `codex-utilities`: local Codex runtime utilities, starting with hooks that prefix generated Codex thread titles with the project directory name
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `game-dev-skills`: Apple platform game development workflows for SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics feedback, Xcode game profiling, game-stack routing, and device-aware validation handoffs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@
 - [Milestone 18: Swift Lang shared language plugin](#milestone-18-swift-lang-shared-language-plugin)
 - [Milestone 19: Project audit skills plugin](#milestone-19-project-audit-skills-plugin)
 - [Milestone 20: Game Dev Skills plugin](#milestone-20-game-dev-skills-plugin)
+- [Milestone 21: Cloud Deployment Skills plugin](#milestone-21-cloud-deployment-skills-plugin)
 - [Small Tickets](#small-tickets)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
@@ -55,6 +56,7 @@
 - Milestone 18: Swift Lang shared language plugin - Completed
 - Milestone 19: Project audit skills plugin - Planned
 - Milestone 20: Game Dev Skills plugin - Completed
+- Milestone 21: Cloud Deployment Skills plugin - Completed
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -629,6 +631,37 @@ Completed
 - [x] Root Socket docs, marketplace wiring, and validation agree on the exported game-dev skill surface.
 
 Completed Milestone 20 by adding the `game-dev-skills` child plugin, shipping the Apple-platform game-development workflow slices, wiring the Socket marketplace entry, documenting the plugin boundary, and validating skill metadata, plugin metadata, and root marketplace wiring. Metal rendering and shader architecture remain planned as a later dedicated slice.
+
+## Milestone 21: Cloud Deployment Skills plugin
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add a thin Socket-hosted `cloud-deployment-skills` child plugin for cloud provider routing, official provider plugin selection, credential and mutation boundary checks, and cross-provider deployment handoffs.
+- [x] Delegate AWS MCP configuration, AWS CLI setup, AWS SAM setup, and curated AWS skill content to the official [`aws/agent-toolkit-for-aws`](https://github.com/aws/agent-toolkit-for-aws) marketplace and its `aws-core` plugin.
+- [x] Keep framework-specific deployment implementation in the owning stack plugins, such as Server-Side Swift Fly.io deployment guidance.
+- [x] Keep the first Socket slice guidance-only: do not bundle AWS MCP config, copied AWS skills, credential setup scripts, provider templates, or local cloud state.
+
+### Tickets
+
+- [x] Record the detailed plan in [`docs/maintainers/cloud-deployment-skills-plugin-plan.md`](./docs/maintainers/cloud-deployment-skills-plugin-plan.md).
+- [x] Create `plugins/cloud-deployment-skills/` with `.codex-plugin/plugin.json`, `AGENTS.md`, an icon asset, and authored `skills/` source.
+- [x] Add `cloud-deployment-skills:cloud-deployment-routing-workflow` for provider routing, AWS Agent Toolkit handoff, mutation boundaries, and validation choices.
+- [x] Wire `cloud-deployment-skills` into the root Socket marketplace as an installable child plugin.
+- [x] Update root README and ROADMAP so users understand the new plugin surface and the AWS delegation decision.
+- [x] Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+
+### Exit Criteria
+
+- [x] The Socket marketplace exposes `cloud-deployment-skills` as an installable child plugin.
+- [x] AWS work routes to the official AWS Agent Toolkit for AWS by default instead of duplicated Socket-owned AWS MCP, AWS CLI, or AWS SAM setup guidance.
+- [x] The plugin boundary is clear enough for future provider slices without absorbing framework-specific deployment workflows.
+- [x] Root Socket docs, marketplace wiring, and validation agree on the exported cloud-deployment skill surface.
+
+Completed Milestone 21 by adding the `cloud-deployment-skills` child plugin, shipping the provider-routing workflow, wiring the Socket marketplace entry, documenting the AWS Agent Toolkit delegation, and keeping future provider expansion scoped to small official-tool routing slices.
 
 ## Small Tickets
 

--- a/docs/maintainers/cloud-deployment-skills-plugin-plan.md
+++ b/docs/maintainers/cloud-deployment-skills-plugin-plan.md
@@ -1,0 +1,34 @@
+# Cloud Deployment Skills Plugin Plan
+
+## Purpose
+
+Add a thin Socket-owned cloud deployment routing plugin without duplicating first-party provider agent tooling.
+
+The first practical use case is AWS. AWS now publishes the official [`aws/agent-toolkit-for-aws`](https://github.com/aws/agent-toolkit-for-aws) Codex marketplace, and its `aws-core` plugin bundles AWS MCP Server configuration plus curated AWS skills. Socket should route users there instead of carrying copied AWS CLI, AWS SAM CLI, or AWS MCP setup guidance.
+
+## Ownership
+
+- `cloud-deployment-skills` owns provider selection, official-tool routing, credential and mutation boundary checks, and cross-provider deployment handoffs.
+- AWS owns the AWS Agent Toolkit, AWS MCP Server configuration, and AWS skill content.
+- Stack plugins keep framework-specific deployment details, such as Server-Side Swift Fly.io deploy workflows.
+
+## First Slice
+
+- Add `plugins/cloud-deployment-skills/`.
+- Add one skill: `cloud-deployment-routing-workflow`.
+- Wire the plugin into the root Socket marketplace.
+- Update root README and ROADMAP so the install surface is visible and the AWS delegation decision is durable.
+- Keep the plugin guidance-only. Do not bundle `.mcp.json` for AWS.
+
+## Future Slices
+
+- Add Cloudflare deployment routing if Socket needs guidance beyond existing Cloudflare docs and tooling.
+- Add Vercel deployment routing if web project handoffs need a first-party Socket decision layer.
+- Add Fly.io provider-neutral routing only if the existing Server-Side Swift workflow is too narrow for non-Swift projects.
+- Add Terraform, Pulumi, CDK, Azure, or GCP slices only after concrete project use proves that official provider docs or plugins are not enough.
+
+## Validation
+
+- Run root metadata validation with `uv run scripts/validate_socket_metadata.py`.
+- Run `git diff --check`.
+- For release, follow the standard Socket release mode because this is a monorepo-owned child plugin with no subtree synchronization requirement.

--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Apple development workflows for Codex, including media and audio repair, Xcode coding intelligence, SwiftUI animation and architecture, Core Animation, Apple typography, SF Symbols, AppKit architecture, Icon Composer app icons, Safari extensions, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "7.9.0"
+version = "7.10.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "7.9.0"
+version = "7.10.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,0 +1,46 @@
+{
+  "name": "cloud-deployment-skills",
+  "version": "7.9.0",
+  "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "homepage": "https://github.com/gaelic-ghost/socket/tree/main/plugins/cloud-deployment-skills",
+  "repository": "https://github.com/gaelic-ghost/socket",
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "keywords": [
+    "codex",
+    "plugin",
+    "skills",
+    "cloud",
+    "deployment",
+    "aws",
+    "agent-toolkit",
+    "mcp",
+    "cloudflare",
+    "vercel",
+    "fly.io"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cloud Deployment Skills",
+    "shortDescription": "Cloud provider and deployment routing guidance for Codex.",
+    "longDescription": "Guide Codex agents through cloud deployment routing, official provider plugin selection, credential and mutation safety checks, and provider handoffs. The first slice delegates AWS work to the official AWS Agent Toolkit for AWS and keeps Socket focused on thin cross-provider deployment decisions instead of duplicating AWS MCP, AWS CLI, or AWS SAM setup.",
+    "developerName": "gaelic-ghost",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/cloud-deployment-skills",
+    "defaultPrompt": [
+      "Choose the right cloud deployment path and route AWS work through the official AWS Agent Toolkit when appropriate.",
+      "Decide whether this deployment should use an official provider plugin, provider CLI, MCP server, framework-owned deploy workflow, or a Socket-owned provider skill."
+    ],
+    "brandColor": "#22D3EE",
+    "composerIcon": "./assets/cloud-deployment-icon.svg",
+    "logo": "./assets/cloud-deployment-icon.svg"
+  }
+}

--- a/plugins/cloud-deployment-skills/AGENTS.md
+++ b/plugins/cloud-deployment-skills/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+This file is the Cloud Deployment Skills child-repo override for work done from `socket`. Follow the root `socket` guidance for general git, docs, release, branch, dependency-provenance, and maintainer workflow rules.
+
+## Scope
+
+- `cloud-deployment-skills` is a monorepo-owned Socket child and the canonical source of truth for shipped cloud-provider deployment routing skills.
+- Root [`skills/`](./skills/) is the authored workflow surface.
+- The repo root is the Codex plugin root through [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+- Keep this plugin focused on provider selection, official-tool routing, deployment readiness, and cross-provider handoffs.
+- Keep framework-specific application implementation in the owning stack plugins such as `server-side-swift`, `web-dev-skills`, `python-skills`, `dotnet-skills`, `rust-skills`, and `server-side-jvm`.
+
+## Local Rules
+
+- Match the `socket` shared semantic version exactly; use the Socket root release workflow for version inventory and bumps.
+- Prefer official provider plugins, MCP servers, CLIs, and docs before adding Socket-authored setup guidance.
+- For AWS work, route Codex users to the official `aws/agent-toolkit-for-aws` marketplace and its `aws-core` plugin before considering Socket-owned AWS guidance.
+- Do not bundle AWS MCP configuration, AWS CLI setup instructions, AWS SAM setup instructions, or copied AWS Agent Toolkit skills in this plugin while the official AWS plugin owns that surface.
+- Treat provider credentials, account configuration, API mutation, billing, and production deployment as high-impact operations. Verify the target account, region, profile, project, and intended mutation before taking action.
+- Keep provider-specific skills small and explicit. Add a new provider workflow only when it removes real routing ambiguity or covers a provider that does not already offer a first-party agent plugin.
+- Do not commit machine-local credentials, profiles, `.env` files, cloud state, generated deployment artifacts, or local cache paths.
+- Use repo-local files, checked-out provider config, provider CLIs, and official provider documentation before making claims about current deployment behavior.

--- a/plugins/cloud-deployment-skills/assets/cloud-deployment-icon.svg
+++ b/plugins/cloud-deployment-skills/assets/cloud-deployment-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Cloud Deployment Skills icon</title>
+  <desc id="desc">Neon cloud deployment badge with angular network paths.</desc>
+  <rect width="256" height="256" rx="28" fill="#070814"/>
+  <path d="M28 68h200M28 100h200M28 132h200M28 164h200M28 196h200" stroke="#14213d" stroke-width="2"/>
+  <circle cx="128" cy="128" r="88" fill="none" stroke="#7c3aed" stroke-width="8"/>
+  <path d="M75 143c-16 0-29-11-29-26 0-13 10-24 23-26 7-22 28-38 53-38 31 0 56 23 59 52 18 3 31 18 31 36 0 20-16 36-36 36H75Z" fill="#0b1220" stroke="#22d3ee" stroke-width="8" stroke-linejoin="round"/>
+  <path d="M83 137h37l18-24 20 35h22" fill="none" stroke="#f472b6" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M89 178l-20 21M128 178v32M167 178l20 21" stroke="#a78bfa" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="69" cy="199" r="7" fill="#22d3ee"/>
+  <circle cx="128" cy="213" r="7" fill="#f472b6"/>
+  <circle cx="187" cy="199" r="7" fill="#22d3ee"/>
+</svg>

--- a/plugins/cloud-deployment-skills/skills/cloud-deployment-routing-workflow/SKILL.md
+++ b/plugins/cloud-deployment-skills/skills/cloud-deployment-routing-workflow/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: cloud-deployment-routing-workflow
+description: Choose the right cloud deployment path before implementation, routing AWS work through the official AWS Agent Toolkit for AWS when appropriate and keeping provider credentials, regions, and mutation boundaries explicit.
+license: PolyForm-Noncommercial-1.0.0
+compatibility: Designed for Codex and compatible Agent Skills clients working with cloud deployments, provider CLIs, provider plugins, MCP servers, and repository-owned deployment configuration.
+metadata:
+  owner: gaelic-ghost
+  repo: socket
+  category: cloud-deployment-routing
+allowed-tools: Read Bash(rg:*) Bash(git:*) Bash(codex:*) Bash(aws:*) Bash(uv:*) Bash(uvx:*)
+---
+
+# Cloud Deployment Routing Workflow
+
+## Purpose
+
+Choose the smallest correct cloud deployment path before changing infrastructure, credentials, or production-facing configuration.
+
+The practical decision is whether the agent should use an official provider plugin, a provider MCP server, a provider CLI, a framework-owned deployment workflow, or a Socket-owned provider skill.
+
+## When To Use
+
+- Use this skill when the user wants cloud deployment help and has not chosen a provider-owned workflow.
+- Use this skill when a project mentions AWS, Cloudflare, Vercel, Fly.io, Azure, GCP, Terraform, Pulumi, CDK, CloudFormation, SAM, containers, serverless, hosting, DNS, secrets, deployment, or production infrastructure.
+- Use this skill before adding provider credentials, changing cloud resources, deploying production services, or wiring new MCP server configuration.
+- Use this skill when an official provider plugin may already own the requested work.
+
+## Source Check
+
+Use repo-local deployment files, checked-out provider config, installed provider CLIs, official provider plugins, and official provider documentation before making claims about current deployment behavior:
+
+- [Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws)
+- [AWS Agent Toolkit plugins](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/plugins.html)
+- [AWS MCP Server setup](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/)
+- [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html)
+
+Translate any documentation rule into the concrete repository decision it changes.
+
+## Routing Workflow
+
+1. Inspect the project shape:
+   - deployment manifests such as `template.yaml`, `serverless.yml`, `cloudformation.yml`, `cdk.json`, `samconfig.toml`, `wrangler.toml`, `vercel.json`, `fly.toml`, `Dockerfile`, `compose.yaml`, Terraform, or Pulumi files
+   - package scripts, Make targets, CI workflows, release docs, and provider-specific README sections
+   - existing credentials guidance, environment variables, account aliases, regions, profiles, and secret names
+2. Identify the deployment job:
+   - provider selection
+   - local credential setup
+   - documentation lookup
+   - infrastructure planning
+   - preview or diff
+   - dev/staging deploy
+   - production deploy
+   - failure triage
+   - cost, IAM, observability, or rollback review
+3. Route AWS work first:
+   - Prefer the official AWS Agent Toolkit for AWS for Codex when the task is general AWS discovery, AWS MCP access, AWS CLI or AWS SAM setup, CDK, CloudFormation, serverless, containers, storage, observability, billing, SDK usage, or deployment.
+   - Install path for Codex users:
+
+     ```bash
+     codex plugin marketplace add aws/agent-toolkit-for-aws
+     ```
+
+     Then use `/plugins` in Codex to install `aws-core`.
+   - Do not duplicate AWS MCP configuration in Socket while `aws-core` bundles that configuration.
+   - Do not copy AWS Agent Toolkit skills into Socket.
+4. Route non-AWS work:
+   - Use a first-party provider plugin or MCP server when one exists and is current.
+   - Use framework-owned Socket skills when the deployment surface is already covered by a stack workflow, such as `server-side-swift:fly-io-deployment-workflow`.
+   - Add or use a Socket-owned provider skill only when no official provider-owned agent surface exists or when Socket needs a small provider-neutral decision layer.
+5. Confirm mutation boundaries:
+   - account or organization
+   - project or app
+   - region
+   - profile or identity
+   - environment such as local, dev, staging, or production
+   - exact resource mutations
+   - expected cost or billing effect
+   - rollback or cleanup path
+6. Choose validation:
+   - read-only documentation or discovery query for planning
+   - provider CLI version and auth check for local setup
+   - plan, diff, dry-run, validate, package, or synth command before deploy
+   - smoke test, logs, metrics, and rollback checks after deploy
+
+## Recommendations
+
+### AWS
+
+Use the official AWS Agent Toolkit for AWS as the default Codex path. It owns AWS MCP setup and the curated AWS skill set, including common deployment, CDK, CloudFormation, serverless, container, storage, observability, billing, and SDK workflows.
+
+Use Socket only for the routing decision, local repo handoff, and any project-specific deployment guardrails that the official AWS plugin does not know.
+
+### Framework-Owned Deployments
+
+When a stack plugin already owns a deployment path, use that plugin for stack-specific implementation details. For example, Fly.io deployment for Vapor or Hummingbird services belongs in `server-side-swift` because that workflow depends on Swift package, Dockerfile, health-check, and runtime conventions.
+
+### Future Provider Skills
+
+Add future provider skills as small routing or implementation slices. Good candidates include Cloudflare, Vercel, Fly.io, Azure, GCP, Terraform, Pulumi, and CDK when an official provider plugin does not already give Codex a better maintained path.
+
+## Output Shape
+
+Return:
+
+1. `Provider`: AWS, Cloudflare, Vercel, Fly.io, Azure, GCP, multi-cloud, or undecided.
+2. `Primary surface`: official provider plugin, MCP server, provider CLI, framework-owned skill, Socket provider skill, or user decision needed.
+3. `Credential boundary`: account, region, profile, environment, and whether credentials are required for the next step.
+4. `Mutation boundary`: read-only, plan/diff, staging deploy, production deploy, cleanup, or blocked.
+5. `Validation path`: exact commands or agent checks to run before and after mutation.
+6. `Next handoff`: official plugin install, provider docs, stack skill, or provider-specific Socket backlog item.
+
+## Guardrails
+
+- Do not invent provider setup steps when an official provider plugin or current provider docs own the path.
+- Do not configure or mutate cloud accounts without confirming account, region, profile, environment, and intended resource changes.
+- Do not store credentials, tokens, account IDs, secrets, local profiles, or `.env` files in git.
+- Do not present an AWS CLI, AWS SAM CLI, or AWS MCP setup path as Socket-owned while AWS Agent Toolkit owns the official Codex path.
+- Do not deploy to production by default. Use planning, validation, and explicit user confirmation before production mutations.

--- a/plugins/codex-utilities/.codex-plugin/plugin.json
+++ b/plugins/codex-utilities/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-utilities",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "7.9.0"
+version = "7.10.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "7.9.0"
+version = "7.10.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "7.9.0"
+version = "7.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add the installable cloud-deployment-skills child plugin
- route AWS work to the official AWS Agent Toolkit instead of duplicating AWS MCP, CLI, or SAM setup
- bump shared Socket version surfaces to 7.10.0

## Verification
- uv run scripts/validate_socket_metadata.py
- scripts/release.sh inventory
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cloud deployment skills plugin to the marketplace, making it available for installation.
  * Included a new cloud deployment routing skill to help guide deployment tasks and handoffs.

* **Documentation**
  * Updated the README and roadmap with the new plugin and its current status.
  * Added maintainer guidance describing cloud deployment routing, boundaries, and validation steps.

* **Chores**
  * Bumped the project and multiple plugin/package versions to `7.10.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->