### PR TITLE
docs: add iOS UI automation guidance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -344,6 +344,7 @@ In Progress
 - [x] Add `apple-dev-skills:xcode-coding-intelligence-workflow` for Xcode Intelligence setup, Xcode-hosted agents, chat providers, ACP agent entries, Xcode-only config homes, command/tool permissions, and external-agent access through `xcrun mcpbridge`.
 - [ ] Add `apple-dev-skills:xcode-agent-localization-workflow` for agent-assisted string catalog, translation, glossary, XLIFF, and human-review workflows.
 - [x] Add `apple-dev-skills:xcode-device-hub-workflow` for simulated and physical device inspection, interaction, screenshots, videos, pairing, environment configuration, and diagnostics handoffs.
+- [x] Extend `xcode-testing-workflow`, `xcode-device-hub-workflow`, and `xcode-debugger-mcp-workflow` with iOS XCUITest simulator-versus-physical-device decisions, destination evidence, bounded `devicectl` support, and physical-device debugging handoffs.
 - [x] Add `apple-dev-skills:macos-window-management-workflow` for native SwiftUI/AppKit window scenes, chrome, drag regions, placement, resize/zoom, restoration, and validation.
 - [x] Add `apple-dev-skills:apple-runtime-telemetry-workflow` for focused unified logging, privacy-aware `Logger` use, `OSSignposter`, and runtime-evidence handoffs.
 - [ ] Add `apple-dev-skills:apple-beta-docs-triage-workflow` for new Apple beta drops, current-docs checks, availability gates, SDK requirements, and skill-routing decisions.

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -577,6 +577,7 @@ Completed
 - [x] Keep Swift Testing, XCTest, XCUITest, and `.xctestplan` execution with `xcode-testing-workflow`.
 - [x] Mark Xcode 27 beta claims with the date checked and separate them from local Xcode 26.5 `mcpbridge` evidence.
 - [x] Add shared Xcode and SwiftPM code-coverage guidance, and keep coverage reporting on documented CLI tools unless a live Xcode MCP session exposes an equivalent contract.
+- [x] Add iOS XCUITest simulator-versus-physical-device destination guidance, preserve `.xcresult` as the automation authority, and connect physical-device failures to Device Hub, bounded `devicectl`, and active-Xcode debugger evidence.
 
 ### Tickets
 

--- a/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-debugger-mcp-workflow/SKILL.md
@@ -43,6 +43,10 @@ This is a local Beta 3 packaging observation. Public Xcode release notes announc
 - Do not replace Xcode's normal debugger session with an unverified third-party MCP server.
 - Do not assume standalone `lldb-mcp` reaches the debugger that Xcode already owns; its public contract describes LLDB MCP discovery or a separately launched `lldb` process.
 
+## Physical-device debugging
+
+For a physical-device failure, keep the XCUITest or run result as the primary failure record. Confirm the paired device identity, app build, OS version, and triggering action through `xcode-device-hub-workflow`, then use the active Xcode debugger session for one focused breakpoint, backtrace, frame inspection, or bounded LLDB command. Preserve only the minimum device-specific diagnostics or screen evidence needed to explain the failure, and do not alter pairing, Developer Mode, app data, or device settings unless the user explicitly requests that state change.
+
 ## References
 
 - `references/beta3-capability-evidence.md`

--- a/plugins/apple-dev-skills/skills/xcode-device-hub-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-device-hub-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: Manage and validate simulated and physical Apple devices through Xc
 
 ## Purpose
 
-Use Device Hub as Xcode's native surface for simulated and physical device work. It owns device selection, interaction, environment inspection, pairing, captures, and diagnostics; it does not replace project build/run, test, debugger, provisioning, or browser-mirror ownership.
+Use Device Hub as Xcode's native surface for simulated and physical device work. It owns device selection, interaction, environment inspection, pairing, captures, and diagnostics; it does not replace project build/run, test, debugger, provisioning, or browser-mirror ownership. Use `xcrun devicectl` as its scriptable companion only for a bounded device-management or diagnostic need, never as a substitute for an XCUITest result.
 
 ## When To Use
 
@@ -26,7 +26,7 @@ Use Device Hub as Xcode's native surface for simulated and physical device work.
 5. For a physical device, inspect pairing and Developer Mode state before attempting a run. Pairing, trust prompts, Developer Mode, unpairing, and configuration changes require explicit user intent at the point of mutation.
 6. Run or interact with the app through its owning build/run workflow. Device Hub interaction is proof of the same target device state, not a separate app runtime.
 7. Capture a screenshot or video only after the requested state is visible. Record the device identity, app state, and destination path; Device Hub screenshots are full device resolution and may contain sensitive content.
-8. Download diagnostics only when they are relevant to the reported failure, then hand the artifact to the debugger, runtime-forensics, or test workflow. State the artifact's source and avoid copying private device data into logs or commits.
+8. Download diagnostics only when they are relevant to the reported failure, then hand the artifact to the debugger, runtime-forensics, or test workflow. State the artifact's source and avoid copying private device data into logs or commits. For a repeatable script or CI need, inspect the selected toolchain's `xcrun devicectl --help` contract first and preserve the same device identifier in the resulting evidence.
 9. Stop the app or device session through its owner. Do not erase, remove, unpair, or reset a device as routine cleanup.
 
 ## Outputs
@@ -43,6 +43,7 @@ Use Device Hub as Xcode's native surface for simulated and physical device work.
 - Do not pair, unpair, enable Developer Mode, remove a simulator, erase data, or change a physical-device setting without the user's explicit action request.
 - Do not expose a Device Hub screen or capture over a LAN, tunnel, or external browser surface. That is a separate AgentDeck runtime decision.
 - Do not call a loaded Device Hub window proof that an app build, launch, or test passed; verify the requested frame, log, test result, or diagnostic instead.
+- Do not treat `devicectl` installation, launch, screen interaction, or a Device Hub capture as proof that an XCUITest passed. Keep the test result and `.xcresult` as the automation authority.
 
 ## References
 

--- a/plugins/apple-dev-skills/skills/xcode-device-hub-workflow/references/device-hub-safety-and-handoffs.md
+++ b/plugins/apple-dev-skills/skills/xcode-device-hub-workflow/references/device-hub-safety-and-handoffs.md
@@ -12,3 +12,5 @@ Use the smallest surface that proves the question:
 | Browser-visible mirror or package preview host | future AgentDeck runtime; unavailable until its bridge status says ready |
 
 Pairing, unpairing, Developer Mode, device removal, erase/reset, and environment changes affect user-owned device state. Read the state first and require an explicit requested action before changing it. A screenshot or diagnostic should identify the exact device and app state that produced it.
+
+For a physical-device UI-test failure, preserve the XCUITest result and `.xcresult` first. Use Device Hub for the visible state and a relevant diagnostic, `xcrun devicectl` for a bounded scripted device-management or diagnostic action, and `xcode-debugger-mcp-workflow` for an active Xcode source-level debugging session. These artifacts complement one another; none replaces the test result.

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/SKILL.md
@@ -44,6 +44,7 @@ Use this skill as the primary execution workflow for test-focused work in or aro
    - `references/code-coverage.md` for Xcode coverage collection, `.xcresult` artifacts, `xccov` reporting, comparison, and the Xcode 27 MCP boundary
    - `references/xctestplan-configurations-and-matrix.md` for `.xctestplan`, launch-argument matrices, named configurations, and Debug/Release test coverage
    - `references/xcuitest-and-xcuiautomation.md` for UI automation mechanics, waits, interruption handling, activities, and attachments
+   - `references/ios-ui-automation-destinations.md` for iOS simulator-versus-physical-device XCUITest decisions, destination evidence, and physical-device debugging handoffs
    - `references/ui-accessibility-verification.md` for accessibility-specific runtime verification expectations and coordination with `apple-ui-accessibility-workflow`
    - `references/instruments-performance-profiling.md` for Instruments, `xctrace`, Time Profiler, Metal System Trace, Allocations, VM Tracker, Points of Interest, and signpost-aligned trace evidence
    - `references/testing-plans-file-membership-and-configurations.md` for the condensed cross-cutting summary and file-membership reminder
@@ -123,6 +124,7 @@ Use this skill as the primary execution workflow for test-focused work in or aro
 - `references/code-coverage.md`
 - `references/xctestplan-configurations-and-matrix.md`
 - `references/xcuitest-and-xcuiautomation.md`
+- `references/ios-ui-automation-destinations.md`
 - `references/ui-accessibility-verification.md`
 - `references/instruments-performance-profiling.md`
 - `references/testing-plans-file-membership-and-configurations.md`

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/ios-ui-automation-destinations.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/ios-ui-automation-destinations.md
@@ -1,0 +1,44 @@
+# iOS UI Automation Destinations
+
+Use the same XCUITest target and test-plan configuration on simulators and physical devices where the behavior under test is shared. The destination changes the evidence required; it is not a reason to duplicate ordinary UI-test code.
+
+## Simulator-first coverage
+
+Use a simulated iPhone or iPad as the default destination for fast, repeatable UI automation:
+
+- common navigation, validation, and regression flows
+- launch-argument and environment-backed fixtures
+- locale, Dynamic Type, appearance, orientation, and accessibility matrices
+- deterministic state-reset and broad device-size coverage
+
+Record the simulator identifier, runtime, device model, app build, selected test-plan configuration, and resulting `.xcresult` bundle when the result will be compared or shared. Keep matrix variants in a versioned `.xctestplan` instead of relying on an operator's remembered Simulator settings.
+
+Simulator output is not proof of hardware performance, battery or thermal behavior, physical touch ergonomics, device GPU output, radios, cameras, sensors, push delivery, or background execution. Move the affected scenario to a physical device when any of those conditions is part of the claim.
+
+## Physical-device coverage
+
+Run the smallest focused XCUITest flow on a paired physical device when the behavior depends on hardware or a real device environment. Before the run, confirm the device name, identifier, platform and OS version, pairing/trust state, Developer Mode state, signed app build, scheme, and test-plan configuration.
+
+Use an explicit Xcode destination identifier for command-line execution, rather than selecting a device by display name. Keep the result bundle and failure attachments with the device identity so a simulator result cannot be mistaken for hardware proof.
+
+For a physical-device failure, capture one bounded evidence packet:
+
+1. the test name, app build, test-plan configuration, device identifier, and OS version
+2. the failing activity and any XCUITest attachment or `.xcresult` evidence
+3. one Device Hub screenshot or video only when it shows the relevant visible state
+4. a targeted diagnostic only when it can explain the failure
+5. the active Xcode debugger frame, variables, or focused LLDB output when source-level diagnosis is needed
+
+Do not reset, erase, unpair, change Developer Mode, or alter a physical device's configuration as test cleanup unless the user explicitly requested that state change.
+
+## Handoffs
+
+- Use `xcode-device-hub-workflow` to inspect, interact with, capture from, or collect diagnostics from the selected simulator or physical device.
+- Use `xcode-debugger-mcp-workflow` for a running app with a source-level failure. Its active Xcode-session route is the normal debugger path for both simulator and physical-device runs.
+- Use `ios-runtime-forensics-workflow` only for its simulator-owned ETTrace and memory-graph evidence. Capture performance, thermal, battery, and hardware GPU claims on a physical device with the appropriate Xcode or Instruments workflow instead.
+
+## Apple documentation
+
+- [Testing in Simulator versus testing on hardware devices](https://developer.apple.com/documentation/xcode/testing-in-simulator-versus-testing-on-hardware-devices)
+- [Running your app on simulated or physical devices](https://developer.apple.com/documentation/xcode/running-your-app-on-simulated-or-physical-devices)
+- [Testing](https://developer.apple.com/documentation/xcode/testing)

--- a/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/xcuitest-and-xcuiautomation.md
+++ b/plugins/apple-dev-skills/skills/xcode-testing-workflow/references/xcuitest-and-xcuiautomation.md
@@ -22,6 +22,11 @@
 - Keep launch arguments and environment variables explicit when UI state, feature flags, locale, accessibility matrices, or deterministic fixtures depend on them.
 - Prefer `.xctestplan` when those launch settings are part of a repeatable verification matrix instead of a one-off local run.
 
+## iOS destinations
+
+- Use `ios-ui-automation-destinations.md` to decide whether a simulator result is sufficient or a physical-device XCUITest run is required.
+- Keep shared UI-test code destination-neutral. Make the destination and its evidence explicit in the test invocation or test-plan result instead of branching the test for simulator versus hardware.
+
 ## Review questions
 
 - What makes this UI test stable?

--- a/plugins/apple-dev-skills/tests/test_xcode_device_window_telemetry_debugger_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_device_window_telemetry_debugger_workflows.py
@@ -20,6 +20,7 @@ class XcodeDeviceWindowTelemetryDebuggerWorkflowTests(unittest.TestCase):
             self.assertIn(term, skill + evidence)
         self.assertIn("future AgentDeck runtime", skill)
         self.assertIn("Do not erase, remove, unpair, or reset", skill)
+        self.assertIn("xcrun devicectl", skill)
         self.assertIn("$xcode-device-hub-workflow", prompt)
 
     def test_window_workflow_keeps_native_chrome_and_restoration_contracts(self) -> None:
@@ -50,6 +51,7 @@ class XcodeDeviceWindowTelemetryDebuggerWorkflowTests(unittest.TestCase):
             self.assertIn(term, skill + evidence + contract)
         self.assertIn("Do not work around this", skill)
         self.assertIn("xcode-build-run-workflow", skill)
+        self.assertIn("Physical-device debugging", skill)
 
 
 if __name__ == "__main__":

--- a/plugins/apple-dev-skills/tests/test_xcode_testing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_testing_workflow.py
@@ -110,10 +110,26 @@ class XcodeTestingWorkflowTests(unittest.TestCase):
 
         self.assertIn("xctestplan-configurations-and-matrix.md", skill_text)
         self.assertIn("xcuitest-and-xcuiautomation.md", skill_text)
+        self.assertIn("ios-ui-automation-destinations.md", skill_text)
         self.assertIn("ui-accessibility-verification.md", skill_text)
         self.assertIn("-only-test-configuration", plan_text)
         self.assertIn("waitForExistence(timeout:)", ui_text)
         self.assertIn("apple-ui-accessibility-workflow", accessibility_text)
+
+    def test_skill_documents_ios_simulator_and_physical_device_boundaries(self) -> None:
+        destination_text = (
+            ROOT / "skills/xcode-testing-workflow/references/ios-ui-automation-destinations.md"
+        ).read_text(encoding="utf-8")
+
+        for term in (
+            "Simulator-first coverage",
+            "Physical-device coverage",
+            "`.xcresult`",
+            "xcode-device-hub-workflow",
+            "xcode-debugger-mcp-workflow",
+            "hardware performance",
+        ):
+            self.assertIn(term, destination_text)
 
     def test_skill_documents_xcodegen_test_project_maintenance(self) -> None:
         skill_text = (ROOT / "skills/xcode-testing-workflow/SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add simulator-versus-physical-device XCUITest destination guidance
- define Device Hub, devicectl, and active-Xcode debugger evidence handoffs
- cover the guidance with workflow tests

## Verification
- bash .github/scripts/validate_repo_docs.sh (plugins/apple-dev-skills)
- uv run pytest (plugins/apple-dev-skills)
- uv run pytest
- uv run mypy
- uv run scripts/validate_socket_metadata.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for choosing between iOS simulators and physical devices for XCUITest coverage.
  * Clarified required evidence, including test results and `.xcresult` files.
  * Added handoff guidance for device diagnostics, bounded device management, and focused debugger investigations.
  * Documented safeguards for preserving device privacy and avoiding unnecessary device changes.
  * Updated roadmap and workflow references to reflect the expanded coverage.

* **Tests**
  * Added coverage checks for simulator/physical-device guidance and physical-device debugging documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->