### PR TITLE
docs: gate Photos album organization

### DIFF
--- a/plugins/apple-dev-skills/skills/photos-library-editing-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/photos-library-editing-workflow/SKILL.md
@@ -36,6 +36,7 @@ Guide PhotosUI selection and PhotoKit library work while requesting the narrowes
    - use `.addOnly` when the app only saves into Photos
    - use `.readWrite` only for fetch, limited-library, organization, observation, or edit requirements
    - handle `.notDetermined`, `.restricted`, `.denied`, `.authorized`, and `.limited` distinctly
+   - require `.authorized`, not merely `.limited`, before fetching, creating, or modifying user albums and provide a picker, selected-assets, or settings fallback when full-library organization is unavailable
 4. Preserve typed identity and lifecycle:
    - keep `PhotosPickerItem`, `PHPickerResult`, `PHAsset`, `PHAssetCollection`, `PHFetchResult`, `PHAssetResource`, request IDs, placeholders, and adjustment data typed
    - attach asynchronous results to the current selection, asset local identifier, request ID, fetch result, or edit generation
@@ -62,6 +63,7 @@ Guide PhotosUI selection and PhotoKit library work while requesting the narrowes
 
 - Do not request PhotoKit read/write authorization when a system picker or add-only access fulfills the feature.
 - Do not treat `.limited` as fully authorized or as denial; operate on the visible library and provide the documented management path when appropriate.
+- Do not promise album browsing or organization under `.limited`; require full `.authorized` read/write access before fetching, creating, renaming, deleting, or changing user albums.
 - Do not mirror the entire library into app-owned state or introduce a Photos repository when `PHFetchResult`, local identifiers, change details, and picker bindings express the requirement.
 - Do not assume a picker item, asset, or resource is local; model iCloud/network delivery, progress, cancellation, and failure explicitly.
 - Do not treat degraded or opportunistic image callbacks as final, and do not let stale request callbacks overwrite a newer selection.

--- a/plugins/apple-dev-skills/skills/photos-library-editing-workflow/references/creation-collections-and-nondestructive-editing.md
+++ b/plugins/apple-dev-skills/skills/photos-library-editing-workflow/references/creation-collections-and-nondestructive-editing.md
@@ -4,6 +4,8 @@
 
 Perform library mutations inside `PHPhotoLibrary.performChanges` or its documented async equivalent. Create assets with `PHAssetCreationRequest` and explicit resource types/options. Create or modify albums with `PHAssetCollectionChangeRequest`. Use placeholders only inside the change transaction, retain local identifiers when needed, and fetch the committed object after successful completion.
 
+Gate user-album fetch, creation, rename, deletion, membership, and ordering work on `PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized`. Do not treat `.limited` as sufficient album access. When the status is `.limited`, preserve selected-asset behavior and provide an explicit broader-access or non-album fallback before entering a collection transaction.
+
 Do not update application success state before the transaction completes. Report the operation, access level, resource/collection intent, error, likely cause, and next probe. Handle partial input preparation outside the transaction so the change block stays deterministic and does not perform arbitrary network or long-running work.
 
 ## Nondestructive Editing

--- a/plugins/apple-dev-skills/skills/photos-library-editing-workflow/references/photosui-selection-and-authorization.md
+++ b/plugins/apple-dev-skills/skills/photos-library-editing-workflow/references/photosui-selection-and-authorization.md
@@ -17,7 +17,9 @@ Handle every `PHAuthorizationStatus`:
 - `.notDetermined`: explain the feature at the moment of need, then request once.
 - `.restricted`: explain that system policy prevents access.
 - `.denied`: preserve nonlibrary app behavior and offer the documented settings route when useful.
-- `.limited`: operate only on visible assets and use the documented limited-library management UI when user intent requires it.
+- `.limited`: operate only on visible assets, do not fetch or organize user albums, and use the documented limited-library management UI when user intent requires it.
 - `.authorized`: use only the access needed by the feature.
+
+Treat `.readWrite` as the requested access level and `.authorized` as the status required for full-library album browsing and organization. A `.limited` result is intentionally narrower: keep picker and selected-asset behavior available, explain why an album feature needs broader access, and offer the documented settings or limited-library management route rather than attempting album fetches or change requests that require the full library.
 
 Provide the correct usage description for each requested access level. Authorization is not permission to copy unrelated metadata, upload media, or retain selected content indefinitely.

--- a/plugins/apple-dev-skills/tests/test_photos_library_editing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_photos_library_editing_workflow.py
@@ -30,6 +30,7 @@ class PhotosLibraryEditingWorkflowTests(unittest.TestCase):
             ".limited",
             ".authorized",
             "narrowest access",
+            "full-library album",
         ):
             self.assertIn(term, skill + selection)
 
@@ -73,6 +74,7 @@ class PhotosLibraryEditingWorkflowTests(unittest.TestCase):
             "nondestructive",
             "transaction",
             "adjustment-version",
+            "authorizationStatus(for: .readWrite) == .authorized",
         ):
             self.assertIn(term, skill + editing)
 


### PR DESCRIPTION
## Summary

- require full authorized read/write status for user-album fetch and organization
- preserve picker and selected-asset fallbacks for limited-library users
- cover the authorization distinction in Photos workflow tests

## Verification

- 8 targeted Photos and media-audit tests passed
- Apple Dev docs validator passed
- verified against current Xcode PhotoKit authorization and collection documentation

Follow-up to the P2 review on #122.
