### PR TITLE
apple: add TipKit workflow guidance

### DIFF
--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-dev-skills",
   "version": "8.8.0",
-  "description": "Apple development workflows for Codex, including Apple Developer provisioning and CloudKit automation planning, SwiftData, SwiftUI architecture, media and audio repair, XcodeGen migration, Xcode coding intelligence, Core Animation, typography, SF Symbols, AppKit, Safari, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC.",
+  "description": "Apple development workflows for Codex, including Apple Developer provisioning and CloudKit automation planning, TipKit, SwiftData, SwiftUI architecture, media and audio repair, XcodeGen migration, Xcode coding intelligence, Core Animation, typography, SF Symbols, AppKit, Safari, DeviceCheck/App Attest, Swift OpenAPI clients, and DocC.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -28,6 +28,8 @@
     "agents",
     "mcp",
     "swiftui",
+    "tipkit",
+    "tooltips",
     "animation",
     "core-animation",
     "typography",
@@ -52,8 +54,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Apple Dev Skills",
-    "shortDescription": "Apple, Swift, media/audio repair, Xcode/XcodeGen, SwiftUI, Core Animation, typography, SF Symbols, AppKit, Safari, DeviceCheck, App Attest, OpenAPI client, and DocC workflows for Codex.",
-    "longDescription": "Bundle Apple-platform development skills for AVFAudio session repair, AVAudioEngine graph repair, AVFoundation media pipelines, Core Media timing and sample-buffer diagnostics, Core Audio modernization, strict Apple media type and framework selection, XcodeGen migration and modernization audits, Xcode coding intelligence setup, Xcode-hosted agents, external-agent MCP access through xcrun mcpbridge, Swift, SwiftUI animation and architecture, Core Animation layer-backed rendering and animation, Apple typography and Dynamic Type, SF Symbols selection and custom-symbol workflows, AppKit architecture, Icon Composer app icon production, Safari extension, Safari Web Inspector, SafariServices integration, DeviceCheck device-state and App Attest app-integrity planning, generated Swift OpenAPI clients with URLSession transport, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling. Most workflows work standalone; bootstrap and guidance-sync workflows that install or refresh repo-maintenance files require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
+    "shortDescription": "Apple, Swift, TipKit, media/audio repair, Xcode/XcodeGen, SwiftUI, Core Animation, typography, SF Symbols, AppKit, Safari, DeviceCheck, App Attest, OpenAPI client, and DocC workflows for Codex.",
+    "longDescription": "Bundle Apple-platform development skills for TipKit inline tips and tooltip popovers, AVFAudio session repair, AVAudioEngine graph repair, AVFoundation media pipelines, Core Media timing and sample-buffer diagnostics, Core Audio modernization, strict Apple media type and framework selection, XcodeGen migration and modernization audits, Xcode coding intelligence setup, Xcode-hosted agents, external-agent MCP access through xcrun mcpbridge, Swift, SwiftUI animation and architecture, Core Animation layer-backed rendering and animation, Apple typography and Dynamic Type, SF Symbols selection and custom-symbol workflows, AppKit architecture, Icon Composer app icon production, Safari extension, Safari Web Inspector, SafariServices integration, DeviceCheck device-state and App Attest app-integrity planning, generated Swift OpenAPI clients with URLSession transport, Xcode, SwiftPM, DocC authoring and review, testing, formatting, and repository guidance work across iOS, macOS, and related Apple tooling. Most workflows work standalone; bootstrap and guidance-sync workflows that install or refresh repo-maintenance files require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -77,6 +79,7 @@
       "Add or diagnose a generated Swift OpenAPI client in this Apple app using OpenAPIURLSession and current Apple docs.",
       "Help me build, test, or debug this Swift or Xcode project using the repo's Apple workflows.",
       "Design, migrate, test, or integrate SwiftData persistence using the dedicated SwiftData workflow and current Apple documentation.",
+      "Add, configure, present, test, or troubleshoot TipKit inline tips and tooltip popovers using current Apple documentation.",
       "Write or review DocC symbol comments, articles, extension files, and landing-page structure for this Swift repository.",
       "Sync the Apple project guidance in this repo without hand-editing Xcode project files, using Productivity Skills when repo-maintenance files must be installed or refreshed."
     ],

--- a/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
+++ b/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
@@ -128,6 +128,7 @@ active_skill_mds=(
   "./skills/appkit-app-architecture-workflow/SKILL.md"
   "./skills/swiftui-app-architecture-workflow/SKILL.md"
   "./skills/swiftdata-workflow/SKILL.md"
+  "./skills/tipkit-workflow/SKILL.md"
   "./skills/apple-ui-accessibility-workflow/SKILL.md"
   "./skills/explore-apple-swift-docs/SKILL.md"
   "./skills/format-swift-sources/SKILL.md"
@@ -139,7 +140,7 @@ active_skill_mds=(
   "./skills/sync-swift-package-guidance/SKILL.md"
   "./skills/xcode-coding-intelligence-workflow/SKILL.md"
 )
-[[ ${#active_skill_mds[@]} -eq 32 ]] || fail "Expected exactly 32 active skills, found ${#active_skill_mds[@]}."
+[[ ${#active_skill_mds[@]} -eq 33 ]] || fail "Expected exactly 33 active skills, found ${#active_skill_mds[@]}."
 
 shared_xcode_snippet="./shared/agents-snippets/apple-xcode-project-core.md"
 shared_package_snippet="./shared/agents-snippets/apple-swift-package-core.md"

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -150,6 +150,7 @@ uv run pytest
 - `sf-symbols-workflow`
 - `structure-swift-sources`
 - `swiftdata-workflow`
+- `tipkit-workflow`
 - `swift-openapi-client-workflow`
 - `swift-package-build-run-workflow`
 - `swift-package-testing-workflow`

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -789,6 +789,26 @@ Completed
 
 Completed Milestone 54 by shipping `apple-developer-provisioning-workflow` with plan-first App Store Connect provisioning, local Xcode discovery handoffs, Keychain-backed CloudKit guidance, account/key prerequisites, and explicit portal-only fallbacks.
 
+## Milestone 55: TipKit Workflow - Completed
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add a docs-first TipKit workflow for SwiftUI, UIKit, and AppKit.
+- [x] Cover one-time configuration, inline tips, tooltip popovers, actions, styling, eligibility, events, donations, invalidation, persistence, testing controls, and diagnosis.
+- [x] Keep TipKit implementation direct instead of introducing a custom tooltip manager or mirrored state layer.
+
+### Exit Criteria
+
+- [x] Apple Dev Skills ships `tipkit-workflow` as the explicit owner for TipKit implementation and troubleshooting guidance.
+- [x] Xcode documentation is the primary behavioral source, with Dash checked as the configured secondary local source.
+- [x] Plugin metadata, README inventory, validator, roadmap, and focused tests agree on the added skill.
+
+Completed Milestone 55 by shipping `tipkit-workflow` with focused presentation and lifecycle references, SwiftUI/UIKit/AppKit routing, deterministic test guidance, plugin metadata, inventory validation, and targeted tests.
+
 ## Backlog Candidates
 
 - [ ] Record plausible future work that is not yet committed to a milestone.

--- a/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
+++ b/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
@@ -8,8 +8,8 @@ Record the Milestone 20 audit of the current customization system, decide whethe
 
 ## Current State Summary
 
-- The active skill surface ships `32` separate `references/customization.template.yaml` files.
-- The active skill surface ships `32` separate `scripts/customization_config.py` entrypoints.
+- The active skill surface ships `33` separate `references/customization.template.yaml` files.
+- The active skill surface ships `33` separate `scripts/customization_config.py` entrypoints.
 - Those `customization_config.py` files are functionally identical and exist only because installed skills are expected to keep runtime resources inside the skill directory.
 - The current templates expose `21` knobs total:
   - `20` are documented as `runtime-enforced`

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: tipkit-workflow
+description: Add, configure, present, style, test, and troubleshoot Apple TipKit tips in SwiftUI, UIKit, and AppKit using current Apple documentation. Use for Tip protocol definitions, Tips.configure, TipView inline tips, popoverTip tooltip popovers, TipUIView, TipUIPopoverViewController, TipNSView, TipNSPopover, rules, parameters, events and donations, actions, invalidation, display frequency, persistent datastores, testing overrides, and tips that do not appear or reappear correctly.
+---
+
+# TipKit Workflow
+
+## Purpose
+
+Implement Apple TipKit directly and predictably. Treat “tooltip” requests as a presentation decision: use TipKit for discoverable feature guidance and onboarding, then choose an inline tip or tip popover based on whether covering nearby controls is acceptable.
+
+## When To Use
+
+Use for adding, configuring, displaying, styling, testing, or diagnosing TipKit guidance in SwiftUI, UIKit, or AppKit.
+
+## Single-Path Workflow
+
+1. Apply the Apple docs gate through `explore-apple-swift-docs`. State the documented TipKit behavior being relied on before changing code.
+2. Inspect the app entry point, deployment targets, highlighted control, existing presentation modifiers, and any existing TipKit configuration or tip types.
+3. Classify the request:
+   - inline SwiftUI guidance with `TipView`
+   - SwiftUI tooltip popover with `popoverTip`
+   - UIKit inline or popover presentation
+   - AppKit inline or popover presentation
+   - eligibility using parameters, events, rules, and options
+   - lifecycle, persistence, testing, or troubleshooting
+4. Read `references/presentation-and-platform-patterns.md` for presentation code and `references/eligibility-lifecycle-and-testing.md` for configuration, rules, persistence, invalidation, and diagnosis.
+5. Define a small `Tip` type with stable identity and focused copy. Add `title`; add `message`, `image`, and `actions` only when they improve comprehension or provide a real next step.
+6. Call `try Tips.configure(...)` once during app startup before tips need to become eligible. Handle configuration failure with a descriptive message that identifies TipKit initialization and the likely datastore or configuration cause.
+7. Prefer inline `TipView` whenever layout can accommodate it. Use `popoverTip` when the tip must point at a compact control and temporary overlap is acceptable.
+8. Encode real eligibility with `@Parameter`, `Tips.Event`, `#Rule`, and options. Donate events where the qualifying behavior actually happens; do not fake eligibility with unrelated view-local Boolean state.
+9. Invalidate the tip when the highlighted feature is used or the guidance becomes permanently irrelevant. Do not confuse temporary dismissal with permanent invalidation.
+10. Validate with deterministic TipKit testing controls, then run the applicable `xcode-build-run-workflow` and `xcode-testing-workflow` checks. Verify appearance, dismissal, action handling, persistence after relaunch, accessibility, and compact-window behavior on each supported platform.
+
+## Inputs
+
+- repository, app entry point, platform, and deployment targets
+- feature or control to highlight
+- inline or popover intent, or permission to choose
+- eligibility, frequency, persistence, and invalidation requirements
+- existing TipKit state and observed failure behavior
+
+## Outputs
+
+Return the documented Apple behavior, chosen presentation, configuration location, tip definition, eligibility and invalidation policy, changed files, validation performed, and any remaining platform limitation.
+
+## Guards and Stop Conditions
+
+- Do not use TipKit as a generic hover-help replacement without confirming that feature education is the intended behavior.
+- Do not add a custom tooltip manager, coordinator, repository, or mirrored state layer around TipKit.
+- Do not call `Tips.configure` repeatedly from feature views.
+- Do not attach multiple competing popover presentations to the same control without checking composition and runtime behavior.
+- Do not promise exact popover timing, simultaneous popovers, or imperative SwiftUI presentation control that TipKit does not expose.
+- Do not reset the TipKit datastore or force all tips visible outside a deliberate debug, preview, or test path.
+- Stop when Apple documentation and current code disagree, when a deployment target cannot support the required API, or when the request needs a custom always-available help surface instead of TipKit.
+
+## Fallbacks and Handoffs
+
+- Recommend `explore-apple-swift-docs` for current API or availability lookup.
+- Recommend `swiftui-app-architecture-workflow` or `appkit-app-architecture-workflow` when ownership of the highlighted feature is unclear.
+- Recommend `apple-ui-accessibility-workflow` for VoiceOver, Dynamic Type, contrast, focus, and alternative-access verification.
+- Recommend `xcode-build-run-workflow` for execution.
+- Recommend `xcode-testing-workflow` for automated validation.
+- Use a native SwiftUI `help` modifier on macOS or a custom help presentation only when the product requirement is persistent contextual help rather than TipKit feature education; verify that API through Apple docs before implementing it.
+
+## Customization
+
+Use `references/customization-flow.md`. The first version has no runtime-enforced knobs; `scripts/customization_config.py` preserves the shared configuration contract.
+
+## References
+
+- `references/presentation-and-platform-patterns.md`
+- `references/eligibility-lifecycle-and-testing.md`
+- `references/customization-flow.md`
+- Recommend `references/snippets/apple-xcode-project-core.md` when the app needs reusable repository policy alongside TipKit implementation guidance.

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/agents/openai.yaml
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TipKit Workflow"
+  short_description: "Add and troubleshoot Apple TipKit guidance"
+  default_prompt: "Use $tipkit-workflow to add, configure, display, test, or troubleshoot Apple TipKit tips and popovers using current Apple documentation."

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/references/customization-flow.md
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/references/customization-flow.md
@@ -1,0 +1,5 @@
+# TipKit Workflow Customization Contract
+
+The first version defines no runtime-enforced knobs. `scripts/customization_config.py` preserves the shared Apple Dev Skills customization contract; future settings must be documented here and in `SKILL.md` before runtime behavior depends on them.
+
+Inspect settings with `scripts/customization_config.py effective`, persist a documented change with `apply --input <yaml-file>`, and verify the effective result afterward.

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/references/customization.template.yaml
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/references/customization.template.yaml
@@ -1,0 +1,3 @@
+schemaVersion: 1
+isCustomized: false
+settings: {}

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/references/eligibility-lifecycle-and-testing.md
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/references/eligibility-lifecycle-and-testing.md
@@ -1,0 +1,127 @@
+# Eligibility, Lifecycle, and Testing
+
+## Configure Once at Startup
+
+Configure TipKit before tips need to display, normally in the app initializer:
+
+```swift
+import SwiftUI
+import TipKit
+
+@main
+struct ExampleApp: App {
+    init() {
+        do {
+            try Tips.configure()
+        } catch {
+            assertionFailure(
+                "TipKit configuration failed before the app created its first scene. " +
+                "Check the configured datastore location and TipKit options. Underlying error: \(error)"
+            )
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}
+```
+
+Use configuration options deliberately:
+
+- `displayFrequency(_:)` controls the minimum cadence used when determining tip eligibility.
+- `datastoreLocation(_:)` changes persistent storage. Apple documents Application Support as the default on iOS, macOS, watchOS, and visionOS, and a caches/UserDefaults arrangement on tvOS.
+- `cloudKitContainer(_:)` enables cross-device TipKit datastore sync. Apple recommends a separate CloudKit container for tips and requires the app’s iCloud and remote-notification background capabilities. TipKit does not sync through CloudKit by default.
+- A group-container datastore requires a correctly configured App Group entitlement.
+
+Do not move configuration into individual feature views and do not silently swallow errors.
+
+## Define Stable Eligibility
+
+Use a parameter rule for persistent app state:
+
+```swift
+struct FavoriteTip: Tip {
+    @Parameter
+    static var hasFavorites = false
+
+    var title: Text { Text("Save a favorite") }
+
+    var rules: [Rule] {
+        #Rule(Self.$hasFavorites) { $0 == false }
+    }
+}
+```
+
+Use an event rule for repeated behavior:
+
+```swift
+struct SearchTip: Tip {
+    static let openedLibrary = Tips.Event(id: "opened-library")
+
+    var title: Text { Text("Search your library") }
+
+    var rules: [Rule] {
+        #Rule(Self.openedLibrary) {
+            $0.donations.donatedWithin(.week).count >= 3
+        }
+    }
+}
+```
+
+Donate where the real product event occurs. Decide whether an “open” means a navigation entry, scene/session activation, or some other boundary; do not blindly count SwiftUI `onAppear` or `.task` reruns as separate user events.
+
+```swift
+Task {
+    await SearchTip.openedLibrary.donate()
+}
+```
+
+Current Xcode documentation exposes async `donate()` / `donate(_:)` methods and callback-based `sendDonation(_:)` / `sendDonation(_:_:)` alternatives. Prefer structured-concurrency `donate` from async-aware code; use `sendDonation` only when the callback form fits the existing boundary better.
+
+Multiple entries in `rules` combine with logical AND. Keep parameter and event identifiers stable after release because persisted eligibility depends on identity and history.
+
+When several tips compete for one presentation surface, use `TipGroup` to select one eligible tip at a time instead of attaching multiple independent popovers. Choose the group priority deliberately and render its current eligible tip through the appropriate presentation API.
+
+Use tip options such as maximum display count or display-frequency overrides only when the product behavior requires them. Confirm current option names and availability through Xcode docs before coding.
+
+## Dismissal and Invalidation
+
+Closing a tip dismisses the current presentation. Calling `invalidate(reason:)` permanently invalidates that tip for the persisted datastore. Invalidate at the feature’s success point, using the reason that matches what happened, such as `.actionPerformed` when the person used the highlighted feature.
+
+Do not invalidate on view appearance, unrelated navigation, or an action that merely opens more information unless the tip’s job is actually complete.
+
+## Deterministic Debugging and Tests
+
+TipKit persists display history, so “the code is correct but nothing appears” often means configuration, eligibility, frequency, or prior invalidation is controlling the result.
+
+Use TipKit’s testing APIs only in deliberate debug, preview, or test setup:
+
+```swift
+#if DEBUG
+try? Tips.resetDatastore()
+Tips.showAllTipsForTesting()
+#endif
+```
+
+Call `Tips.resetDatastore()` before `Tips.configure()`. Apple documents that reset removes existing tip, event, and parameter records and must run before configuration. Apply force-visible or force-hidden testing overrides in the same deliberate startup test path, then configure TipKit once.
+
+Apple also provides `hideAllTipsForTesting()` for deterministic hidden-state checks. Verify exact signatures and throwing behavior in the active Xcode documentation before committing test helpers, because these controls can evolve with the SDK.
+
+Never leave unconditional datastore resets or force-visible overrides in production startup.
+
+## Troubleshooting Order
+
+1. Confirm `Tips.configure` completed before presentation.
+2. Confirm the running OS supports the chosen TipKit API.
+3. Confirm the tip instance is attached to the intended live view or control.
+4. Inspect every parameter and event rule; remember multiple rules AND together.
+5. Confirm event donations occur on the actual runtime path.
+6. Check display-frequency and max-display-count options.
+7. Check whether the tip was dismissed or permanently invalidated in the current datastore.
+8. Temporarily force visibility in a debug/test path to separate content/presentation problems from eligibility problems.
+9. Reset the datastore only when losing local TipKit history is acceptable.
+10. For UIKit or AppKit, confirm the status-observation task is alive, main-actor UI updates occur, and presentation objects are retained.
+11. For SwiftUI toolbar controls, check toolbar overflow, menus, sheets, alerts, other popovers, competing tips, and compact geometry for presentation conflicts.
+
+Test the normal path again without force-visible overrides. Relaunch the app to verify persistence and test the smallest supported window or device size to expose popover collisions.

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/references/presentation-and-platform-patterns.md
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/references/presentation-and-platform-patterns.md
@@ -1,0 +1,80 @@
+# Presentation and Platform Patterns
+
+## Choose the Presentation
+
+Prefer an inline tip whenever practical. Apple documents that inline tips change layout to make room but avoid obscuring interactive UI. A popover tip overlays the current layout and can obscure controls, so reserve it for a compact feature that benefits from a visual pointer.
+
+Keep a stable tip instance in the owning view. Define the content separately from presentation and feature behavior.
+
+```swift
+import SwiftUI
+import TipKit
+
+struct FavoriteTip: Tip {
+    var title: Text { Text("Save a favorite") }
+    var message: Text? { Text("Favorites stay at the top of your library.") }
+    var image: Image? { Image(systemName: "star") }
+}
+
+struct LibraryView: View {
+    private let favoriteTip = FavoriteTip()
+
+    var body: some View {
+        VStack {
+            TipView(favoriteTip, arrowEdge: .bottom)
+
+            Button("Favorite", systemImage: "star") {
+                saveFavorite()
+                favoriteTip.invalidate(reason: .actionPerformed)
+            }
+        }
+    }
+}
+```
+
+For a SwiftUI tip popover, attach `popoverTip` to the exact feature being explained:
+
+```swift
+Button("Favorite", systemImage: "star") {
+    saveFavorite()
+    favoriteTip.invalidate(reason: .actionPerformed)
+}
+.popoverTip(favoriteTip, arrowEdge: .top)
+```
+
+Treat the arrow edge as a preference whose visual result must be checked in the real window or device geometry. Avoid imagery in a compact popover when the pointer already makes the target clear.
+
+## Actions
+
+Define `actions` on the tip, then route by stable action identifiers in the presentation callback. An action is not automatically the same as completing the highlighted feature; invalidate only when the action makes the tip permanently irrelevant.
+
+```swift
+struct ExportTip: Tip {
+    var title: Text { Text("Export your project") }
+
+    var actions: [Action] {
+        Action(id: "learn-more", title: "Learn More")
+    }
+}
+
+TipView(ExportTip()) { action in
+    guard action.id == "learn-more" else { return }
+    openExportHelp()
+}
+```
+
+## Styling
+
+Use `tipViewStyle(_:)` and a focused `TipViewStyle` only when the system style cannot meet the app’s visual requirements. Preserve title, message, image, actions, dismissal, Dynamic Type, contrast, and accessibility semantics. Do not build a second presentation system merely to restyle tips.
+
+## UIKit
+
+Use `TipUIView` for inline UIKit content and `TipUIPopoverViewController` for a popover. Observe `shouldDisplayUpdates` or `statusUpdates` to add, present, remove, and dismiss the UIKit object as eligibility changes. Own the observation task in the view controller, run UI work on the main actor, and cancel the task when the view leaves its active lifecycle.
+
+## AppKit
+
+Use `TipNSView` for inline AppKit content and `TipNSPopover` for a popover. Observe `shouldDisplayUpdates` or `statusUpdates`, keep the presentation object alive while shown, update views on the main actor, and cancel the observation task when the owning controller disappears.
+
+## Platform Verification
+
+Check the exact API availability in Xcode documentation against every deployment target before editing. Build each affected platform because SwiftUI modifiers and framework bridges can differ even when the `Tip` content is shared.

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/references/snippets/apple-xcode-project-core.md
@@ -1,0 +1,133 @@
+# Apple Xcode Project Core AGENTS Snippet
+
+Use this snippet in repository `AGENTS.md` files when you want baseline standards for an existing native Apple app project managed through Xcode.
+
+## General Swift Baseline
+
+- For any Swift, Apple-framework, Apple-platform, SwiftUI, SwiftData, Observation, AppKit, UIKit, Foundation-on-Apple, or Xcode-related task, read the relevant Apple documentation first before planning, proposing, or making changes.
+- Use Xcode MCP `DocumentationSearch` or Xcode-local documentation first for Apple-owned SDK, framework, lifecycle, and Xcode behavior; use Dash MCP or Dash HTTP next when installed local package docs or multi-ecosystem docs are a better fit; use open source Swift project repositories, generated DocC, or release notes when the relevant Swift package or tool is open source and available there; use official Apple web docs only when the page content is actually readable through a capable source. Generic no-JS web search/open results, snippets, metadata shells, or bare Apple Developer URLs are not enough evidence that Apple docs were read.
+- Before proposing an architecture or implementation, state the documented API behavior, lifecycle rule, or workflow requirement being relied on.
+- Do not rely on memory, habit, or analogy as the primary source when Apple documentation exists.
+- If Apple documentation and the current code disagree, stop and report the conflict before continuing.
+- If no relevant Apple documentation can be found, say that explicitly before proceeding.
+- Prefer the simplest correct Swift that is easiest to read, reason about, and maintain.
+- Treat idiomatic Swift, Cocoa conventions, and modern Swift features as tools in service of readability, not as goals by themselves.
+- Do not add ceremony, abstraction, or boilerplate just to make code look more architectural, more generic, or more "Swifty".
+- Strongly prefer synthesized, implicit, and framework-provided behavior over custom code.
+- Prefer synthesized conformances (`Codable`, `Equatable`, `Hashable`, etc.) whenever they satisfy the actual requirements.
+- Prefer memberwise and otherwise synthesized initializers, default property values, and framework defaults over handwritten setup code.
+- Do not add `CodingKeys`, manual `Codable` methods, custom initializers, wrappers, helper types, protocols, coordinators, or extra layers unless they are required by a concrete constraint or they make the final code clearly easier to understand.
+- Prefer applicable existing framework or platform error types before inventing custom error wrappers or error hierarchies.
+- Prefer direct, simple error flows and small focused error enums only when they materially improve understanding.
+- Prefer stable, source-of-truth naming across layers when the data and meaning have not changed.
+- Treat naming consistency as a reliability feature: if the same data still serves the same purpose, keep the same name.
+- Do not rename fields just to match local style conventions when the external schema is already clear and stable.
+- Do not use automatic case-conversion strategies such as `.convertFromSnakeCase` or `.convertToSnakeCase` unless the project explicitly wants that behavior and it clearly improves readability overall.
+- When an API, cloud service, or wire format already provides clear names, preserve those names directly in Swift models and nearby code unless the meaning actually changes or a concrete collision must be resolved.
+- Preserve raw wire and persistence shapes by default; do not add DTO, domain, or view-model conversion layers unless meaning actually changes or a concrete boundary requires it.
+- Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
+- This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
+- Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
+- Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
+- Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
+- When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.
+- Do not force value types by default, protocols at seams, actors by default, or other pattern slogans when a plainer concrete implementation is easier to reason about.
+- Keep code compliant with Swift 6 language mode.
+- Keep strict concurrency checking enabled.
+- Prefer modern structured concurrency (`async`/`await`, task groups, actors) over legacy async patterns when it keeps the flow clearer and more direct.
+- Make async code cancellation-aware and keep actor or task boundaries explicit instead of hiding them behind detached tasks or queue wrappers.
+- Prefer clear `Sendable` boundaries for values that cross task or actor isolation, and keep unchecked sendability exceptional and justified locally.
+- Prefer Swift Testing (`import Testing`) as the default test framework, and use XCTest only when a dependency or platform constraint requires it.
+- Prefer Swift Testing for unit-style and package-style test surfaces in modern Xcode projects, including suites, tags, parameterized tests, and direct async tests.
+- Use XCTest when the platform surface, dependency graph, or Apple tooling still expects it, and keep XCTest and Swift Testing responsibilities clearly separated when both coexist.
+- Use XCUITest for UI automation, and prefer explicit element wait APIs such as `waitForExistence(timeout:)`, `waitForNonExistence(timeout:)`, and related state waits over fixed sleeps.
+- Keep `.xctestplan` files versioned when test configurations, diagnostics, sanitizers, locale coverage, or selective plan execution matter, and inspect or run them explicitly with `xcodebuild -showTestPlans` and `xcodebuild -testPlan ...`.
+- Prefer normal Xcode and XCTest parallel execution for ordinary Swift Testing, XCTest, and XCUITest runs when the project, scheme, destination, and test plan support it. Do not serialize regular tests just because they use Swift, XCTest, async tests, UI automation, or `.xctestplan` matrices.
+- Treat tests that load large local AI or ML models, especially models over 500 million parameters, as heavy system-resource tests. Run those tests sequentially, one at a time.
+- Prefer first-party and top-tier Swift ecosystem packages from Apple, `swiftlang`, the Swift Server Work Group, and similarly trusted core Swift projects when they simplify the code and make it easier to reason about.
+- Commonly approved examples include `swift-configuration` and `swift-async-algorithms` when they reduce bespoke code and improve readability.
+- For Apple app projects, prefer Apple-native logging facilities first and allow Swift Logging where it makes the project API clearer.
+- Prefer Swift OpenTelemetry for telemetry and instrumentation when telemetry is needed, and prefer existing ecosystem integrations over bespoke wrappers.
+- Prefer a checked-in repo-root `.swiftformat` file as the default Swift formatting source of truth, and prefer a pre-commit hook that formats staged Swift sources and then verifies them with `swiftformat --lint` before commit.
+- Treat SwiftLint as an optional complementary signal layer for clarity, safety, and maintainability after SwiftFormat owns formatting shape.
+- Keep automation and CI commands deterministic, non-interactive, and explicit about toolchain, platform, and configuration assumptions.
+
+## SwiftUI and State Architecture
+
+- Treat SwiftUI views as component UI: keep them small, composable, reusable, and easy to scan from top to bottom.
+- Choose and record one explicit three-letter uppercase prefix for every app or package. Prefix project-owned Swift files and primary declarations; exempt only `Package.swift`, externally generated Swift, and vendored third-party Swift.
+- Never use `+` in project-owned Swift filenames. Concatenate the owner and concern so Xcode navigation, rename, and refactoring keep one consistent grammar.
+- Name views `GEAWhateverView.swift`, paired `@Observable final class` view models `GEAWhateverViewModel.swift`, and extracted modifiers `GEAWhateverViewModifier.swift`.
+- Give independently editable or previewable view components their own files. Small private computed view properties or helper views may remain while they do not clutter focused editing or previews.
+- Prefix extracted child components with their complete composition owner, such as `GEASettingsSheetToggleCard.swift`.
+- Extract a custom `ViewModifier` after more than eight chained modifiers, or earlier when a coherent chain is reusable or obscures the view body.
+- Prefer straight, top-down data flow with state owned at the narrowest view, scene, or app boundary that matches the behavior.
+- Do not build monolithic views, monolithic controllers, or broad shared mutable state when a smaller component boundary would be clearer.
+- Keep updates to view-driving state minimal and localized.
+- Prefer durable identity for types that drive SwiftUI state and view updates.
+- Treat `App` as the application entry and scene composition boundary, `Scene` as the container for scene-specific lifecycle and environment, and `View` as the component rendering layer.
+- Every native app target must have exactly one app lifecycle entry point: one `@main` app type, one `main.swift`, or the platform-equivalent single launch entry. Do not add alternate app entry points, second `@main` types, duplicate `main.swift` files, target-specific app entry files, or parallel app structs for variants. When launch behavior must differ by platform, configuration, or feature flag, keep the single entry point and use Swift conditional compilation or ordinary runtime conditionals inside that boundary.
+- Use app-level lifecycle concerns at the `App` boundary, scene lifecycle concerns at the `Scene` boundary, and view-local active or presentation behavior inside views.
+- Use `@Binding` to pass a focused writable piece of parent-owned state into a child view.
+- Use `@Bindable` when working with an observable model that should project bindings to its mutable properties in a view.
+- Use the dedicated SwiftData workflow for persistence architecture and its direct SwiftUI integration path.
+- Prefer environment values for shared context that truly belongs to the surrounding hierarchy, not as a dumping ground for unrelated dependencies.
+- Prefer key-path-based APIs, predicates, and sort descriptors when they keep data access direct and readable.
+- Extract repeated chains of view modifiers into custom view modifiers early when that reduces clutter and clearly matches a view or family of views.
+
+## Xcode Workspace and Project Baseline
+
+- Treat the `.xcworkspace` or `.xcodeproj` as the source of truth for Apple platform app integration, schemes, build settings, destinations, and target membership.
+- Prefer edits through Xcode-aware project structure and keep project file changes intentional and reviewed closely.
+- Use the standard top-level Xcode app repository layout when creating or normalizing native app repos: `Sources/`, `Tests/`, `Shared/`, `Extensions/`, `Configurations/`, `Scripts/`, and `Packages/`.
+- `Sources/` owns the main app target implementation and app-owned resources/support files. `Tests/` owns all test targets. `Shared/` owns reusable source intended to be compiled into the app and extension targets. `Extensions/` owns extension target roots, one folder per extension. `Configurations/` owns `.xcconfig` layers. `Scripts/` owns project-local automation and build helper scripts. `Packages/` owns local Swift packages only when a real package boundary is justified.
+- Keep those top-level roots stable. Do not invent parallel names such as `AppSources`, `TestSources`, `Config`, `BuildScripts`, or `LocalPackages` for ordinary Xcode app repos unless the existing repo already has a deliberate, documented convention.
+- Inside `Sources/`, use this strict app structure by default: `Views/`, `Models/`, and `Services/`. Do not create a root `Controllers/` directory.
+- `Sources/Views/` owns SwiftUI views and UIKit/AppKit view surfaces. Use `Sources/Views/Shared`, `Sources/Views/macOS`, and `Sources/Views/iOS` so shared, macOS-specific, and iOS/iPadOS-specific UI have clear homes.
+- Use bare prefixed names such as `GEAWhatever.swift` for runtime/domain values. Reserve `GEAWhateverModel.swift` for persistence, and use `GEAWhateverRecord.swift` or `GEAWhateverDTO.swift` only for genuinely additional representations.
+- `Sources/Models/` owns Core Data and SwiftData persistence models plus additional record or transfer representations.
+- `Sources/Services/` owns app-wide and boundary-facing services. Use `Consumed/` for external services the app calls, `Internal/` for services owned only by the app, and `Provided/` for services the app exposes to extensions, helpers, plugins, integrations, or other clients.
+- Name services `GEAWhateverService.swift`; they manage the matching runtime/domain value `GEAWhatever`. `GEAAppService.swift` may manage `GEA`, while `GEAApp.swift` is the lifecycle-entry special case.
+- Use `xcodebuild` for Apple platform integration validation, including scheme, destination or SDK, and configuration-specific build or test runs.
+- Keep `xcodebuild` invocations reproducible in automation by passing explicit schemes, destinations or SDKs, and configurations when relevant.
+- For Codex GUI worktree-first Xcode repos, use a portable `.codex/environments/*.toml` local environment file when the repo wants shared app setup or action buttons. Start from `apple-dev-skills/templates/codex-local-environments/xcode-project.toml`, keep paths repo-relative, and prefer `-derivedDataPath ./DerivedData` or another ignored repo-local build directory instead of user-global DerivedData.
+- When scripts or terminal workflows add files on disk, verify that Xcode project membership, target membership, build-phase membership, and resource-bundle inclusion all match the intended result; files appearing in the directory tree alone are not enough.
+- Direct filesystem edits outside `.pbxproj` are generally safe when Xcode is closed or when the current project is not open in Xcode, but still verify that the Xcode project picks up the intended files and memberships afterward.
+- Prefer Debug builds for everyday edit-build-test loops, but validate Release builds explicitly when optimization, packaging, launch behavior, watchdog timing, or deployment realism matters.
+- Treat tagged releases as a signal to validate both the normal Debug path and a Release artifact path, and when shipping apps or deliverables test the Release behavior without relying on an attached debugger.
+- Prefer direct filesystem edits in Xcode-managed scope only when the workflow already accounts for project-file and scheme integrity.
+- Never edit `.pbxproj` files directly. If a project-file change is needed and no safe project-aware tool is available, stop and ask for an Xcode-mediated project change instead. When `.pbxproj` is tracked and Xcode, XcodeGen, or another project-aware workflow legitimately changes it, treat that diff as critical project state: review it, stage it, and commit it with the branch before any push, merge, release, or cleanup.
+
+## XcodeGen and Build Configuration Defaults
+
+- For new Xcode app, framework, and workspace repositories, prefer an XcodeGen-backed project by default unless the user explicitly asks for a hand-managed Xcode project or the repository has a concrete reason to avoid a generator dependency.
+- If the repo contains `project.yml`, `project.yaml`, or clearly named included XcodeGen spec files, treat the XcodeGen spec set as the source of truth for generated project structure.
+- For XcodeGen-backed repos, make target membership, resource membership, schemes, Swift package declarations, test-plan references, project references, build configurations, configuration-file wiring, generation options, and project-level settings in the XcodeGen specs instead of editing the generated `.pbxproj`.
+- Before running `xcodegen generate`, inspect the current git diff for generated `.xcodeproj` or `.pbxproj` changes. Treat existing project-file diffs as intentional user or Xcode GUI changes by default, not disposable generator drift.
+- When Xcode GUI changes added build settings, signing settings, capabilities, `Info.plist` build setting overrides, file membership, scheme changes, or entitlement wiring to `.pbxproj`, preserve the user intent by moving each intentional value to the owning tracked source first: XcodeGen spec for structure, `.xcconfig` for build settings, `.entitlements` for entitlement keys, `Info.plist` for plist keys, `.xcscheme` or scheme spec for scheme behavior, and `.xctestplan` for test-plan content.
+- Only regenerate after that promotion is complete, then review the generated project diff to confirm XcodeGen preserved the intended behavior instead of deleting it. If the owning tracked file is ambiguous, stop and ask before regenerating.
+- For new XcodeGen-backed app scaffolds, start from the maintained `apple-dev-skills/templates/xcodegen/` templates when available instead of inventing a fresh project-spec shape from memory.
+- Keep `minimumXcodeGenVersion` on a recent validated release for new scaffolds. Prefer updating the template and validation together when the repo intentionally raises the baseline.
+- For Xcode 16 or newer project formats, prefer XcodeGen `syncedFolder` roots at the broad top-level directory boundary so file creation, deletion, and organization stay synchronized between Xcode and the filesystem without hand-listing every source file in YAML.
+- Do not fragment ordinary XcodeGen source roots by subdirectory. A standard app target gets one `Sources` source entry that includes all app source, resource, support, generated plist, entitlement, and nested feature folders, plus one `Shared` source entry when shared app/extension code exists. A standard test target gets one `Tests` source entry that includes all test subdirectories. Extension targets use one `Extensions/<ExtensionName>` source entry per extension target. If a project has another separate top-level logical root, use one top-level entry for that root, not one entry per child folder.
+- Never split `Sources/App`, `Sources/Resources`, `Sources/Support`, feature folders, or `Tests/<TargetName>Tests` into separate XcodeGen source entries unless a specific non-ordinary file or folder truly needs custom compiler flags, build-phase routing, destination filters, or target membership that cannot be represented from the broad root.
+- If `syncedFolder` behaves poorly for a repo, fall back to the same broad top-level recursive paths such as `Sources`, `Tests`, or `Resources` with explicit `includes` and `excludes`; do not fall back to subdirectory-level fragmentation or one YAML entry per ordinary source file.
+- Keep XcodeGen specs readable as project structure, not as a dumping ground for every build setting. Use `configs`, `configFiles`, `targets`, `schemes`, `packages`, `projectReferences`, `targetTemplates`, and `schemeTemplates` deliberately so future edits have an obvious owner.
+- Prefer explicit top-level schemes for app scaffolds once scheme behavior matters. Put build, run, test, profile, analyze, archive, environment variables, command-line arguments, and test-plan references in the scheme spec rather than relying on hidden generated defaults.
+- Prefer external `.xcconfig` files as the default home for nontrivial build settings. Keep build settings in XcodeGen inline settings only when they are small, local, and clearer there.
+- Use `.xcconfig` files for settings that vary by Debug, Release, CI, local development, signing, bundle identity, compiler flags, Swift settings, deployment variants, or environment-specific behavior.
+- Keep configuration layering explicit. Prefer a small shared base config, target-level configs for app/test/extension identity, then per-configuration configs that include the narrower target config and override only what changes.
+- In XcodeGen specs, wire build configurations to their matching `.xcconfig` files instead of duplicating the same settings across generated project objects.
+- Prefer checked-in external `.entitlements` files for app, extension, and capability-bearing targets, with `CODE_SIGN_ENTITLEMENTS` declared in the owning target's `.xcconfig`. Let Xcode capabilities update the entitlement plist when possible, then review and commit the entitlement diff; keep XcodeGen responsible for wiring the file, not regenerating its contents from inline YAML.
+- Do not assume Xcode's Build Settings UI writes edited values back into `.xcconfig` files. When a build setting should remain tracked in `.xcconfig`, inspect the generated project diff after GUI changes and move intentional build-setting overrides from `.pbxproj` back into the owning `.xcconfig` before regenerating.
+- Keep secrets, personal team IDs, local machine paths, provisioning profiles, API tokens, and private signing material out of committed `.xcconfig` files. Use build settings only for non-secret configuration values, safe placeholders, references to externally supplied values, or local developer placeholders that are safe to commit.
+- Before changing generated project structure, inspect the root spec plus any `include` entries so the edit lands in the owning spec rather than duplicating settings in the wrong file. Remember that included specs merge into the root spec, and local overrides may intentionally replace arrays or maps.
+- After changing XcodeGen specs, `.xcconfig` files, or entitlement-file wiring, run `xcodegen generate` from the spec root, or `xcodegen generate --spec <path>` when the project uses a non-default spec path.
+- If the spec uses environment variables or generation hooks, preserve and document the required environment before regenerating so CI and other contributors can reproduce the project.
+- Review the spec diff, `.xcconfig` diff, and generated `.xcodeproj` diff after regeneration. Generated `.pbxproj` changes are acceptable output when they come from XcodeGen, but they should still be reviewed for unintended target, scheme, signing, package, build-setting, or file-membership churn.
+- Validate regenerated projects with explicit `xcodebuild` commands for the affected scheme, destination or SDK, and configuration.
+- For existing hand-managed Xcode projects, do not migrate to XcodeGen or externalize build settings into `.xcconfig` files unless the user explicitly asks for that migration. When they do, treat it as a project-structure migration with before/after validation.

--- a/plugins/apple-dev-skills/skills/tipkit-workflow/scripts/customization_config.py
+++ b/plugins/apple-dev-skills/skills/tipkit-workflow/scripts/customization_config.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "PyYAML>=6.0.2,<7",
+# ]
+# ///
+"""Load and persist per-skill customization state."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+SCHEMA_VERSION = 1
+SKILL_NAME = "tipkit-workflow"
+CONFIG_HOME_ENV = "APPLE_DEV_SKILLS_CONFIG_HOME"
+DEFAULT_CONFIG_ROOT = "~/.config/gaelic-ghost/apple-dev-skills"
+ALLOWED_TOP_LEVEL = {"schemaVersion", "isCustomized", "settings"}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def quote_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def encode_scalar(value) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return quote_string("")
+    return quote_string(str(value))
+
+
+def parse_yaml(path: Path) -> dict:
+    if not path.exists():
+        fail(f"Missing YAML file: {path}")
+
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        fail(f"Invalid YAML in {path}: {exc}")
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        fail(f"Top-level YAML document must be a mapping in {path}")
+
+    if isinstance(loaded.get("settings"), dict):
+        loaded["settings"] = {
+            key: ("" if value is None else value) for key, value in loaded["settings"].items()
+        }
+
+    return loaded
+
+
+def validate_config(config: dict, *, allow_partial: bool) -> None:
+    unknown = set(config.keys()) - ALLOWED_TOP_LEVEL
+    if unknown:
+        fail(f"Unknown top-level keys: {', '.join(sorted(unknown))}")
+
+    if not allow_partial:
+        for required in ("schemaVersion", "isCustomized", "settings"):
+            if required not in config:
+                fail(f"Missing required key: {required}")
+
+    if "schemaVersion" in config and config["schemaVersion"] != SCHEMA_VERSION:
+        fail(f"schemaVersion must be {SCHEMA_VERSION}")
+
+    if "isCustomized" in config and not isinstance(config["isCustomized"], bool):
+        fail("isCustomized must be boolean")
+
+    if "settings" in config:
+        if not isinstance(config["settings"], dict):
+            fail("settings must be a mapping")
+        for key, value in config["settings"].items():
+            if not re.fullmatch(r"[A-Za-z0-9_]+", key):
+                fail(f"Invalid settings key: {key}")
+            if isinstance(value, (dict, list)):
+                fail(f"settings values must be scalar: {key}")
+
+
+def merge_configs(base: dict, overlay: dict) -> dict:
+    merged = {
+        "schemaVersion": base.get("schemaVersion", SCHEMA_VERSION),
+        "isCustomized": base.get("isCustomized", False),
+        "settings": copy.deepcopy(base.get("settings", {})),
+    }
+
+    if "schemaVersion" in overlay:
+        merged["schemaVersion"] = overlay["schemaVersion"]
+    if "isCustomized" in overlay:
+        merged["isCustomized"] = overlay["isCustomized"]
+    if "settings" in overlay:
+        merged["settings"].update(overlay["settings"])
+
+    return merged
+
+
+def dump_yaml(config: dict) -> str:
+    lines = [
+        f"schemaVersion: {int(config['schemaVersion'])}",
+        f"isCustomized: {'true' if config['isCustomized'] else 'false'}",
+        "settings:",
+    ]
+    for key in sorted(config["settings"].keys()):
+        lines.append(f"  {key}: {encode_scalar(config['settings'][key])}")
+    return "\n".join(lines) + "\n"
+
+
+def template_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "references" / "customization.template.yaml"
+
+
+def config_root() -> Path:
+    root = os.environ.get(CONFIG_HOME_ENV, DEFAULT_CONFIG_ROOT)
+    return Path(root).expanduser()
+
+
+def durable_path() -> Path:
+    return config_root() / SKILL_NAME / "customization.yaml"
+
+
+def load_template() -> dict:
+    cfg = parse_yaml(template_path())
+    validate_config(cfg, allow_partial=False)
+    return cfg
+
+
+def load_durable() -> dict:
+    path = durable_path()
+    if not path.exists():
+        return {}
+    cfg = parse_yaml(path)
+    validate_config(cfg, allow_partial=False)
+    return cfg
+
+
+def cmd_path(_: argparse.Namespace) -> None:
+    print(durable_path())
+
+
+def cmd_effective(_: argparse.Namespace) -> None:
+    effective = merge_configs(load_template(), load_durable())
+    validate_config(effective, allow_partial=False)
+    print(dump_yaml(effective), end="")
+
+
+def cmd_apply(args: argparse.Namespace) -> None:
+    template = load_template()
+    current = merge_configs(template, load_durable())
+    incoming = parse_yaml(Path(args.input))
+    validate_config(incoming, allow_partial=True)
+
+    updated = merge_configs(current, incoming)
+    updated["schemaVersion"] = SCHEMA_VERSION
+    updated["isCustomized"] = True
+    validate_config(updated, allow_partial=False)
+
+    target = durable_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(dump_yaml(updated), encoding="utf-8")
+    print(target)
+
+
+def cmd_reset(_: argparse.Namespace) -> None:
+    target = durable_path()
+    if target.exists():
+        target.unlink()
+    print(target)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage per-skill customization config")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_path = subparsers.add_parser("path", help="Print durable config path")
+    parser_path.set_defaults(func=cmd_path)
+
+    parser_effective = subparsers.add_parser("effective", help="Print merged effective config")
+    parser_effective.set_defaults(func=cmd_effective)
+
+    parser_apply = subparsers.add_parser("apply", help="Apply and persist config overrides")
+    parser_apply.add_argument("--input", required=True, help="Path to YAML overrides")
+    parser_apply.set_defaults(func=cmd_apply)
+
+    parser_reset = subparsers.add_parser("reset", help="Delete durable config for this skill")
+    parser_reset.set_defaults(func=cmd_reset)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/apple-dev-skills/tests/test_apple_developer_provisioning_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_apple_developer_provisioning_workflow.py
@@ -55,7 +55,7 @@ class AppleDeveloperProvisioningWorkflowTests(unittest.TestCase):
         self.assertIn("apple-developer-provisioning-workflow", readme)
         self.assertIn("Apple Developer provisioning", plugin)
         self.assertIn("./skills/apple-developer-provisioning-workflow/SKILL.md", validator)
-        self.assertIn("Expected exactly 32 active skills", validator)
+        self.assertIn("Expected exactly 33 active skills", validator)
         self.assertIn("Milestone 54: Apple Developer Provisioning and CloudKit Workflow - Completed", roadmap)
 
     def test_customization_cli_preserves_shared_apply_and_reset_verbs(self) -> None:

--- a/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
+++ b/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
@@ -66,8 +66,8 @@ class CustomizationConsolidationReviewTests(unittest.TestCase):
         knob_count = _count_template_knobs()
         runtime_enforced, policy_only = _count_statuses()
 
-        self.assertEqual(template_count, 32)
-        self.assertEqual(script_count, 32)
+        self.assertEqual(template_count, 33)
+        self.assertEqual(script_count, 33)
         self.assertEqual(knob_count, 21)
         self.assertEqual(runtime_enforced, 20)
         self.assertEqual(policy_only, 1)

--- a/plugins/apple-dev-skills/tests/test_devicecheck_app_attest_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_devicecheck_app_attest_workflow.py
@@ -71,7 +71,7 @@ class DeviceCheckAppAttestWorkflowTests(unittest.TestCase):
         self.assertIn("DeviceCheck", plugin)
         self.assertIn("App Attest", plugin)
         self.assertIn("./skills/devicecheck-app-attest-workflow/SKILL.md", validator)
-        self.assertIn("Expected exactly 32 active skills", validator)
+        self.assertIn("Expected exactly 33 active skills", validator)
         self.assertIn("Milestone 53: DeviceCheck and App Attest Workflow - Completed", roadmap)
 
 

--- a/plugins/apple-dev-skills/tests/test_tipkit_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_tipkit_workflow.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TipKitWorkflowTests(unittest.TestCase):
+    def read(self, relative_path: str) -> str:
+        return (ROOT / relative_path).read_text(encoding="utf-8")
+
+    def test_skill_owns_tipkit_setup_and_presentations(self) -> None:
+        skill = self.read("skills/tipkit-workflow/SKILL.md")
+        presentation = self.read("skills/tipkit-workflow/references/presentation-and-platform-patterns.md")
+
+        for term in ("Tips.configure", "TipView", "popoverTip", "TipUIView", "TipUIPopoverViewController", "TipNSView", "TipNSPopover"):
+            self.assertIn(term, skill + presentation)
+        self.assertIn("Prefer an inline tip whenever practical", presentation)
+        self.assertIn("attach `popoverTip` to the exact feature", presentation)
+
+    def test_skill_covers_eligibility_lifecycle_testing_and_diagnosis(self) -> None:
+        skill = self.read("skills/tipkit-workflow/SKILL.md")
+        lifecycle = self.read("skills/tipkit-workflow/references/eligibility-lifecycle-and-testing.md")
+
+        for term in ("@Parameter", "Tips.Event", "#Rule", "donate()", "sendDonation", "invalidate(reason:)", "showAllTipsForTesting", "hideAllTipsForTesting", "resetDatastore"):
+            self.assertIn(term, skill + lifecycle)
+        self.assertIn("Multiple entries in `rules` combine with logical AND", lifecycle)
+        self.assertIn("Call `Tips.resetDatastore()` before `Tips.configure()`", lifecycle)
+        self.assertIn("Never leave unconditional datastore resets", lifecycle)
+
+    def test_skill_requires_docs_and_explicit_handoffs(self) -> None:
+        skill = self.read("skills/tipkit-workflow/SKILL.md")
+        prompt = self.read("skills/tipkit-workflow/agents/openai.yaml")
+        customization = self.read("skills/tipkit-workflow/scripts/customization_config.py")
+
+        self.assertIn("Apply the Apple docs gate", skill)
+        self.assertIn("State the documented TipKit behavior", skill)
+        self.assertIn("Recommend `explore-apple-swift-docs`", skill)
+        self.assertIn("Recommend `xcode-build-run-workflow`", skill)
+        self.assertIn("Recommend `xcode-testing-workflow`", skill)
+        self.assertIn("$tipkit-workflow", prompt)
+        self.assertIn('SKILL_NAME = "tipkit-workflow"', customization)
+
+    def test_inventory_and_metadata_include_tipkit(self) -> None:
+        readme = self.read("README.md")
+        plugin = self.read(".codex-plugin/plugin.json")
+        validator = self.read(".github/scripts/validate_repo_docs.sh")
+        roadmap = self.read("ROADMAP.md")
+
+        self.assertIn("tipkit-workflow", readme)
+        self.assertIn("TipKit", plugin)
+        self.assertIn("./skills/tipkit-workflow/SKILL.md", validator)
+        self.assertIn("Expected exactly 33 active skills", validator)
+        self.assertIn("Milestone 55: TipKit Workflow - Completed", roadmap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a docs-first TipKit workflow for SwiftUI, UIKit, and AppKit
- cover inline tips, tooltip popovers, eligibility, lifecycle, testing, and troubleshooting
- align Apple Dev Skills metadata, inventory, roadmap, and validation contracts

## Verification

- `uv run --directory plugins/apple-dev-skills pytest` (201 passed)
- `bash plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh`
- `uv run scripts/validate_socket_metadata.py`
- isolated forward test against a toolbar popover and event-rule scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TipKit workflow covering setup, presentations, eligibility, lifecycle management, testing, troubleshooting, and platform-specific patterns across SwiftUI, UIKit, and AppKit.
  * Added guidance for TipKit customization, configuration, and persistent settings.
  * Added the TipKit workflow to the available Apple development skills and documentation inventory.

* **Tests**
  * Added focused validation covering TipKit guidance, metadata, inventory, and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->