### PR TITLE
docs: update Icon Composer 1.6 guidance

### DIFF
--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/agentdeck/.codex-plugin/plugin.json
+++ b/plugins/agentdeck/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentdeck",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Apple development workflows for Codex, including media and audio repair, Xcode coding intelligence, SwiftUI animation and architecture, Core Animation, Apple typography, SF Symbols, AppKit architecture, Icon Composer app icons, Safari extensions, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "8.2.1"
+version = "8.2.2"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/icon-composer-app-icon-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/icon-composer-app-icon-workflow/SKILL.md
@@ -62,7 +62,7 @@ Before a live workflow, inspect the Mac and report what is available:
    `/Applications/Xcode-beta.app/Contents/Applications/Icon Composer.app/Contents/Executables/ictool`
    `/Applications/Betas/Xcode-beta.app/Contents/Applications/Icon Composer.app/Contents/Executables/ictool`
 7. Run `ictool --help` or `ictool --version` when preview export is part of the task.
-8. Record the local Icon Composer app version when behavior matters. On Gale's current stable Xcode, Icon Composer 1.6 reports `short-bundle-version` `1.6` and `bundle-version` `99.1`; the installed Xcode beta reports Icon Composer 2.0 and may expose newer options.
+8. Record the local Icon Composer app version when behavior matters. Stable Icon Composer 1.6 reports `short-bundle-version` `1.6` and `bundle-version` `99.1`; a newer Xcode beta may report Icon Composer 2.0 and expose newer options.
 9. Identify the target app project shape before promising Xcode integration.
 
 Do not assume Icon Composer exists just because Xcode exists. Older Xcode installs, alternate Xcode locations, or standalone Icon Composer installs can change the path.

--- a/plugins/apple-dev-skills/skills/icon-composer-app-icon-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/icon-composer-app-icon-workflow/SKILL.md
@@ -39,10 +39,11 @@ State the documented behavior being relied on before recommending a design, expo
 Current documented anchors to verify against the live docs:
 
 - Icon Composer creates layered app icons from one design for iPhone, iPad, Mac, and Apple Watch.
-- The workflow starts in a design tool, exports layers, imports them into Icon Composer, tunes glass properties, previews platforms and appearance modes, saves a `.icon` file, and delivers that file to Xcode.
+- The workflow starts in a design tool, exports layers, imports them into Icon Composer, tunes glass properties, previews platforms and rendering modes, saves a `.icon` file, and delivers that file to Xcode.
 - Icon Composer can export flattened images for marketing and communication needs, but the `.icon` file is the primary app icon production artifact when Xcode supports it.
 - Flat graphics should usually be exported as scalable SVG when possible. Custom gradients, raster images, and non-SVG elements should be exported as PNGs with transparent backgrounds.
 - Complex or illustrative icons may still be better delivered to Xcode as individual images when the artwork does not translate well into the layered Liquid Glass model.
+- Apple's current Icon Composer page names specular highlights, refraction, translucency, shadows, Default, Dark, and Mono rendering-mode annotation. Verify those names against the live page and local app before coaching a user through exact inspector controls.
 
 ## Local Tool Check
 
@@ -61,9 +62,11 @@ Before a live workflow, inspect the Mac and report what is available:
    `/Applications/Xcode-beta.app/Contents/Applications/Icon Composer.app/Contents/Executables/ictool`
    `/Applications/Betas/Xcode-beta.app/Contents/Applications/Icon Composer.app/Contents/Executables/ictool`
 7. Run `ictool --help` or `ictool --version` when preview export is part of the task.
-8. Identify the target app project shape before promising Xcode integration.
+8. Record the local Icon Composer app version when behavior matters. On Gale's current stable Xcode, Icon Composer 1.6 reports `short-bundle-version` `1.6` and `bundle-version` `99.1`; the installed Xcode beta reports Icon Composer 2.0 and may expose newer options.
+9. Identify the target app project shape before promising Xcode integration.
 
 Do not assume Icon Composer exists just because Xcode exists. Older Xcode installs, alternate Xcode locations, or standalone Icon Composer installs can change the path.
+Do not mix stable and beta behavior. If stable Icon Composer 1.6 and beta Icon Composer 2.0 disagree, say which app bundle was inspected and keep guidance scoped to that version unless the user explicitly asks to compare them.
 
 ## Brief Intake
 
@@ -162,8 +165,8 @@ Use this sequence for real icon work:
 4. Open Icon Composer through Computer Use only when the user wants GUI help.
 5. Import layers and preserve their visual order.
 6. Organize related layers into groups when the live app supports it.
-7. Tune Liquid Glass, color, composition, and appearance-mode settings in the GUI.
-8. Preview the icon across target platforms, appearances, sizes, backgrounds, and grid overlays.
+7. Tune Liquid Glass, color, composition, and rendering-mode settings in the GUI. For Icon Composer 1.6, expect controls around specular highlights, refraction, translucency, shadows, and light behavior; confirm exact labels in the live app before narrating a GUI step.
+8. Preview the icon across target platforms, rendering modes, sizes, backgrounds, and grid overlays.
 9. Save the `.icon` document as the durable app icon artifact.
 10. Export PNG previews through Icon Composer or `ictool` for review artifacts.
 11. Hand off Xcode project integration to the Xcode workflow skills.
@@ -189,13 +192,15 @@ Example shape:
 ```
 
 Discover exact platform and rendition values from current `ictool --help`, Apple docs, or live errors. Do not hard-code assumptions beyond examples.
+For Icon Composer 1.6, stable `ictool --help` documents optional `--light-angle`, `--tint-color`, and `--tint-strength` export arguments. Treat those as render-export controls only; do not imply they are a substitute for inspecting and saving the `.icon` document in Icon Composer.
+For newer beta `ictool` builds, inspect `--help` again before using beta-only flags such as `--design-generation`.
 
 Use preview exports to:
 
 - compare variants
 - attach review artifacts
 - check legibility at multiple sizes
-- validate default, dark, clear, tinted, mono, or other current appearances when supported
+- validate Default, Dark, Mono, tinted, or other current renditions when supported by the inspected `ictool` build
 - preserve a visual record before Xcode integration
 
 ## Xcode Integration Handoff

--- a/plugins/apple-dev-skills/tests/test_xcode_toolchain_selection_guidance.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_toolchain_selection_guidance.py
@@ -44,6 +44,22 @@ class XcodeToolchainSelectionGuidanceTests(unittest.TestCase):
         )
         self.assertNotIn("/Users/galew/Applications/Betas", text)
 
+    def test_icon_composer_documents_stable_1_6_and_beta_2_0_boundaries(self) -> None:
+        text = self.read("skills/icon-composer-app-icon-workflow/SKILL.md")
+
+        for term in [
+            "Icon Composer 1.6",
+            "bundle-version` `99.1",
+            "Icon Composer 2.0",
+            "Do not mix stable and beta behavior",
+            "--light-angle",
+            "--tint-color",
+            "--tint-strength",
+            "--design-generation",
+        ]:
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "8.2.1"
+version = "8.2.2"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-inference-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-inference-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-inference-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Cloud AI inference workflow skills for routing model serving, training, conversion, and GPU infrastructure work across Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/network-protocol-skills/.codex-plugin/plugin.json
+++ b/plugins/network-protocol-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "network-protocol-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for choosing, planning, implementing, and diagnosing modern application transports and real-time networking protocols, including QUIC, HTTP/3, WebRTC, Media over QUIC, WebTransport-adjacent handoffs, protocol maturity checks, and stack-specific implementation routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "8.2.1"
+version = "8.2.2"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "8.2.1"
+version = "8.2.2"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "8.2.1"
+version = "8.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "8.2.1"
+version = "8.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- update Icon Composer workflow guidance for stable Icon Composer 1.6 behavior
- distinguish stable 1.6 from beta 2.0 guidance and document current ictool flags
- bump shared Socket version surfaces to 8.2.2 for the patch release

## Verification
- uv run pytest plugins/apple-dev-skills/tests/test_xcode_toolchain_selection_guidance.py
- uv run scripts/validate_socket_metadata.py
- bash plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the overall release version from 8.2.1 to 8.2.2 across the project and multiple plugins.
  * Updated matching package/manifest versions so everything stays in sync.

* **Documentation**
  * Expanded Apple icon workflow guidance with clearer, version-specific instructions for stable vs. beta tool behavior and export options.

* **Tests**
  * Added coverage to ensure the updated workflow guidance includes the expected version boundaries and key terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->