### PR TITLE
release: clarify Xcode LLDB MCP guidance

### DIFF
--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/agentdeck/.codex-plugin/plugin.json
+++ b/plugins/agentdeck/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentdeck",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Apple development workflows for Codex, including App Intents, Liquid Glass, PhotosUI/PhotoKit, VideoToolbox codecs, ARKit spatial/face/body sensing, camera/depth capture, Core Image, Image I/O, Vision/Core ML recognition, media/audio repair, provisioning, CloudKit, TipKit, SwiftData, SwiftUI, XcodeGen, Core Animation, AppKit, Safari, security, OpenAPI, and DocC.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -104,7 +104,7 @@ codex plugin marketplace add gaelic-ghost/apple-dev-skills
 codex plugin marketplace upgrade apple-dev-skills
 ```
 
-When installed as a Codex plugin, Apple Dev Skills also registers Xcode's built-in MCP bridge through `xcrun mcpbridge` and the Xcode-selected LLDB MCP server through `xcrun lldb-mcp`. Users still need to allow external agents in Xcode's Intelligence settings, keep the relevant project open in Xcode before external Codex sessions can use Xcode-provided tools, and verify `lldb-mcp` startup against the installed Xcode because the LLDB MCP surface is still Xcode 27 beta-era behavior.
+When installed as a Codex plugin, Apple Dev Skills declares two Xcode-selected MCP commands: `xcrun mcpbridge` for Xcode's active project and debugging-session tools, plus experimental `xcrun lldb-mcp` for LLDB's standalone MCP bridge. Users still need to allow external agents in Xcode's Intelligence settings and keep the relevant project open before external Codex sessions can use Xcode-provided tools. Xcode 27.0 Beta 3 resolves but does not start `lldb-mcp`, so use the working `mcpbridge` path and Xcode's active debugger session until a later Xcode release starts the standalone bridge normally.
 
 ## Development
 

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -718,25 +718,25 @@ Planned
 
 ### Status
 
-Planned
+Completed
 
 ### Scope
 
-- [ ] Add a dedicated Xcode 27 beta-era LLDB MCP workflow skill for debugger setup, target/session selection, breakpoint and expression workflows, crash investigation, and handoffs back to build/test skills.
-- [ ] Keep the workflow docs-first and beta-gated until `xcrun lldb-mcp` startup, help output, tool inventory, and MCP client behavior are validated against an installed Xcode 27 beta.
-- [ ] Keep Xcode-owned debugger integration separate from third-party debugger MCP servers and from normal `xcrun mcpbridge` project/build tools.
+- [x] Add a dedicated Xcode 27 beta-era LLDB MCP workflow skill for debugger setup, target/session selection, breakpoint and expression workflows, crash investigation, and handoffs back to build/test skills.
+- [x] Keep the workflow docs-first and beta-gated while recording the Beta 3 startup boundary and the direct Xcode active-session fallback.
+- [x] Keep Xcode-owned debugger integration separate from standalone LLDB MCP and third-party debugger MCP servers, while documenting `xcrun mcpbridge` as the owner of Xcode project, build, and active-session debugging tools.
 
 ### Tickets
 
 - [x] Add an experimental `xcode_lldb` MCP config entry that resolves through the selected Xcode toolchain with `xcrun lldb-mcp`.
-- [ ] Capture `xcrun lldb-mcp --help`, startup behavior, and tool inventory from Xcode 27 Beta 2 or a later beta before claiming the config is stable.
-- [ ] Document the observed Beta 2 rpath failure and the exact toolchain environment that fixes it, if Apple does not resolve the direct-launch issue in a later beta.
-- [ ] Add the workflow skill, metadata, README inventory entry, and targeted tests after the launch and tool-surface evidence exists.
+- [x] Capture `xcrun lldb-mcp --help` startup behavior from Xcode 27 Beta 3, including its unresolved dynamic-library failure before MCP startup.
+- [x] Document the Xcode 27 Beta 3 rpath failure as a local observation without publishing an unsupported environment workaround or claiming it is universal.
+- [x] Add the workflow skill, metadata, README inventory entry, and targeted tests with a clear distinction between Xcode active-session tools and standalone LLDB MCP.
 
 ### Exit Criteria
 
-- [ ] Apple Dev Skills exposes a debugger workflow that can safely decide when to use LLDB MCP, normal Xcode UI debugging, `lldb`, `lldb-dap`, or existing build/test handoffs.
-- [ ] The plugin MCP config, README, skill guidance, and tests agree on whether `xcode_lldb` is experimental or stable.
+- [x] Apple Dev Skills exposes a debugger workflow that can safely decide when to use standalone LLDB MCP, Xcode active-session debugging, `lldb`, `lldb-dap`, or existing build/test handoffs.
+- [x] The plugin MCP config, README, skill guidance, and tests agree that `xcode_lldb` is declared but experimental, and that Beta 3 does not start it.
 
 ## Milestone 52: Apple Design Animation And Symbols Workflow Skills
 

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "9.2.0"
+version = "9.2.1"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/SKILL.md
@@ -7,23 +7,32 @@ description: Diagnose a running Apple app through Xcode’s active LLDB debuggin
 
 ## Purpose
 
-Use Xcode's active debugger session as the stable agent-facing LLDB route. Treat the standalone `xcrun lldb-mcp` executable as experimental until it starts successfully on the selected Xcode toolchain and exposes a documented tool contract.
+Use Xcode's active debugger session through `xcrun mcpbridge` as the stable agent-facing LLDB route. Treat the standalone `xcrun lldb-mcp` executable as experimental until it starts successfully on the selected Xcode toolchain and exposes a documented tool contract.
+
+## Xcode And LLDB MCP Boundaries
+
+Xcode 27 exposes two distinct MCP paths:
+
+- `xcrun mcpbridge` is Xcode's STDIO bridge. It connects an external MCP client to a running Xcode process, selecting it with `MCP_XCODE_PID` or `MCP_XCODE_SESSION_ID` when needed. It owns Xcode project tools and the active run/debug-session tools. On the locally observed surface, `InvokeDebuggerCommand` sends a focused LLDB command to that active debugging session.
+- `xcrun lldb-mcp` is LLDB's standalone STDIO-to-socket bridge. It discovers an LLDB MCP server or launches a separate background `lldb` process when none exists. Its documented surface is one general `lldb_command` tool plus debugger and target resources. It does not document a way to select or take ownership of Xcode's active debugging session.
+
+For a running Xcode app, start with `mcpbridge`, the active session, and the smallest Xcode-provided debugger command. Use standalone `lldb-mcp` only for a separately owned LLDB workflow after its startup and tool discovery both succeed.
 
 ## Current Xcode 27 Beta 3 State
 
-On 2026-07-12, the selected Xcode 27.0 Beta 3 toolchain (`27A5218g`) resolves both `mcpbridge` and `lldb-mcp`. `mcpbridge --help` works and documents bridge and agent export behavior. `lldb-mcp --help` fails before startup because dyld cannot resolve `@rpath/lib_CompilerSwiftIDEUtils.dylib`, even though that library exists elsewhere inside the Xcode bundle.
+On 2026-07-12, the selected Xcode 27.0 Beta 3 toolchain (`27A5218g`) resolves both `mcpbridge` and `lldb-mcp`. `mcpbridge --help` works and documents STDIO bridge behavior, Xcode PID/session selection, and agent export behavior. `lldb-mcp --help` fails before startup because dyld cannot resolve `@rpath/lib_CompilerSwiftIDEUtils.dylib`, even though that library exists elsewhere inside the Xcode bundle.
 
-Do not work around this with copied libraries, symlinks, modified Xcode bundles, or a persistent loader-path override. Recheck a later Xcode beta or release before claiming standalone `lldb-mcp` support.
+This is a local Beta 3 packaging observation. Public Xcode release notes announce `lldb-mcp`, but neither those notes nor the public LLDB documentation identify this dyld failure as a known issue. Do not claim it affects every Xcode installation or beta. Do not work around this with copied libraries, symlinks, modified Xcode bundles, or a persistent loader-path override. Recheck a later Xcode beta or release before claiming standalone `lldb-mcp` support.
 
 ## Workflow
 
 1. Classify the need: breakpoint, crash/exception, stalled thread, incorrect value, object lifetime, framework behavior, or an ordinary build/test failure.
 2. For normal project execution, use `xcode-build-run-workflow` to open the project, select the destination, and run with the debugger attached. Do not attach a debugger merely to replace a build log.
-3. Verify an active Xcode debug session before sending a command. If no session exists, report that prerequisite instead of inventing a process identifier or attaching to an unrelated process.
-4. Use Xcode's active-session debugger command surface for focused LLDB requests: `bt`, `thread list`, `frame variable`, `po`, a named breakpoint, or a bounded step. The command shares Xcode's own LLDB state.
+3. Connect through `mcpbridge` to the intended running Xcode. When multiple Xcode apps are open, use `MCP_XCODE_PID`; use `MCP_XCODE_SESSION_ID` only when the caller owns a specific Xcode tool session. Verify an active Xcode debug session before sending a command. If no session exists, report that prerequisite instead of inventing a process identifier or attaching to an unrelated process.
+4. Discover the tools exposed by that Xcode session. Use its active-session debugger command surface for focused LLDB requests: `bt`, `thread list`, `frame variable`, `po`, a named breakpoint, or a bounded step. In the observed Beta 3 surface, `InvokeDebuggerCommand` shares Xcode's own LLDB state.
 5. Capture the smallest evidence packet: the triggering action, stopped thread/frame, relevant variables, exception or return state, and the exact command output. Redact user content, secrets, and unnecessary memory values.
 6. Hand off by evidence type: tests to `xcode-testing-workflow`, simulator trace or memgraph evidence to `ios-runtime-forensics-workflow`, device selection or capture to `xcode-device-hub-workflow`, and source repair to the owning code workflow.
-7. If the request specifically requires standalone `lldb-mcp`, run a no-mutation capability probe on the selected toolchain first. If startup fails, return the loader failure and use the Xcode active-session path only when a project debug session exists.
+7. If the request specifically requires standalone `lldb-mcp`, run a no-mutation capability probe on the selected toolchain first. If startup succeeds, discover `lldb_command` and the debugger/target resources before sending a bounded command to a separately owned LLDB debugger ID. If startup fails, return the loader failure and use the Xcode active-session path only when a project debug session exists.
 
 ## Guards
 
@@ -32,8 +41,10 @@ Do not work around this with copied libraries, symlinks, modified Xcode bundles,
 - Do not run unbounded `continue`, expression evaluation with side effects, or process-control commands without user intent and a clear debug-session owner.
 - Do not treat a debugger value as a leak, performance profile, or test result without the matching runtime or test evidence.
 - Do not replace Xcode's normal debugger session with an unverified third-party MCP server.
+- Do not assume standalone `lldb-mcp` reaches the debugger that Xcode already owns; its public contract describes LLDB MCP discovery or a separately launched `lldb` process.
 
 ## References
 
 - `references/beta3-capability-evidence.md`
 - `references/active-session-debugging-contract.md`
+- `references/xcode-27-debugging-mcp-surface.md`

--- a/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/references/active-session-debugging-contract.md
+++ b/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/references/active-session-debugging-contract.md
@@ -1,6 +1,8 @@
 # Active-Session Debugging Contract
 
-The Xcode MCP surface available to this session exposes `InvokeDebuggerCommand`. It sends an LLDB command to Xcode's active debugging session, returns whether a session is active, preserves the same debugger state visible in Xcode, and reports output plus a process identifier when Xcode provides one.
+The Xcode MCP surface available to this session exposes `InvokeDebuggerCommand`. It sends an LLDB command to Xcode's active debugging session, returns whether a session is active, preserves the same debugger state visible in Xcode, and reports output plus a process identifier when Xcode provides one. It is reached through Xcode's `mcpbridge` connection, not the standalone `lldb-mcp` bridge.
+
+Xcode 27 beta tool inventories can vary by Xcode process, selected session, and beta build. Discover the current Xcode MCP tools before assuming this exact command is available.
 
 Use the smallest safe command for the question:
 

--- a/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/references/xcode-27-debugging-mcp-surface.md
+++ b/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/references/xcode-27-debugging-mcp-surface.md
@@ -1,0 +1,25 @@
+# Xcode 27 Debugging MCP Surface
+
+## Documented Server Shapes
+
+Xcode 27 Beta 2 release notes state that LLDB ships with `lldb-mcp` and direct readers to the LLDB MCP documentation. The same Xcode release notes say the Xcode MCP server can manipulate active run state and interact with the debugger console. Those are different server surfaces.
+
+- Xcode MCP route: start `xcrun mcpbridge` as an MCP client's STDIO server. It connects to a running Xcode process and exposes the tools associated with that Xcode session.
+- LLDB MCP route: start `lldb` and run `protocol-server start MCP listen://localhost:<port>` to host LLDB's MCP socket. An MCP client normally starts `lldb-mcp`; that helper bridges client STDIO to the socket, discovers a running LLDB MCP server, or launches its own background `lldb` when no server is available.
+
+The public LLDB MCP contract documents one `lldb_command` tool, accepting a debugger ID and command string, plus debugger and target resources. It does not document a mechanism for choosing an Xcode-managed active debugger session. Treat the standalone route as a separately owned LLDB workflow unless actual tool output proves otherwise.
+
+Sources:
+
+- [Xcode 27 Beta 2 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-27-release-notes)
+- [LLDB Model Context Protocol documentation](https://lldb.llvm.org/use/mcp.html)
+
+## Local Xcode 27 Beta 3 Result
+
+On 2026-07-12, the selected `/Applications/Xcode-beta.app` toolchain was Xcode 27.0 build `27A5218g`. `xcrun mcpbridge --help` started and documented STDIO bridging, `MCP_XCODE_PID`, and `MCP_XCODE_SESSION_ID`. `xcrun lldb-mcp --help` exited before protocol startup because dyld could not load `@rpath/lib_CompilerSwiftIDEUtils.dylib`.
+
+The Xcode bundle passed `codesign --verify --deep --strict`. The required library exists in the selected toolchain and the bundled LLDB framework, but `lldb-mcp` has neither location in its recorded rpath list. That is strong evidence of an Apple packaging defect in this Beta 3 helper rather than a damaged local Xcode installation or a project-level configuration problem.
+
+Socket history also recorded a Beta 2 rpath failure when the experimental config was first added. Together, that makes a persistent Beta 2-to-Beta 3 packaging regression plausible. It is still not proof that every installation has the same defect: the public release notes announce the feature but do not list this loader failure as a known issue, and no independently reproducible public report was identified in the Apple, LLVM, and general-web sources checked on 2026-07-12.
+
+Do not alter Xcode, copy libraries, create symlinks, or ship an environment-variable workaround. Recheck the next beta or release with the selected toolchain before changing the availability guidance.

--- a/plugins/apple-dev-skills/tests/test_xcode_device_window_telemetry_debugger_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_device_window_telemetry_debugger_workflows.py
@@ -46,7 +46,7 @@ class XcodeDeviceWindowTelemetryDebuggerWorkflowTests(unittest.TestCase):
         evidence = self.read("skills/xcode-debugger-mcp-workflow/references/beta3-capability-evidence.md")
         contract = self.read("skills/xcode-debugger-mcp-workflow/references/active-session-debugging-contract.md")
 
-        for term in ("Xcode 27.0 Beta 3", "27A5218g", "lib_CompilerSwiftIDEUtils.dylib", "InvokeDebuggerCommand", "active debugging session"):
+        for term in ("Xcode 27.0 Beta 3", "27A5218g", "lib_CompilerSwiftIDEUtils.dylib", "InvokeDebuggerCommand", "active debugging session", "mcpbridge", "lldb_command", "does not document a way to select"):
             self.assertIn(term, skill + evidence + contract)
         self.assertIn("Do not work around this", skill)
         self.assertIn("xcode-build-run-workflow", skill)

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "9.2.0"
+version = "9.2.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-inference-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-inference-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-inference-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Cloud AI inference workflow skills for routing model serving, training, conversion, and GPU infrastructure work across Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/network-protocol-skills/.codex-plugin/plugin.json
+++ b/plugins/network-protocol-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "network-protocol-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for choosing, planning, implementing, and diagnosing modern application transports and real-time networking protocols, including QUIC, HTTP/3, WebRTC, Media over QUIC, WebTransport-adjacent handoffs, protocol maturity checks, and stack-specific implementation routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "9.2.0"
+version = "9.2.1"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "9.2.0"
+version = "9.2.1"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "9.2.0"
+version = "9.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "9.2.0"
+version = "9.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- distinguish Xcode's active-session MCP bridge from standalone LLDB MCP
- document the signed Xcode 27 Beta 3 rpath packaging failure without claiming it is universal
- bump Socket shared version surfaces to 9.2.1

## Verification
- Validating roadmap presence...
Validating root docs presence...
Validating local discovery mirrors...
Validating root README contract...
Validating CONTRIBUTING contract...
Validating AGENTS contract...
Validating reality audit guide...
Validating customization consolidation review...
Validating skill directory layout...
Validating shared snippet sync...
Shared snippet skill-local copies are in sync.
Validating Dash docs exploration references...
Validating stale installer and nested-packaging guidance is gone...
Validating maintain-project-repo delegation...
Validating preserved guidance in AGENTS assets...
Validating skill-creator contract...
All validation checks passed.
- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /private/tmp/socket-wt-xcode-lldb-mcp-guidance/plugins/apple-dev-skills
configfile: pyproject.toml
collected 4 items

plugins/apple-dev-skills/tests/test_xcode_device_window_telemetry_debugger_workflows.py . [ 25%]
...                                                                      [100%]

============================== 4 passed in 0.01s ===============================
- full Apple Dev Skills suite: 240 tests passed
- Validating root marketplace presence...
Validating marketplace entries...
Socket marketplace validation passed.