### PR TITLE
plugin: use app-named entitlement files

### DIFF
--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/agentdeck/.codex-plugin/plugin.json
+++ b/plugins/agentdeck/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentdeck",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Apple development workflows for Codex, including media and audio repair, XcodeGen migration, Xcode coding intelligence, SwiftUI animation and architecture, Core Animation, Apple typography, SF Symbols, AppKit architecture, Icon Composer app icons, Safari extensions, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC authoring guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "8.5.0"
+version = "8.5.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py
+++ b/plugins/apple-dev-skills/skills/bootstrap-xcode-app-project/scripts/bootstrap_xcode_app_project.py
@@ -16,7 +16,7 @@ from pathlib import Path
 XCODEGEN_TEMPLATE_DIR = Path(__file__).resolve().parents[3] / "templates" / "xcodegen" / "swiftui-app"
 XCODEGEN_TEMPLATE_OUTPUTS = {
     "project.yml.tmpl": "project.yml",
-    "Sources/Support/App.entitlements.tmpl": "Sources/Support/App.entitlements",
+    "Sources/Support/App.entitlements.tmpl": "Sources/Support/__APP_NAME__.entitlements",
     "Sources/Resources/Assets.xcassets/Contents.json.tmpl": "Sources/Resources/Assets.xcassets/Contents.json",
     "Sources/Resources/Assets.xcassets/AccentColor.colorset/Contents.json.tmpl": "Sources/Resources/Assets.xcassets/AccentColor.colorset/Contents.json",
     "Sources/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json.tmpl": "Sources/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json",
@@ -80,7 +80,10 @@ def install_xcodegen_templates(target_dir: Path, name: str, platform: str, bundl
     }
     installed_paths: list[str] = []
     for template_relative_path, output_relative_path in XCODEGEN_TEMPLATE_OUTPUTS.items():
-        output_path = target_dir / output_relative_path
+        rendered_output_relative_path = output_relative_path
+        for placeholder, value in replacements.items():
+            rendered_output_relative_path = rendered_output_relative_path.replace(placeholder, value)
+        output_path = target_dir / rendered_output_relative_path
         write_text(output_path, render_template(template_relative_path, replacements))
         installed_paths.append(str(output_path))
     return installed_paths

--- a/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/SKILL.md
+++ b/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/SKILL.md
@@ -50,7 +50,7 @@ Convert existing native Apple app projects to the current XcodeGen baseline with
 6. Prepare the migration branch:
    - add or update `project.yml`
    - add or update `Configurations/*.xcconfig`
-   - add or update `Sources/Support/App.entitlements`
+   - add or update `Sources/Support/<AppName>.entitlements`
    - add or update `Sources/Support/Info.plist`
    - add or update `Sources/Resources/Assets.xcassets`
    - preserve existing package, framework, source, resource, script phase, scheme, and test-plan state

--- a/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/references/migration-audit-and-promotion.md
+++ b/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/references/migration-audit-and-promotion.md
@@ -8,7 +8,7 @@ Use this reference after `scripts/run_workflow.py` has produced a project audit.
 - Promote durable settings into checked-in files before regenerating:
   - `project.yml` for project structure, targets, packages, source roots, resource roots, schemes, and test plans
   - `Configurations/*.xcconfig` for build settings
-  - `Sources/Support/App.entitlements` for capabilities and sandbox entitlements
+  - `Sources/Support/<AppName>.entitlements` for capabilities and sandbox entitlements
   - `Sources/Support/Info.plist` for Info.plist values
   - `Sources/Resources/Assets.xcassets` for assets, app icons, accent colors, and generated asset symbols
 - Keep `xcodegen generate` as the last step after promotion, not the first step.

--- a/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/scripts/migrate_xcode_project_to_xcodegen.py
+++ b/plugins/apple-dev-skills/skills/migrate-xcode-project-to-xcodegen/scripts/migrate_xcode_project_to_xcodegen.py
@@ -32,7 +32,7 @@ BASELINE_PROJECT_YML_NEEDLES = {
     "synced_folder_sources": "type: syncedFolder",
     "config_files": "configFiles:",
     "resources_root": "Sources/Resources",
-    "app_entitlements": "Sources/Support/App.entitlements",
+    "support_files": "Sources/Support",
     "version_marketing": "CFBundleShortVersionString: $(MARKETING_VERSION)",
     "version_build": "CFBundleVersion: $(CURRENT_PROJECT_VERSION)",
 }
@@ -112,6 +112,17 @@ def extract_pbxproj_target_names(pbxproj_text: str) -> list[str]:
     return sorted(cleaned)
 
 
+def infer_app_name(discovered: dict[str, Any], target_names: list[str]) -> str | None:
+    if target_names:
+        app_targets = [name for name in target_names if not name.lower().endswith(("tests", "uitests"))]
+        return app_targets[0] if app_targets else target_names[0]
+    if discovered["project"]:
+        return Path(discovered["project"]).stem
+    if discovered["workspace"]:
+        return Path(discovered["workspace"]).stem
+    return None
+
+
 def audit_project_yml(project_yml_path: Path | None) -> dict[str, Any]:
     if not project_yml_path or not project_yml_path.exists():
         return {
@@ -131,13 +142,16 @@ def audit_project_yml(project_yml_path: Path | None) -> dict[str, Any]:
     }
 
 
-def audit_files(repo_root: Path) -> dict[str, Any]:
+def audit_files(repo_root: Path, app_name: str | None) -> dict[str, Any]:
     xcconfigs = sorted(repo_root.rglob("*.xcconfig"), key=lambda item: str(item))
     entitlements = sorted(repo_root.rglob("*.entitlements"), key=lambda item: str(item))
     info_plists = sorted(path for path in repo_root.rglob("Info.plist") if path.is_file())
     asset_catalogs = sorted(repo_root.rglob("*.xcassets"), key=lambda item: str(item))
     schemes = sorted(repo_root.rglob("*.xcscheme"), key=lambda item: str(item))
     test_plans = sorted(repo_root.rglob("*.xctestplan"), key=lambda item: str(item))
+    expected_app_entitlements = (
+        f"Sources/Support/{app_name}.entitlements" if app_name else "Sources/Support/<AppName>.entitlements"
+    )
     return {
         "xcconfigs": sorted_relative(xcconfigs, repo_root),
         "entitlements": sorted_relative(entitlements, repo_root),
@@ -145,7 +159,8 @@ def audit_files(repo_root: Path) -> dict[str, Any]:
         "asset_catalogs": sorted_relative(asset_catalogs, repo_root),
         "schemes": sorted_relative(schemes, repo_root),
         "test_plans": sorted_relative(test_plans, repo_root),
-        "has_default_app_entitlements": (repo_root / "Sources/Support/App.entitlements").exists(),
+        "expected_app_entitlements": expected_app_entitlements,
+        "has_app_named_entitlements": (repo_root / expected_app_entitlements).exists() if app_name else False,
         "has_default_assets": (repo_root / "Sources/Resources/Assets.xcassets").exists(),
     }
 
@@ -190,8 +205,10 @@ def build_recommendations(
         recommendations.append("Promote pbxproj build settings into .xcconfig owners: " + ", ".join(pbxproj_settings) + ".")
     if not file_audit["xcconfigs"]:
         recommendations.append("Add checked-in Configurations/*.xcconfig layers before preserving build settings.")
-    if not file_audit["has_default_app_entitlements"]:
-        recommendations.append("Add Sources/Support/App.entitlements and wire CODE_SIGN_ENTITLEMENTS through the app .xcconfig.")
+    if not file_audit["has_app_named_entitlements"]:
+        recommendations.append(
+            f"Add {file_audit['expected_app_entitlements']} and wire CODE_SIGN_ENTITLEMENTS through the app .xcconfig."
+        )
     if not file_audit["has_default_assets"]:
         recommendations.append("Add Sources/Resources/Assets.xcassets with AppIcon and AccentColor placeholders.")
     return recommendations
@@ -256,8 +273,10 @@ def main() -> int:
     pbxproj_path = repo_root / discovered["pbxproj"] if discovered["pbxproj"] else None
     pbxproj_text = read_text(pbxproj_path) if pbxproj_path else ""
     project_yml_path = repo_root / discovered["project_yml"] if discovered["project_yml"] else None
+    target_names = extract_pbxproj_target_names(pbxproj_text)
+    app_name = infer_app_name(discovered, target_names)
     project_yml_audit = audit_project_yml(project_yml_path)
-    file_audit = audit_files(repo_root)
+    file_audit = audit_files(repo_root, app_name)
     pbxproj_settings = extract_pbxproj_settings(pbxproj_text)
 
     output = {
@@ -270,7 +289,8 @@ def main() -> int:
         "file_audit": file_audit,
         "pbxproj_audit": {
             "present": bool(pbxproj_path),
-            "target_names": extract_pbxproj_target_names(pbxproj_text),
+            "inferred_app_name": app_name,
+            "target_names": target_names,
             "settings_to_promote": pbxproj_settings,
         },
         "recommended_phases": build_recommendations(migration_path or "", project_yml_audit, file_audit, pbxproj_settings),

--- a/plugins/apple-dev-skills/templates/xcodegen/swiftui-app/Configurations/App.xcconfig.tmpl
+++ b/plugins/apple-dev-skills/templates/xcodegen/swiftui-app/Configurations/App.xcconfig.tmpl
@@ -6,7 +6,7 @@ MARKETING_VERSION = 0.0.1
 CURRENT_PROJECT_VERSION = 1
 GENERATE_INFOPLIST_FILE = NO
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
-CODE_SIGN_ENTITLEMENTS = Sources/Support/App.entitlements
+CODE_SIGN_ENTITLEMENTS = Sources/Support/__APP_NAME__.entitlements
 
 // macOS signing and sandbox defaults. Keep off by default, but make GUI-created
 // capability changes easy to promote from the generated project into config.

--- a/plugins/apple-dev-skills/tests/test_xcode_app_bootstrap_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_app_bootstrap_workflow.py
@@ -204,7 +204,7 @@ exit 1
             self.assertIn("Configurations/App-Debug.xcconfig", project_yml)
             self.assertIn("Configurations/Tests-Debug.xcconfig", project_yml)
             self.assertIn("parallelizable: true", project_yml)
-            self.assertTrue((target / "Sources" / "Support" / "App.entitlements").exists())
+            self.assertTrue((target / "Sources" / "Support" / "DemoApp.entitlements").exists())
             self.assertTrue((target / "Sources" / "Resources" / "Assets.xcassets" / "Contents.json").exists())
             self.assertTrue(
                 (target / "Sources" / "Resources" / "Assets.xcassets" / "AppIcon.appiconset" / "Contents.json").exists()
@@ -232,7 +232,7 @@ exit 1
                 (target / "Configurations" / "App.xcconfig").read_text(encoding="utf-8"),
             )
             self.assertIn(
-                "CODE_SIGN_ENTITLEMENTS = Sources/Support/App.entitlements",
+                "CODE_SIGN_ENTITLEMENTS = Sources/Support/DemoApp.entitlements",
                 (target / "Configurations" / "App.xcconfig").read_text(encoding="utf-8"),
             )
             self.assertIn(

--- a/plugins/apple-dev-skills/tests/test_xcodegen_migration_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcodegen_migration_workflow.py
@@ -74,7 +74,8 @@ class XcodeGenMigrationWorkflowTests(unittest.TestCase):
             self.assertIn("CODE_SIGN_ENTITLEMENTS", output["pbxproj_audit"]["settings_to_promote"])
             self.assertIn("DEAD_CODE_STRIPPING", output["pbxproj_audit"]["settings_to_promote"])
             self.assertTrue(any("Promote pbxproj build settings" in phase for phase in output["recommended_phases"]))
-            self.assertTrue(any("Sources/Support/App.entitlements" in phase for phase in output["recommended_phases"]))
+            self.assertEqual(output["file_audit"]["expected_app_entitlements"], "Sources/Support/DemoApp.entitlements")
+            self.assertTrue(any("Sources/Support/DemoApp.entitlements" in phase for phase in output["recommended_phases"]))
 
     def test_audits_existing_xcodegen_project_for_current_baseline_gaps(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "8.5.0"
+version = "8.5.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-inference-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-inference-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-inference-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Cloud AI inference workflow skills for routing model serving, training, conversion, and GPU infrastructure work across Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/network-protocol-skills/.codex-plugin/plugin.json
+++ b/plugins/network-protocol-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "network-protocol-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for choosing, planning, implementing, and diagnosing modern application transports and real-time networking protocols, including QUIC, HTTP/3, WebRTC, Media over QUIC, WebTransport-adjacent handoffs, protocol maturity checks, and stack-specific implementation routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "8.5.0"
+version = "8.5.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "8.5.0"
+version = "8.5.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "8.5.0"
+version = "8.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "8.5.0"
+version = "8.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- generate XcodeGen bootstrap entitlement files as Sources/Support/<AppName>.entitlements
- wire CODE_SIGN_ENTITLEMENTS to the app-named entitlement file
- update the migration audit to expect <AppName>.entitlements instead of a hard-coded App.entitlements path
- bump shared Socket version surfaces to 8.5.1

## Verification
- uv run pytest plugins/apple-dev-skills/tests/test_xcode_app_bootstrap_workflow.py plugins/apple-dev-skills/tests/test_xcodegen_migration_workflow.py
- uv run pytest plugins/apple-dev-skills/tests
- uv run scripts/validate_socket_metadata.py
- uv run pytest tests
- xcodebuild build probe for generated EntitlementNameProbe scaffold