### PR TITLE
release: add coverage and Xcode MCP guidance

### DIFF
--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/agentdeck/.codex-plugin/plugin.json
+++ b/plugins/agentdeck/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentdeck",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Apple development workflows for Codex, including App Intents, Liquid Glass, PhotosUI/PhotoKit, VideoToolbox codecs, ARKit spatial/face/body sensing, camera/depth capture, Core Image, Image I/O, Vision/Core ML recognition, media/audio repair, provisioning, CloudKit, TipKit, SwiftData, SwiftUI, XcodeGen, Core Animation, AppKit, Safari, security, OpenAPI, and DocC.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -576,6 +576,7 @@ Completed
 - [x] Keep build, run, preview, file-membership, and project-integrity execution with `xcode-build-run-workflow`.
 - [x] Keep Swift Testing, XCTest, XCUITest, and `.xctestplan` execution with `xcode-testing-workflow`.
 - [x] Mark Xcode 27 beta claims with the date checked and separate them from local Xcode 26.5 `mcpbridge` evidence.
+- [x] Add shared Xcode and SwiftPM code-coverage guidance, and keep coverage reporting on documented CLI tools unless a live Xcode MCP session exposes an equivalent contract.
 
 ### Tickets
 
@@ -590,7 +591,7 @@ Completed
 - [x] Existing Xcode execution skills keep execution ownership while linking to the setup workflow only where needed.
 - [x] Beta-specific claims are dated, source-linked, and separated from stable or local-tool evidence.
 
-Completed Milestone 47 by shipping `xcode-coding-intelligence-workflow`, updating the active skill inventory and plugin metadata, adding routing notes from build/test execution skills, and covering the new setup and permission boundary with targeted tests.
+Completed Milestone 47 by shipping `xcode-coding-intelligence-workflow`, updating the active skill inventory and plugin metadata, adding routing notes from build/test execution skills, documenting Xcode 27 MCP capability additions without inventing beta tool names, adding shared Xcode and SwiftPM coverage guidance, and covering the setup, coverage, and permission boundaries with targeted tests.
 
 ## Milestone 48: Core AI and Foundation Models Workflow Planning
 

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "9.2.1"
+version = "9.3.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/shared/references/code-coverage-contract.md
+++ b/plugins/apple-dev-skills/shared/references/code-coverage-contract.md
@@ -1,0 +1,21 @@
+# Code Coverage Contract
+
+Code coverage is execution evidence: it shows which instrumented code ran during a test run. It does not prove behavior is correct, tests assert the right outcomes, or UI and device paths are adequately verified.
+
+## Default Policy
+
+- Report coverage by target and file, and include function-level detail when the tool provides it.
+- Keep test failures, coverage-collection failures, and missing-report failures as separate results.
+- Default to reporting only. Do not invent a global coverage percentage, fail a build, exclude a source path, or claim changed-line coverage without an explicit repository policy.
+- Treat generated, vendored, test-target, and platform-glue sources as visible in the first report. Exclude them only with a checked-in, human-readable reason.
+- Do not commit generated coverage reports by default. Keep local reports ephemeral and upload CI reports only when that repository's CI policy asks for it.
+
+## Required Evidence Packet
+
+Every coverage result should state the toolchain and coverage command; configuration, scheme or package, and destination when applicable; report artifact path and format; target and file summary; exclusions and their reason; whether the result is comparable with a baseline; and test, collection, and report-extraction failures independently.
+
+## Comparison And Gates
+
+Compare coverage only when the source revision, toolchain, build configuration, selected targets, destination, and exclusion policy are compatible. A raw project-wide percentage is not a substitute for changed-file or changed-line evidence.
+
+Add a CI gate only after the repository chooses one concrete metric: an overall minimum, target minimum, changed-file minimum, or changed-line minimum. Record the policy and allowed exceptions in the repository; keep the Apple Dev Skills default report-only.

--- a/plugins/apple-dev-skills/skills/swift-package-testing-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/swift-package-testing-workflow/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: swift-package-testing-workflow
-description: Guide Swift Testing, XCTest holdouts, xctestplan handoff conditions, async test design, semantic accessibility-test boundaries, test-fixture organization, and package test-diagnosis work in existing Swift Package Manager repositories. Use when Package.swift is the source of truth and the task is primarily about testing rather than package build or run work.
+description: Guide Swift Testing, XCTest holdouts, code coverage, xctestplan handoff conditions, async test design, semantic accessibility-test boundaries, test-fixture organization, and package test-diagnosis work in existing Swift Package Manager repositories. Use when Package.swift is the source of truth and the task is primarily about testing rather than package build or run work.
 ---
 
 # Swift Package Testing Workflow
 
 ## Purpose
 
-Use this skill as the primary execution workflow for test-focused work in existing Swift Package Manager repositories. Keep it focused on Swift Testing, XCTest holdouts, `.xctestplan` handoff conditions, async-test guidance, semantic accessibility-test boundaries, performance-sensitive package workload profiling, filters, retries, fixtures, and package-level test diagnosis instead of broad manifest and build/run work. `scripts/run_workflow.py` is the runtime entrypoint for repo-shape checks, test-surface command planning, and clean handoff to the build/run or Xcode-oriented surfaces when the request drifts.
+Use this skill as the primary execution workflow for test-focused work in existing Swift Package Manager repositories. Keep it focused on Swift Testing, XCTest holdouts, code coverage, `.xctestplan` handoff conditions, async-test guidance, semantic accessibility-test boundaries, performance-sensitive package workload profiling, filters, retries, fixtures, and package-level test diagnosis instead of broad manifest and build/run work. `scripts/run_workflow.py` is the runtime entrypoint for repo-shape checks, test-surface command planning, and clean handoff to the build/run or Xcode-oriented surfaces when the request drifts.
 
 ## When To Use
 
@@ -47,10 +47,11 @@ Use this skill as the primary execution workflow for test-focused work in existi
    - preserve its explicit `swiftLanguageModes: [.v6]` package-manifest default and prefer that spelling over the legacy `swiftLanguageVersions` alias on current manifest surfaces
    - preserve its package-appropriate logging, telemetry, structured-concurrency, and Swift Testing guidance
 4. Run `scripts/run_workflow.py` to resolve repo shape, confirm the request stays on the testing surface, and plan the package-testing command path.
-5. Use `references/package-resources-testing-and-builds.md` when the request touches Swift Testing, XCTest, `.xctestplan`, accessibility-related semantic tests, fixtures, async test discipline, or test-related Debug/Release validation.
-6. Use `references/performance-sensitive-testing-and-profiling.md` when the request touches package-first instrumentation, `OSSignposter`, `xctrace`, Time Profiler, Metal System Trace, Allocations, VM Tracker, Audio, MLX, local AI, streaming, or other performance-sensitive Apple silicon workloads.
-7. If the repo root is ambiguous because Xcode-managed markers are present at the same root, use `references/xcode-handoff-conditions.md` and hand off cleanly to `xcode-testing-workflow`.
-8. Report which parts were agent-executed, the docs relied on, the repo-shape result, and any required next step or handoff.
+5. Use `references/code-coverage.md` when the request needs SwiftPM collection, exported-JSON discovery, coverage reporting, comparison, or an explicit coverage-gate boundary.
+6. Use `references/package-resources-testing-and-builds.md` when the request touches Swift Testing, XCTest, `.xctestplan`, accessibility-related semantic tests, fixtures, async test discipline, or test-related Debug/Release validation.
+7. Use `references/performance-sensitive-testing-and-profiling.md` when the request touches package-first instrumentation, `OSSignposter`, `xctrace`, Time Profiler, Metal System Trace, Allocations, VM Tracker, Audio, MLX, local AI, streaming, or other performance-sensitive Apple silicon workloads.
+8. If the repo root is ambiguous because Xcode-managed markers are present at the same root, use `references/xcode-handoff-conditions.md` and hand off cleanly to `xcode-testing-workflow`.
+9. Report which parts were agent-executed, the docs relied on, the repo-shape result, and any required next step or handoff.
 
 ## Inputs
 
@@ -122,6 +123,7 @@ Use this skill as the primary execution workflow for test-focused work in existi
 
 - `references/workflow-policy.md`
 - `references/repo-shape-detection.md`
+- `references/code-coverage.md`
 - `references/package-resources-testing-and-builds.md`
 - `references/performance-sensitive-testing-and-profiling.md`
 - `references/xcode-handoff-conditions.md`

--- a/plugins/apple-dev-skills/skills/swift-package-testing-workflow/references/code-coverage.md
+++ b/plugins/apple-dev-skills/skills/swift-package-testing-workflow/references/code-coverage.md
@@ -1,0 +1,31 @@
+# SwiftPM Code Coverage
+
+Use SwiftPM coverage for a package-first test surface. Follow the shared [`code-coverage-contract`](../../../shared/references/code-coverage-contract.md) for evidence, artifacts, comparisons, and gates.
+
+## Collection And Report Discovery
+
+Run coverage as part of the test command:
+
+```bash
+swift test --enable-code-coverage
+```
+
+After a successful collection, ask the active toolchain for the exported JSON location instead of hard-coding a `.build` path:
+
+```bash
+swift test --show-codecov-path
+```
+
+Treat `--show-codecov-path` as a separate report-location query. Do not assume every SwiftPM release accepts it combined with `--enable-code-coverage`, and do not split coverage into a separate build plus `swift test --skip-build` path unless that exact toolchain has been verified.
+
+## Reporting
+
+Read the exported JSON from the reported path and summarize the targets and files it contains. Preserve the original artifact path in the evidence packet. If the file is missing, unreadable, or does not contain the expected coverage payload, report extraction failed; do not substitute a guessed `.build` location or a percentage inferred from test output.
+
+SwiftPM coverage is appropriate for package targets and their ordinary tests. It does not replace app-host, XCUITest, simulator, physical-device, or Xcode test-plan coverage. Hand off to `xcode-testing-workflow` when those surfaces matter.
+
+## Failure Boundaries
+
+- A passing `swift test` without an exported coverage JSON is a coverage-collection failure, not a zero-coverage result.
+- Keep package coverage reports out of version control unless the package has an explicit artifact policy.
+- Do not create a coverage gate without a repository-owned metric and exclusion policy.

--- a/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/SKILL.md
@@ -36,6 +36,7 @@ Beta-specific note: Xcode 27 claims in this skill were checked against Apple dev
    - external-agent access through `xcrun mcpbridge`
    - command, tool, approval, or permission policy
    - Xcode-only agent configuration home
+   - Xcode 27 MCP capability discovery for run state, debugger, schemes, destinations, project settings, runtime insights, simulators, previews, or localization
    - plan-mode, artifacts, diff-review, preview, build, or test handoff
    - beta documentation or installed-Xcode capability check
 2. Apply the Apple docs gate before making setup or behavior claims:
@@ -60,6 +61,8 @@ Beta-specific note: Xcode 27 claims in this skill were checked against Apple dev
    - use `xcrun mcpbridge run-agent <agent-name>` only when intentionally launching a coding agent with Xcode-provided configuration
    - use Xcode Settings > Intelligence > Plug-ins for official plug-in import checks
    - use `MCP_XCODE_PID` when multiple Xcode processes make auto-detection ambiguous
+   - discover the live Xcode MCP tool inventory before naming a beta-era tool; Apple documents capability groups but does not make a stable tool-name contract part of this skill
+   - use `xcodebuild` and `xccov` for code coverage unless a live Xcode MCP session exposes and documents an equivalent coverage contract
    - keep normal Codex config separate from Xcode-launched Codex config
 5. Plan command and tool permissions:
    - identify which agent is allowed to read files, modify source, edit project settings, build, run tests, render previews, inspect devices, or search documentation

--- a/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/references/source-evidence.md
+++ b/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/references/source-evidence.md
@@ -160,6 +160,12 @@ Observed current behavior:
 - `xcrun --find lldb-mcp` resolves the beta executable, but `xcrun lldb-mcp --help` fails before startup because dyld cannot resolve `@rpath/lib_CompilerSwiftIDEUtils.dylib`.
 - A non-mutating fallback-library-path probe did not change that failure. Do not modify Xcode, copy libraries, create symlinks, or publish an environment-variable workaround; use Xcode's active debugger session until a later toolchain starts `lldb-mcp` normally.
 
+### Documented Xcode 27 MCP Additions
+
+Apple's Xcode 27 beta release notes describe MCP capability additions for manipulating active run state, interacting with and reading the debugger console, listing and switching schemes and run destinations, inspecting and modifying build settings/compiler flags/entitlements/Info.plist keys, runtime health insights, simulator boot/install/launch/touch/screenshot actions, preview variants, and String Catalog workflows.
+
+The release notes do not document a dedicated MCP code-coverage reporting tool. Keep code coverage on the `xcodebuild` plus `xccov` path unless a live Xcode session exposes a documented coverage contract.
+
 The Device Hub and Xcode debugger workflow references own the detailed behavior and handoffs from this probe.
 - Xcode copied imported plug-ins into `~/Library/Developer/Xcode/CodingAssistant/codex/plugins/cache`.
 - Xcode enabled imported plug-ins in `~/Library/Developer/Xcode/CodingAssistant/codex/config.toml`.

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: xcode-testing-workflow
-description: Guide Swift Testing, XCTest, XCUITest, XCUIAutomation-oriented mechanics, xctestplan matrices, accessibility-verification follow-through, test filtering, retries, diagnostics, and test-specific fallback work in existing Xcode-managed projects and workspaces. Use when Xcode-aware execution is needed and the task is primarily about testing rather than build or run work.
+description: Guide Swift Testing, XCTest, XCUITest, XCUIAutomation-oriented mechanics, code coverage, xctestplan matrices, accessibility-verification follow-through, test filtering, retries, diagnostics, and test-specific fallback work in existing Xcode-managed projects and workspaces. Use when Xcode-aware execution is needed and the task is primarily about testing rather than build or run work.
 ---
 
 # Xcode Testing Workflow
 
 ## Purpose
 
-Use this skill as the primary execution workflow for test-focused work in or around Xcode-managed projects and workspaces. Keep it focused on Swift Testing, XCTest, XCUITest, XCUIAutomation-oriented mechanics, `.xctestplan`, destinations, launch arguments, interruption handling, attachments, accessibility-verification follow-through, Instruments profiling, `xctrace` trace capture, filters, retries, diagnostics, and test-specific Debug/Release validation instead of broad build/run or toolchain work. `scripts/run_workflow.py` is the runtime entrypoint for MCP-first test execution, official CLI fallback planning, and the remaining `.pbxproj` warning boundary when mutation enters project-file territory.
+Use this skill as the primary execution workflow for test-focused work in or around Xcode-managed projects and workspaces. Keep it focused on Swift Testing, XCTest, XCUITest, XCUIAutomation-oriented mechanics, code coverage, `.xctestplan`, destinations, launch arguments, interruption handling, attachments, accessibility-verification follow-through, Instruments profiling, `xctrace` trace capture, filters, retries, diagnostics, and test-specific Debug/Release validation instead of broad build/run or toolchain work. `scripts/run_workflow.py` is the runtime entrypoint for MCP-first test execution, official CLI fallback planning, and the remaining `.pbxproj` warning boundary when mutation enters project-file territory.
 
 ## When To Use
 
@@ -41,6 +41,7 @@ Use this skill as the primary execution workflow for test-focused work in or aro
    - preserve its project-appropriate logging, telemetry, and SwiftUI architecture guidance
 4. Run `scripts/run_workflow.py` to apply runtime configuration, `.pbxproj` warning safeguards, and CLI fallback planning.
 5. Use the focused references for the right testing surface:
+   - `references/code-coverage.md` for Xcode coverage collection, `.xcresult` artifacts, `xccov` reporting, comparison, and the Xcode 27 MCP boundary
    - `references/xctestplan-configurations-and-matrix.md` for `.xctestplan`, launch-argument matrices, named configurations, and Debug/Release test coverage
    - `references/xcuitest-and-xcuiautomation.md` for UI automation mechanics, waits, interruption handling, activities, and attachments
    - `references/ui-accessibility-verification.md` for accessibility-specific runtime verification expectations and coordination with `apple-ui-accessibility-workflow`
@@ -119,6 +120,7 @@ Use this skill as the primary execution workflow for test-focused work in or aro
 - `references/workflow-policy.md`
 - `references/mcp-tool-matrix.md`
 - `references/cli-fallback-matrix.md`
+- `references/code-coverage.md`
 - `references/xctestplan-configurations-and-matrix.md`
 - `references/xcuitest-and-xcuiautomation.md`
 - `references/ui-accessibility-verification.md`

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/cli-fallback-matrix.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/cli-fallback-matrix.md
@@ -7,6 +7,8 @@
   - `xcodebuild -workspace <ws.xcworkspace> -scheme <scheme> build`
 - Xcode tests:
   - `xcodebuild test -project <proj.xcodeproj> -scheme <scheme> -destination '<dest>'`
+  - Coverage: `xcodebuild test -project <proj.xcodeproj> -scheme <scheme> -destination '<dest>' -enableCodeCoverage YES -resultBundlePath <artifacts>/<run>.xcresult`
+  - Coverage report: `xcrun xccov view --report --json <artifacts>/<run>.xcresult`
 
 ## Runtime and tooling
 
@@ -30,6 +32,8 @@
   - `swift build`
 - Test:
   - `swift test`
+  - Coverage: `swift test --enable-code-coverage`
+  - Coverage report location: `swift test --show-codecov-path`
 - Run executable target:
   - `swift run <target>`
 - Package commands:

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/code-coverage.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/code-coverage.md
@@ -1,0 +1,38 @@
+# Xcode Code Coverage
+
+Use Xcode coverage for Xcode-managed test targets, UI tests, app-hosted tests, simulator or device destinations, and `.xctestplan` configurations. Follow the shared [`code-coverage-contract`](../../../shared/references/code-coverage-contract.md) for evidence, artifacts, comparisons, and gates.
+
+## Collection
+
+For an explicit CLI run, use a real project or workspace, scheme, and destination. Capture an `.xcresult` bundle so the coverage data is inspectable after the test process exits:
+
+```bash
+xcodebuild test -workspace <workspace>.xcworkspace -scheme <scheme> \
+  -destination '<destination>' -enableCodeCoverage YES \
+  -resultBundlePath <artifacts>/<run>.xcresult
+```
+
+Replace `-workspace` with `-project <project>.xcodeproj` only when the project is not workspace-managed. For repeatable named configurations, version an `.xctestplan` that enables coverage and run it with `-testPlan <plan>`; do not use a plan merely to hide an otherwise simple one-off coverage command.
+
+## Reporting
+
+Use `xccov` against the result bundle rather than scraping test logs:
+
+```bash
+xcrun xccov view --report --json <artifacts>/<run>.xcresult
+xcrun xccov view --archive --json <artifacts>/<run>.xcresult
+```
+
+The report gives target, file, and function coverage. The archive provides execution-count detail. Use `xcrun xccov diff --json <before>.xcresult <after>.xcresult` only when the two runs meet the shared comparison contract.
+
+## Xcode 27 MCP Boundary
+
+Xcode 27 beta documents new MCP capabilities for active run-state control, debugger-console interaction, scheme and run-destination management, build-setting/compiler-flag/entitlement/Info.plist inspection and mutation, runtime health insights, simulator interaction, preview variants, and String Catalog workflows. Discover the tool inventory from the live Xcode session before naming or invoking a specific tool.
+
+Apple does not document a coverage-report MCP tool in this beta. Use Xcode MCP for session discovery and test execution when the live session provides those tools, then use `xcodebuild` and `xccov` for deterministic coverage collection and report extraction.
+
+## Failure Boundaries
+
+- A successful test run without an `.xcresult` or readable `xccov` report is a coverage-collection failure, not a coverage result.
+- A coverage report with failing tests remains a failing test run; do not report its percentage as a passing quality signal.
+- Do not compare simulator and physical-device coverage, Debug and Release coverage, or different schemes as though they are the same baseline.

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/mcp-tool-matrix.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/mcp-tool-matrix.md
@@ -42,3 +42,11 @@ These are Xcode-owned MCP tools exposed through `xcrun mcpbridge` after external
 - Runtime and preview operations require files in active scheme targets.
 - Tab indices can remain stable after window closure; always resolve by workspace path.
 - Deep directory creation may require parent-by-parent creation.
+
+## Xcode 27 Beta Additions
+
+Apple documents additional beta-era MCP capability groups for active run-state control, debugger-console interaction, scheme and run-destination management, build-setting/compiler-flag/entitlement/Info.plist inspection and mutation, runtime health insights, simulator interaction, preview variants, and String Catalog workflows.
+
+These are capability groups, not stable tool names. Discover the live Xcode tool inventory before invoking a tool, apply the existing permission boundary, and hand off to the owning build, testing, debugger, Device Hub, preview, or localization workflow.
+
+Apple does not document a code-coverage MCP tool. Use the official `xcodebuild` and `xccov` coverage path when a deterministic report is required.

--- a/plugins/apple-dev-skills/tests/test_swift_package_testing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_swift_package_testing_workflow.py
@@ -98,6 +98,15 @@ class SwiftPackageTestingWorkflowTests(unittest.TestCase):
             self.assertIn("unload_models", text)
             self.assertIn("reload_models", text)
 
+    def test_skill_documents_swiftpm_coverage_collection_and_discovery(self) -> None:
+        skill_text = (ROOT / "skills/swift-package-testing-workflow/SKILL.md").read_text(encoding="utf-8")
+        coverage_text = (ROOT / "skills/swift-package-testing-workflow/references/code-coverage.md").read_text(encoding="utf-8")
+
+        self.assertIn("references/code-coverage.md", skill_text)
+        self.assertIn("swift test --enable-code-coverage", coverage_text)
+        self.assertIn("swift test --show-codecov-path", coverage_text)
+        self.assertIn("separate report-location query", coverage_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/apple-dev-skills/tests/test_xcode_coding_intelligence_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_coding_intelligence_workflow.py
@@ -81,6 +81,14 @@ class XcodeCodingIntelligenceWorkflowTests(unittest.TestCase):
         self.assertIn("Reviewable Artifacts", permissions_text)
         self.assertIn("Do not store provider API keys", permissions_text)
 
+    def test_xcode27_mcp_additions_stay_capability_based(self) -> None:
+        skill_text = self.read("skills/xcode-coding-intelligence-workflow/SKILL.md")
+        evidence_text = self.read("skills/xcode-coding-intelligence-workflow/references/source-evidence.md")
+
+        self.assertIn("discover the live Xcode MCP tool inventory", skill_text)
+        self.assertIn("Documented Xcode 27 MCP Additions", evidence_text)
+        self.assertIn("do not document a dedicated MCP code-coverage reporting tool", evidence_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/apple-dev-skills/tests/test_xcode_testing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_testing_workflow.py
@@ -150,6 +150,17 @@ class XcodeTestingWorkflowTests(unittest.TestCase):
         self.assertNotIn("unload_models", snippet_text)
         self.assertNotIn("reload_models", snippet_text)
 
+    def test_skill_documents_xcode_coverage_and_mcp_boundary(self) -> None:
+        skill_text = (ROOT / "skills/xcode-testing-workflow/SKILL.md").read_text(encoding="utf-8")
+        coverage_text = (ROOT / "skills/xcode-testing-workflow/references/code-coverage.md").read_text(encoding="utf-8")
+        mcp_text = (ROOT / "skills/xcode-testing-workflow/references/mcp-tool-matrix.md").read_text(encoding="utf-8")
+
+        self.assertIn("references/code-coverage.md", skill_text)
+        for term in ("-enableCodeCoverage YES", "-resultBundlePath", "xccov view --report --json", "does not document a coverage-report MCP tool"):
+            self.assertIn(term, coverage_text)
+        self.assertIn("Xcode 27 Beta Additions", mcp_text)
+        self.assertIn("does not document a code-coverage MCP tool", mcp_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "9.2.1"
+version = "9.3.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-inference-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-inference-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-inference-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Cloud AI inference workflow skills for routing model serving, training, conversion, and GPU infrastructure work across Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/network-protocol-skills/.codex-plugin/plugin.json
+++ b/plugins/network-protocol-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "network-protocol-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for choosing, planning, implementing, and diagnosing modern application transports and real-time networking protocols, including QUIC, HTTP/3, WebRTC, Media over QUIC, WebTransport-adjacent handoffs, protocol maturity checks, and stack-specific implementation routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "9.2.1"
+version = "9.3.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "9.2.1"
+version = "9.3.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "9.2.1"
+version = "9.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "9.2.1"
+version = "9.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Add shared coverage evidence, comparison, artifact, and gating guidance.
- Document Xcode `xcodebuild` plus `xccov` and SwiftPM coverage flows.
- Record Xcode 27 MCP capability additions without inventing a coverage MCP API.
- Bump Socket to 9.3.0.

## Verification

- Apple Dev Skills: 243 tests passed.
- Child documentation validation passed.
- Root marketplace metadata validation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive SwiftPM and Xcode code coverage guidance, including collection, reporting, validation, and comparison practices.
  - Expanded Xcode workflow guidance for beta-era MCP capabilities, simulator interaction, debugging, runtime insights, and localization workflows.

- **Documentation**
  - Clarified testing workflows, coverage boundaries, evidence requirements, CLI fallbacks, and MCP tool discovery.

- **Chores**
  - Updated the release version across the project and available plugins from 9.2.1 to 9.3.0.

- **Tests**
  - Added checks covering SwiftPM coverage documentation, Xcode coverage guidance, and capability-based MCP documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->