### PR TITLE
localization: add Xcode String Catalog workflow

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -342,7 +342,7 @@ In Progress
 ### Tickets
 
 - [x] Add `apple-dev-skills:xcode-coding-intelligence-workflow` for Xcode Intelligence setup, Xcode-hosted agents, chat providers, ACP agent entries, Xcode-only config homes, command/tool permissions, and external-agent access through `xcrun mcpbridge`.
-- [ ] Add `apple-dev-skills:xcode-agent-localization-workflow` for agent-assisted string catalog, translation, glossary, XLIFF, and human-review workflows.
+- [x] Add `apple-dev-skills:xcode-localization-workflow` for durable String Catalog setup, source extraction, translator context, plural/device variants, XLIFF, human review, locale validation, and optional Xcode 27 agent-assisted translation.
 - [x] Add `apple-dev-skills:xcode-device-hub-workflow` for simulated and physical device inspection, interaction, screenshots, videos, pairing, environment configuration, and diagnostics handoffs.
 - [x] Extend `xcode-testing-workflow`, `xcode-device-hub-workflow`, and `xcode-debugger-mcp-workflow` with iOS XCUITest simulator-versus-physical-device decisions, destination evidence, bounded `devicectl` support, and physical-device debugging handoffs.
 - [x] Add `apple-dev-skills:macos-window-management-workflow` for native SwiftUI/AppKit window scenes, chrome, drag regions, placement, resize/zoom, restoration, and validation.

--- a/docs/maintainers/xcode-27-agentic-tooling-plan.md
+++ b/docs/maintainers/xcode-27-agentic-tooling-plan.md
@@ -133,17 +133,18 @@ Non-goals:
 - Do not add a second packaging layer to Socket until a concrete Xcode import shape is verified.
 - Do not make a beta-only distribution promise before local install testing works.
 
-### 3. `xcode-agent-localization-workflow`
+### 3. `xcode-localization-workflow`
 
 Job:
 
-- Guide Xcode agent-assisted localization work from preparation through review.
+- Guide durable Xcode String Catalog localization from preparation through review, with agent-assisted translation as an optional Xcode 27 beta-era path.
 
 Scope:
 
-- Add languages with Xcode-hosted agents.
+- Add and organize catalogs, languages, and regions through Xcode's stable localization surfaces.
 - Update string catalogs by building the project where Xcode requires it.
-- Use `String(localized:)` and platform-localizable APIs when strings are missed.
+- Use `Text`, `String(localized:)`, `AttributedString(localized:)`, `LocalizedStringResource`, and owning resource bundles when strings are missed or cross module boundaries.
+- Cover source comments, glossary terms, non-translatable strings, tone, region, audience, plurals, device variants, generated symbols, and locale-aware formatting before translation.
 - Preserve or create project translation guidance such as `TRANSLATION.md`.
 - Track glossary terms, non-translatable strings, tone, region, and audience.
 - Explain that Xcode marks generated translations as machine translated in string catalogs and XLIFF exports.
@@ -302,7 +303,7 @@ uv run pytest
 
 ### Slice 3: Localization And Device Hub
 
-- Add `xcode-agent-localization-workflow`.
+- Add `xcode-localization-workflow` as a stable catalog-first workflow with optional agent-assisted translation.
 - Add `xcode-device-hub-workflow`.
 - Update plugin metadata and Apple Dev Skills roadmap.
 - Add handoff notes from build/test/UI skills.

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -46,6 +46,9 @@
     "photosui",
     "photos-picker",
     "coding-intelligence",
+    "localization",
+    "string-catalog",
+    "xliff",
     "agents",
     "mcp",
     "lldb",
@@ -91,7 +94,7 @@
   "interface": {
     "displayName": "Apple Dev Skills",
     "shortDescription": "Apple, Swift, image/media repair, SwiftUI, TipKit, Xcode, AppKit, Safari, security, OpenAPI, and DocC workflows for Codex.",
-    "longDescription": "Bundle Apple-platform development skills for PhotosUI selection and PhotoKit libraries/editing, VideoToolbox codecs, Core Video buffers, compressed samples, color/HDR, ARKit spatial/face/body sensing, world tracking, scene depth, LiDAR meshes and visionOS providers, AVFoundation camera/photo/depth/computational capture, Core Image, Image I/O, Apple Vision, custom Core ML recognition, AppKit/UIKit/Core Graphics images, AVFAudio, AVAudioEngine, AVFoundation media pipelines, Core Media, Core Audio, TipKit, XcodeGen migration, Xcode coding intelligence, Swift, SwiftUI, Core Animation, Apple typography, SF Symbols, AppKit, Icon Composer, Safari, DeviceCheck and App Attest, Swift OpenAPI clients, Xcode, SwiftPM, DocC, testing, formatting, and repository guidance. Most workflows work standalone; bootstrap and guidance-sync workflows require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
+    "longDescription": "Bundle Apple-platform development skills for PhotosUI selection and PhotoKit libraries/editing, VideoToolbox codecs, Core Video buffers, compressed samples, color/HDR, ARKit spatial/face/body sensing, world tracking, scene depth, LiDAR meshes and visionOS providers, AVFoundation camera/photo/depth/computational capture, Core Image, Image I/O, Apple Vision, custom Core ML recognition, AppKit/UIKit/Core Graphics images, AVFAudio, AVAudioEngine, AVFoundation media pipelines, Core Media, Core Audio, TipKit, XcodeGen migration, Xcode coding intelligence and String Catalog localization, Swift, SwiftUI, Core Animation, Apple typography, SF Symbols, AppKit, Icon Composer, Safari, DeviceCheck and App Attest, Swift OpenAPI clients, Xcode, SwiftPM, DocC, testing, formatting, and repository guidance. Most workflows work standalone; bootstrap and guidance-sync workflows require the companion Productivity Skills plugin, or the socket marketplace that installs both.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -117,6 +120,7 @@
       "Decide when Core Animation is justified, then repair CALayer trees, CAAnimation timing, transactions, model/presentation behavior, and layer-backed framework bridges.",
       "Choose Apple system typography, Dynamic Type, San Francisco or New York system designs, custom font integration, and font licensing boundaries.",
       "Set up Xcode coding intelligence, Xcode-hosted agents, external-agent MCP access through xcrun mcpbridge, and command/tool permission boundaries.",
+      "Plan or implement Xcode String Catalog localization with source extraction, translator context, plural and device variants, XLIFF review, and locale-aware UI validation.",
       "Use Xcode Device Hub to inspect simulated or physical devices, vary a simulator environment, capture evidence, and hand off diagnostics safely.",
       "Debug a running Apple app through Xcode's active LLDB session and verify whether the selected Xcode toolchain can start standalone lldb-mcp.",
       "Design and validate native macOS window scenes, chrome, drag regions, placement, restoration, and utility-window behavior.",

--- a/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
+++ b/plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
@@ -154,8 +154,9 @@ active_skill_mds=(
   "./skills/sync-xcode-project-guidance/SKILL.md"
   "./skills/sync-swift-package-guidance/SKILL.md"
   "./skills/xcode-coding-intelligence-workflow/SKILL.md"
+  "./skills/xcode-localization-workflow/SKILL.md"
 )
-[[ ${#active_skill_mds[@]} -eq 48 ]] || fail "Expected exactly 48 active skills, found ${#active_skill_mds[@]}."
+[[ ${#active_skill_mds[@]} -eq 49 ]] || fail "Expected exactly 49 active skills, found ${#active_skill_mds[@]}."
 
 shared_xcode_snippet="./shared/agents-snippets/apple-xcode-project-core.md"
 shared_package_snippet="./shared/agents-snippets/apple-swift-package-core.md"

--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -79,6 +79,7 @@ Use Apple Dev Skills when an agent is helping with:
 - Xcode build, run, test, and project workflows
 - XcodeGen migration and modernization for existing Xcode app projects
 - Xcode coding intelligence, Xcode-hosted agents, and external-agent MCP setup
+- Xcode String Catalog localization, translator context, plural/device variants, XLIFF handoff, and locale-aware validation
 - Icon Composer app icon design, preview, and Xcode handoff
 - Safari extension and SafariServices integration choices
 - DeviceCheck per-device state and App Attest app-integrity flow planning
@@ -190,6 +191,7 @@ uv run pytest
 - `xcode-coding-intelligence-workflow`
 - `xcode-debugger-mcp-workflow`
 - `xcode-device-hub-workflow`
+- `xcode-localization-workflow`
 - `xcode-testing-workflow`
 
 ## Release Notes

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -40,6 +40,7 @@ Swift naming and persistence ownership are now standardized: each project explic
 - [Milestone 61: Photos Library and Media Selection](#milestone-61-photos-library-and-media-selection)
 - [Milestone 62: Media Expansion Audit and Socket Major Release](#milestone-62-media-expansion-audit-and-socket-major-release)
 - [Milestone 63: System Integration, Runtime Evidence, and Distribution](#milestone-63-system-integration-runtime-evidence-and-distribution)
+- [Milestone 64: Xcode String Catalog Localization Workflow](#milestone-64-xcode-string-catalog-localization-workflow)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -98,6 +99,7 @@ Swift naming and persistence ownership are now standardized: each project explic
 - Milestone 61: Photos Library and Media Selection - Completed
 - Milestone 62: Media Expansion Audit and Socket Major Release - Completed
 - Milestone 63: System Integration, Runtime Evidence, and Distribution - In Progress
+- Milestone 64: Xcode String Catalog Localization Workflow - Completed
 
 ## Milestone 21: Swift Cleanup Automation Exploration
 
@@ -1190,6 +1192,26 @@ In Progress
 
 - [ ] All five workflows, metadata, inventory, tests, and root Socket documentation validate together.
 - [ ] Each workflow relies on current Apple documentation and names an honest evidence boundary.
+
+## Milestone 64: Xcode String Catalog Localization Workflow
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add a durable, catalog-first Xcode localization workflow instead of limiting guidance to Xcode 27 agent translation.
+- [x] Cover String Catalog setup, build-backed extraction, localizable SwiftUI and Foundation APIs, resource bundles, comments, tables, generated symbols, plurals, device variants, XLIFF, and locale-aware validation.
+- [x] Keep Xcode 27 agent translation optional, beta-scoped, provenance-aware, and dependent on fluent human review.
+
+### Exit Criteria
+
+- [x] The repository ships `xcode-localization-workflow` with implementation and validation guidance that applies without Xcode agents.
+- [x] Plugin metadata, active-skill inventory, roadmap, and docs validation recognize the new skill.
+- [x] Targeted tests prove the catalog-first, human-review, and beta-boundary contracts.
+
+Completed Milestone 64 by shipping `xcode-localization-workflow` as the durable owner of String Catalog localization. The workflow makes stable source extraction, catalog organization, translator context, plural/device variants, XLIFF review, and locale-aware validation the core path, and treats Xcode 27 agent translation only as an explicitly bounded optional enhancement.
 
 ## Backlog Candidates
 

--- a/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
+++ b/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
@@ -8,8 +8,8 @@ Record the Milestone 20 audit of the current customization system, decide whethe
 
 ## Current State Summary
 
-- The active skill surface ships `48` separate `references/customization.template.yaml` files.
-- The active skill surface ships `48` separate `scripts/customization_config.py` entrypoints.
+- The active skill surface ships `49` separate `references/customization.template.yaml` files.
+- The active skill surface ships `49` separate `scripts/customization_config.py` entrypoints.
 - Those `customization_config.py` files are functionally identical and exist only because installed skills are expected to keep runtime resources inside the skill directory.
 - The current templates expose `21` knobs total:
   - `20` are documented as `runtime-enforced`
@@ -30,7 +30,7 @@ Milestone 20 audited a larger surface before the implementation pass landed.
 - Milestone 27 applied the approved reduction so the live surface now reflects the smaller counts in the current-state summary above.
 - Milestone 38 later added the narrower `author-swift-docc-docs` skill with one runtime-enforced tutorial-handling knob, which is included in the current-state counts above.
 - The current-state counts also include `structure-swift-sources`, which now ships runtime-enforced header-policy and split-threshold knobs for the structural-cleanup workflow.
-- The current-state counts now also include the no-runtime-knob `apple-ui-accessibility-workflow`, `safari-extension-control-workflow`, `devicecheck-app-attest-workflow`, `apple-developer-provisioning-workflow`, `swiftui-app-architecture-workflow`, `swiftui-component-audit-workflow`, `swiftui-animation-workflow`, `sf-symbols-workflow`, `core-animation-layer-workflow`, `apple-typography-workflow`, `appkit-app-architecture-workflow`, `xcode-coding-intelligence-workflow`, `migrate-xcode-project-to-xcodegen`, `avfaudio-session-workflow`, `avaudio-engine-workflow`, `avfoundation-media-pipeline-workflow`, `coremedia-timing-samplebuffer-workflow`, and `coreaudio-modernization-repair-workflow` surfaces, all of which keep the customization-file contract without introducing runtime knobs.
+- The current-state counts now also include the no-runtime-knob `apple-ui-accessibility-workflow`, `safari-extension-control-workflow`, `devicecheck-app-attest-workflow`, `apple-developer-provisioning-workflow`, `swiftui-app-architecture-workflow`, `swiftui-component-audit-workflow`, `swiftui-animation-workflow`, `sf-symbols-workflow`, `core-animation-layer-workflow`, `apple-typography-workflow`, `appkit-app-architecture-workflow`, `xcode-coding-intelligence-workflow`, `xcode-localization-workflow`, `migrate-xcode-project-to-xcodegen`, `avfaudio-session-workflow`, `avaudio-engine-workflow`, `avfoundation-media-pipeline-workflow`, `coremedia-timing-samplebuffer-workflow`, and `coreaudio-modernization-repair-workflow` surfaces, all of which keep the customization-file contract without introducing runtime knobs.
 
 ## Decision
 

--- a/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-coding-intelligence-workflow/SKILL.md
@@ -72,6 +72,7 @@ Beta-specific note: Xcode 27 claims in this skill were checked against Apple dev
 6. Hand off execution:
    - build, run, preview, file membership, and project-integrity work goes to `xcode-build-run-workflow`
    - Swift Testing, XCTest, XCUITest, and `.xctestplan` work goes to `xcode-testing-workflow`
+   - durable String Catalog implementation, translation review, and locale validation go to `xcode-localization-workflow`
    - docs lookup goes to `explore-apple-swift-docs`
    - repo guidance sync goes to `sync-xcode-project-guidance`
 7. Report:

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: xcode-localization-workflow
+description: Plan, implement, review, and validate Apple-platform localization with Xcode String Catalogs. Use for .xcstrings setup, localizable SwiftUI and Foundation text, string tables, comments, plural and device variants, XLIFF handoff, locale UI checks, or Xcode 27 agent-assisted translation.
+---
+
+# Xcode Localization Workflow
+
+## Purpose
+
+Make an Apple app understandable and usable in its supported languages, regions, and interface directions. This workflow owns the durable localization path: String Catalog setup, source-code extraction, translator context, translation handoff, and locale-aware UI evidence. It treats Xcode 27 agent translation as an optional beta-era acceleration, never as the reason to adopt localization or as proof that a translation is ready to ship.
+
+Use Xcode String Catalogs (`.xcstrings`) as the default catalog format for current Xcode projects. They centralize extracted strings, translations, plural variants, and device-specific variants. They do not make arbitrary runtime strings, poor source context, date/number formatting, or clipped layouts localizable by themselves.
+
+## When To Use
+
+- Use this workflow when adding, repairing, migrating to, or reviewing a String Catalog.
+- Use it for localizable SwiftUI, UIKit, AppKit, Foundation, attributed text, bundle/table, plural, device-variation, XLIFF, or translation-context work.
+- Use it when an Xcode-hosted or external agent is asked to add languages or translate a catalog.
+- Hand project inspection, source membership, build, and Xcode-managed project mutation to `xcode-build-run-workflow`.
+- Hand locale-aware test design and execution to `xcode-testing-workflow`; hand visual destination selection and physical-device evidence to `xcode-device-hub-workflow`.
+- Hand accessibility semantics, Dynamic Type, VoiceOver, and bidirectional-layout concerns to `apple-ui-accessibility-workflow`.
+- Hand agent setup, permissions, and live Xcode 27 MCP capability discovery to `xcode-coding-intelligence-workflow`.
+
+## Single-Path Workflow
+
+1. Establish the localization contract before editing. Record the development language, supported language-and-region pairs, audience, tone, terminology, names that must remain unchanged, and which content is intentionally not user-facing. Put durable translator-facing guidance in `TRANSLATION.md` when the project needs more than a few code comments.
+2. Inspect the app for user-visible text and its owning bundle. Do not localize identifiers, logging, protocol values, stable machine-readable data, accessibility identifiers, or text that a product requirement explicitly preserves. Do localize visible labels, actions, errors, empty states, onboarding, notifications, and format strings.
+3. Add `Localizable.xcstrings` through Xcode's String Catalog file template when the target has no catalog. Keep one default catalog until a catalog has a real ownership boundary, such as Navigation or a separately shipped feature. Use a named `table` or `tableName` only when the corresponding catalog exists.
+4. Make source text discoverable and contextual:
+   - SwiftUI view literals such as `Text("Continue")` are localizable by default; use the API's `comment` parameter when the visual role or meaning is ambiguous.
+   - Use `String(localized:table:bundle:locale:comment:)` for a resolved Foundation string, including UIKit and AppKit controls. Use `AttributedString(localized:...)` when localized Markdown or attributed content is required.
+   - Use `LocalizedStringResource` when a localized resource must cross an API or process boundary before resolution. Specify the owning bundle for code in a framework or Swift package rather than silently reading the app's main bundle.
+   - Prefer static literals or explicit static keys with a development-language default. Do not expect Xcode extraction to resolve a dynamically constructed key, table, or comment.
+   - Never concatenate translated fragments, inject grammatical punctuation outside the localized sentence, or use English singular/plural branching in code. Put values into one localizable interpolated string so translators can reorder or inflect them.
+5. Build every relevant target. Xcode discovers localizable API calls and updates the catalog on build; inspect each new or changed entry in the catalog's source view. Treat a clean build as extraction evidence, not as translation or visual-fit evidence.
+6. Add the requested language and region variants in the catalog or project localization settings. Provide translator comments that explain role, audience, variable meaning, constraints, and whether a term is a product name. Enable Xcode's automatic comment generation only as a supplement to deliberately written context.
+7. Model language-specific variation in the catalog:
+   - For count-dependent text, start with interpolation, build, then choose **Vary by Plural**. Review the forms Xcode creates for every target language; do not assume English's one/other rules apply elsewhere.
+   - Add device variants only when the wording genuinely differs by device, not to hide a layout problem.
+   - Prefer localized `FormatStyle` APIs for dates, numbers, measurements, lists, and names. Do not translate preformatted English data or bake locale-specific formatting into a catalog string.
+8. Translate and review. Enter known translations in Xcode or export an `.xcloc` package for a localization service, then import and review the resulting diff. Mark uncertain strings as needing review. A person fluent in the target language and region must review terminology, grammar, tone, placeholders, and cultural suitability before release.
+9. Validate the product, not merely catalog completeness. Build the affected targets; run locale-specific tests where available; inspect representative long-text, Dynamic Type, right-to-left, plural, device-variant, error, onboarding, and system-dialog states. Use simulator evidence for normal visual behavior and a physical device where hardware or production-only behavior matters.
+10. Use Xcode 27 agent translation only after the stable path above is in place. Confirm the installed Xcode version, the agent surface, permission boundary, and live String Catalog tool inventory through `xcode-coding-intelligence-workflow`. Preserve glossary and project guidance, review the generated catalog/XLIFF changes, and retain Xcode's machine-translation provenance. Do not present agent output as human-reviewed translation.
+
+## Inputs
+
+- `request`: the localization change, audit, migration, or translation task.
+- `targets`: optional app, framework, package, or extension targets that own localizable text.
+- `locales`: optional supported languages and regions; discover and confirm them when omitted.
+- `translation_surface`: optional `catalog-editor`, `xliff`, `agent`, or `unknown`; default to the catalog editor when no external translation handoff is required.
+- `validation_focus`: optional emphasis such as `plurals`, `rtl`, `dynamic-type`, `formatting`, `device-variants`, or `full`.
+
+## Implementation Choices
+
+### Keys, values, and generated symbols
+
+Development-language literals are appropriate when a string's value is a stable, readable key. For product copy that must evolve independently from call sites, add a catalog key and use Xcode-generated `LocalizedStringResource` symbols. This avoids duplicating a key in code while preserving a typed parameter surface for format placeholders.
+
+Choose one convention per catalog: readable development-language literals or semantic keys with explicit default values. Do not mix conventions casually in the same feature because translators and reviewers lose a predictable source of truth.
+
+### Tables and bundles
+
+Tables are an organizational boundary, not a workaround for missing context. Keep the default `Localizable` catalog for small apps. Split only when a distinct feature, framework, or ownership boundary makes translation handoff clearer. When code belongs to a framework or Swift package, pass its resource bundle explicitly and test that bundle's localization independently.
+
+### Legacy resources
+
+Do not bulk-convert `.strings` and `.stringsdict` resources without checking deployment targets, existing localization-service contracts, and source control diffs. String Catalogs are the recommended current Xcode path, including plural handling, but a migration should preserve every supported locale and plural form. Keep a legacy file only when a real compatibility or external-tool constraint requires it; do not create parallel duplicate catalogs as a fallback.
+
+## Outputs
+
+- supported language/region contract and translation guidance location
+- catalog and table ownership, source APIs, and resource-bundle decision
+- build-backed extraction result and reviewed catalog diff
+- translation provenance and human-review status for every target locale
+- locale, Dynamic Type, right-to-left, and device evidence or explicit gaps
+- handoff to build/run, testing, Device Hub, accessibility, or coding-intelligence workflows
+
+## Guards and Stop Conditions
+
+- Do not hard-code a `DEVELOPER_DIR`, DerivedData location, product path, or simulator identifier. Use the selected Xcode toolchain and the owning build/device workflow.
+- Do not infer translation quality from a 100-percent catalog indicator, an agent result, or a successful import.
+- Do not translate privacy-sensitive user content, source code, logs, identifiers, secrets, or machine-readable protocol values through a catalog or an external translation service without explicit approval.
+- Do not use string concatenation, runtime-generated localization keys, English plural logic, or unlocalized format values as a shortcut.
+- Do not claim right-to-left support from a left-to-right simulator pass. Inspect a right-to-left locale and the affected directional UI.
+- Do not perform an XLIFF import, add a language, or apply agent-generated translations without a reviewable diff and explicit scope for the changed locale set.
+- Do not claim stable Xcode behavior from an Xcode 27 beta agent capability. Date beta evidence and confirm the installed Xcode surface before use.
+
+Stop and surface the decision when the requested change needs a new catalog ownership model, changes a product's supported locales, migrates legacy translation assets, sends content to a third-party translation service, or broadens the translation scope beyond the approved target and language set.
+
+## Fallbacks and Handoffs
+
+- Use `xcode-build-run-workflow` when a build, target-membership, resource-bundle, or project-integrity decision is required.
+- Use `xcode-testing-workflow` for deterministic localization assertions and `xcode-device-hub-workflow` for destination-specific visual evidence.
+- Use `apple-ui-accessibility-workflow` when Dynamic Type, right-to-left, VoiceOver, or semantic UI behavior is the primary concern.
+- Use `xcode-coding-intelligence-workflow` only for Xcode 27 agent setup, permissions, or live localization-MCP capability discovery; return here for the catalog-first implementation and review path.
+
+## Customization
+
+Use `references/customization-flow.md`. The initial workflow has no runtime-enforced customization knobs; it keeps the shared configuration surface available without turning locale or translation policy into hidden machine state.
+
+Recommend `references/snippets/apple-xcode-project-core.md` when a target app repository needs durable Xcode project guidance alongside its localization contract.
+
+## References
+
+- `references/string-catalog-foundations.md`
+- `references/source-apis-and-translator-context.md`
+- `references/translation-review-and-validation.md`
+- `references/agent-assisted-translation.md`
+- `references/customization-flow.md`
+- `references/snippets/apple-xcode-project-core.md`

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/agents/openai.yaml
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Xcode Localization Workflow"
+  short_description: "Localize Apple apps with String Catalogs"
+  default_prompt: "Use $xcode-localization-workflow to plan or implement Xcode String Catalog localization, source extraction, translator context, plural or device variants, XLIFF review, and locale-aware validation."

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/agent-assisted-translation.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/agent-assisted-translation.md
@@ -1,0 +1,13 @@
+# Agent-Assisted Translation
+
+## Boundary
+
+Xcode 27's coding agents can help prepare a project, build targets to discover strings, populate String Catalogs, and identify localization issues. This is an optional beta-era workflow layered on a normal catalog-first project. It does not change the source API, ownership, review, or privacy requirements.
+
+Before invoking an agent, establish the target languages and regions, glossary, audience, tone, names to retain, prohibited translations, and which catalogs/targets are in scope. Verify the active Xcode version, agent surface, permissions, and live String Catalog tools through `xcode-coding-intelligence-workflow`; tool names are not a stable contract in this workflow.
+
+## Review contract
+
+Ask the agent to make a reviewable, bounded locale change. Inspect the catalog and XLIFF diff, preserve machine-translation provenance, and have a fluent human reviewer check the output before shipment. Re-run locale and layout validation after changes. Do not send secrets, private user content, or text outside the approved translation scope to an agent or provider.
+
+Apple's [Translate your app using agents in Xcode](https://developer.apple.com/videos/play/wwdc2026/213/) session documents the project preparation/build flow, language-specific Xcode guidance, machine-translation provenance in XLIFF, and the need to gather native-speaker feedback. The behavior is Xcode 27 beta-specific as checked on 2026-07-13.

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/customization-flow.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/customization-flow.md
@@ -1,0 +1,30 @@
+# Xcode Localization Workflow Customization Contract
+
+## Purpose
+
+Preserve the repo-wide customization-file contract without pretending the first version of `xcode-localization-workflow` already has runtime-tunable behavior.
+
+## Knobs
+
+The first version defines no documented runtime-enforced knobs.
+
+Keep the skill stable around its catalog-first localization decision model before introducing persistent settings.
+
+## Runtime Behavior
+
+- `scripts/customization_config.py` exists so the skill participates cleanly in the shared repo customization surface.
+- `xcode-localization-workflow` currently ignores persisted settings at runtime because no runtime-enforced knobs are documented yet.
+- Future runtime knobs should only be added after the skill proves a stable need for deterministic configuration.
+
+## Update Flow
+
+1. Inspect current settings with `scripts/customization_config.py effective`.
+2. If a real runtime knob is being introduced, update `SKILL.md` and the affected references first.
+3. Persist the metadata change with `scripts/customization_config.py apply --input <yaml-file>`.
+4. Re-run `scripts/customization_config.py effective` and confirm the stored values match the documented knob set.
+5. Verify the skill text and any future runtime logic agree on the same contract.
+
+## Validation
+
+1. Verify the skill does not claim runtime-tunable behavior that is not actually implemented.
+2. Verify future knobs are documented in both `SKILL.md` and this file before runtime behavior depends on them.

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/customization.template.yaml
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/customization.template.yaml
@@ -1,0 +1,3 @@
+schemaVersion: 1
+isCustomized: false
+settings: {}

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/snippets/apple-xcode-project-core.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/snippets/apple-xcode-project-core.md
@@ -1,0 +1,142 @@
+# Apple Xcode Project Core AGENTS Snippet
+
+Use this snippet in repository `AGENTS.md` files when you want baseline standards for an existing native Apple app project managed through Xcode.
+
+## General Swift Baseline
+
+- For any Swift, Apple-framework, Apple-platform, SwiftUI, SwiftData, Observation, AppKit, UIKit, Foundation-on-Apple, or Xcode-related task, read the relevant Apple documentation first before planning, proposing, or making changes.
+- For Apple, Swift, and Xcode documentation, use Xcode MCP `DocumentationSearch` first. Then use the Dash.app MCP when its installed docsets cover the question. Use Dash localhost HTTP only when the Dash.app MCP is unavailable or incomplete; use checked-out source, generated DocC, GitHub/source repositories, release notes, and readable online documentation only after those local MCP paths. Generic no-JS web search/open results, snippets, metadata shells, or bare Apple Developer URLs are not enough evidence that Apple docs were read.
+- Before proposing an architecture or implementation, state the documented API behavior, lifecycle rule, or workflow requirement being relied on.
+- Do not rely on memory, habit, or analogy as the primary source when Apple documentation exists.
+- If Apple documentation and the current code disagree, stop and report the conflict before continuing.
+- If no relevant Apple documentation can be found, say that explicitly before proceeding.
+- Prefer the simplest correct Swift that is easiest to read, reason about, and maintain.
+- Treat idiomatic Swift, Cocoa conventions, and modern Swift features as tools in service of readability, not as goals by themselves.
+- Do not add ceremony, abstraction, or boilerplate just to make code look more architectural, more generic, or more "Swifty".
+- Strongly prefer synthesized, implicit, and framework-provided behavior over custom code.
+- Prefer synthesized conformances (`Codable`, `Equatable`, `Hashable`, etc.) whenever they satisfy the actual requirements.
+- Prefer memberwise and otherwise synthesized initializers, default property values, and framework defaults over handwritten setup code.
+- Do not add `CodingKeys`, manual `Codable` methods, custom initializers, wrappers, helper types, protocols, coordinators, or extra layers unless they are required by a concrete constraint or they make the final code clearly easier to understand.
+- Prefer applicable existing framework or platform error types before inventing custom error wrappers or error hierarchies.
+- Prefer direct, simple error flows and small focused error enums only when they materially improve understanding.
+- Prefer stable, source-of-truth naming across layers when the data and meaning have not changed.
+- Treat naming consistency as a reliability feature: if the same data still serves the same purpose, keep the same name.
+- Do not rename fields just to match local style conventions when the external schema is already clear and stable.
+- Do not use automatic case-conversion strategies such as `.convertFromSnakeCase` or `.convertToSnakeCase` unless the project explicitly wants that behavior and it clearly improves readability overall.
+- When an API, cloud service, or wire format already provides clear names, preserve those names directly in Swift models and nearby code unless the meaning actually changes or a concrete collision must be resolved.
+- Preserve raw wire and persistence shapes by default; do not add DTO, domain, or view-model conversion layers unless meaning actually changes or a concrete boundary requires it.
+- Treat redundant wrappers, rename-and-copy layers, and duplicated logic as anti-patterns by default.
+- This guidance is optimized for an advanced Swift reader and may prefer dense but readable modern Swift over beginner-style explicitness.
+- Prefer explicit names that are consistent, unambiguous, and easy to scan at the call site.
+- For public Swift APIs, treat streamlined, compact, ergonomic call sites as the only acceptable default; do not grow method families, overload sets, or loosely typed entry points when one clear typed API can express the operation.
+- Prefer optional parameters with explicit default values over additional methods or overloads whenever the difference is optional behavior on the same operation.
+- When a public function, initializer, or method reaches four or more arguments or parameters, strongly prefer a named typed `struct` request, options, or configuration value so call sites stay readable and future additions do not multiply overloads.
+- Prefer enums, enum cases with associated values, and narrow typed values over strings, booleans, sentinel values, or parallel parameters whenever the domain has a closed or meaningful set of choices.
+- Prefer compact syntax when it improves local reasoning, including shorthand syntax, ternary expressions, trailing closures, enums, `switch`, `map`, `filter`, `forEach`, async iteration, `AsyncSequence`, `AsyncStream`, and `AsyncAlgorithms`.
+- Prefer explicit default values at initialization when they reduce optional-handling clutter and keep the code easier to follow.
+- When lines, chains, or expressions get long, prefer chopping them down into a clean vertical, top-down structure with straight visual flow.
+- Do not force value types by default, protocols at seams, actors by default, or other pattern slogans when a plainer concrete implementation is easier to reason about.
+- Keep code compliant with Swift 6 language mode.
+- Keep strict concurrency checking enabled.
+- Prefer modern structured concurrency (`async`/`await`, task groups, actors) over legacy async patterns when it keeps the flow clearer and more direct.
+- Make async code cancellation-aware and keep actor or task boundaries explicit instead of hiding them behind detached tasks or queue wrappers.
+- Prefer clear `Sendable` boundaries for values that cross task or actor isolation, and keep unchecked sendability exceptional and justified locally.
+- Prefer Swift Testing (`import Testing`) as the default test framework, and use XCTest only when a dependency or platform constraint requires it.
+- Prefer Swift Testing for unit-style and package-style test surfaces in modern Xcode projects, including suites, tags, parameterized tests, and direct async tests.
+- Use XCTest when the platform surface, dependency graph, or Apple tooling still expects it, and keep XCTest and Swift Testing responsibilities clearly separated when both coexist.
+- Use XCUITest for UI automation, and prefer explicit element wait APIs such as `waitForExistence(timeout:)`, `waitForNonExistence(timeout:)`, and related state waits over fixed sleeps.
+- Keep `.xctestplan` files versioned when test configurations, diagnostics, sanitizers, locale coverage, or selective plan execution matter, and inspect or run them explicitly with `xcodebuild -showTestPlans` and `xcodebuild -testPlan ...`.
+- Prefer normal Xcode and XCTest parallel execution for ordinary Swift Testing, XCTest, and XCUITest runs when the project, scheme, destination, and test plan support it. Do not serialize regular tests just because they use Swift, XCTest, async tests, UI automation, or `.xctestplan` matrices.
+- Treat tests that load large local AI or ML models, especially models over 500 million parameters, as heavy system-resource tests. Run those tests sequentially, one at a time.
+- Prefer first-party and top-tier Swift ecosystem packages from Apple, `swiftlang`, the Swift Server Work Group, and similarly trusted core Swift projects when they simplify the code and make it easier to reason about.
+- Commonly approved examples include `swift-configuration` and `swift-async-algorithms` when they reduce bespoke code and improve readability.
+- For Apple app projects, prefer Apple-native logging facilities first and allow Swift Logging where it makes the project API clearer.
+- Prefer Swift OpenTelemetry for telemetry and instrumentation when telemetry is needed, and prefer existing ecosystem integrations over bespoke wrappers.
+- Prefer a checked-in repo-root `.swiftformat` file as the default Swift formatting source of truth, and prefer a pre-commit hook that formats staged Swift sources and then verifies them with `swiftformat --lint` before commit.
+- Treat SwiftLint as an optional complementary signal layer for clarity, safety, and maintainability after SwiftFormat owns formatting shape.
+- Keep automation and CI commands deterministic, non-interactive, and explicit about toolchain, platform, and configuration assumptions.
+
+## SwiftUI and State Architecture
+
+- Treat SwiftUI as declarative component UI, closer to React, F# Fabulous, and Elm than to imperative AppKit or UIKit code. Keep views self-contained, reactive, flexible, reusable, and easy to scan from top to bottom.
+- Give each independently reusable view a declarative interface of plain values, narrow bindings, and action closures. Do not inject external ViewModels, stores, coordinators, managers, services, or other collaborating objects from one reusable view into another.
+- Choose and record one explicit three-letter uppercase prefix for every app or package. Prefix project-owned Swift files and primary declarations; exempt only `Package.swift`, externally generated Swift, and vendored third-party Swift.
+- Never use `+` in project-owned Swift filenames. Concatenate the owner and concern so Xcode navigation, rename, and refactoring keep one consistent grammar.
+- Name views `GEAWhateverView.swift` and extracted modifiers `GEAWhateverViewModifier.swift`. Do not introduce ViewModel files as a SwiftUI default.
+- Give independently editable or previewable view components their own files. Small private computed view properties or helper views may remain while they do not clutter focused editing or previews.
+- Prefix extracted child components with their complete composition owner, such as `GEASettingsSheetToggleCard.swift`.
+- Extract a custom `ViewModifier` after more than eight chained modifiers, or earlier when a coherent chain is reusable or obscures the view body.
+- Prefer straight, top-down data flow with state owned at the narrowest view, scene, or app boundary that matches the behavior.
+- Prefer `@State`, derived values, bindings, and small private helpers for component-local presentation state. When a component genuinely needs an observable state type, create and own it locally with `@State`; do not pass it to a separately reusable view.
+- Do not build monolithic views, monolithic controllers, or broad shared mutable state when a smaller component boundary would be clearer.
+- Keep updates to view-driving state minimal and localized.
+- Prefer durable identity for types that drive SwiftUI state and view updates.
+- Treat `App` as the application entry and scene composition boundary, `Scene` as the container for scene-specific lifecycle and environment, and `View` as the component rendering layer.
+- Every native app target must have exactly one app lifecycle entry point: one `@main` app type, one `main.swift`, or the platform-equivalent single launch entry. Do not add alternate app entry points, second `@main` types, duplicate `main.swift` files, target-specific app entry files, or parallel app structs for variants. When launch behavior must differ by platform, configuration, or feature flag, keep the single entry point and use Swift conditional compilation or ordinary runtime conditionals inside that boundary.
+- Use app-level lifecycle concerns at the `App` boundary, scene lifecycle concerns at the `Scene` boundary, and view-local active or presentation behavior inside views.
+- Use `@Binding` to pass a focused writable piece of parent-owned state into a child view.
+- Use `@Bindable` when working with an observable model that should project bindings to its mutable properties in a view.
+- Use the dedicated SwiftData workflow for persistence architecture and its direct SwiftUI integration path.
+- Prefer existing SwiftUI environment values and actions before inventing an equivalent router or service. Use environment values for shared context that truly belongs to the surrounding hierarchy, not as a dumping ground for unrelated dependencies.
+- Model app capabilities as direct, concrete feature services. A service provides one capability or a cohesive group of related operations directly to the app; it talks directly to the framework, persistence, network, or system boundary that capability needs instead of forwarding through an app-service wrapper, repository stack, or manager chain.
+- Create a feature service at the narrowest app or scene boundary that owns its lifecycle. Put a service into the SwiftUI environment only when independent descendants need to invoke it or observe its state directly. Keep a service private to its feature root when that is the only consumer.
+- A service may be `@Observable` when the UI must observe its feature state. Otherwise prefer direct values, async operations, explicit errors, and narrow action closures. Reusable leaf views still receive only values, bindings, and action closures; never pass a service, repository, coordinator, manager, ViewModel, store, or other collaborator into their public interface.
+- Keep services concrete by default. Introduce a protocol only for a demonstrated alternate implementation or boundary that cannot otherwise be tested; do not create protocol, adapter, or wrapper layers merely because a service exists.
+- Add custom environment values or actions when a capability is dynamic across the hierarchy or shared by many independent components. Keep actions local to the owning component when only that component and its private child views use them.
+- Use preference keys only to publish descendant-derived information upward to an ancestor, never as a general state bus.
+- Prefer Swift's synthesized memberwise initializer for view properties. Do not write an explicit initializer unless it has real behavior beyond assigning those properties.
+- Prefer key-path-based APIs, predicates, and sort descriptors when they keep data access direct and readable.
+- Extract repeated chains of view modifiers into custom view modifiers early when that reduces clutter and clearly matches a view or family of views.
+
+## Xcode Workspace and Project Baseline
+
+- Treat the `.xcworkspace` or `.xcodeproj` as the source of truth for Apple platform app integration, schemes, build settings, destinations, and target membership.
+- Prefer edits through Xcode-aware project structure and keep project file changes intentional and reviewed closely.
+- Use the standard top-level Xcode app repository layout when creating or normalizing native app repos: `Sources/`, `Tests/`, `Shared/`, `Extensions/`, `Configurations/`, `Scripts/`, and `Packages/`.
+- `Sources/` owns the main app target implementation and app-owned resources/support files. `Tests/` owns all test targets. `Shared/` owns reusable source intended to be compiled into the app and extension targets. `Extensions/` owns extension target roots, one folder per extension. `Configurations/` owns `.xcconfig` layers. `Scripts/` owns project-local automation and build helper scripts. `Packages/` owns local Swift packages only when a real package boundary is justified.
+- Keep those top-level roots stable. Do not invent parallel names such as `AppSources`, `TestSources`, `Config`, `BuildScripts`, or `LocalPackages` for ordinary Xcode app repos unless the existing repo already has a deliberate, documented convention.
+- Inside `Sources/`, use this strict app structure by default: `Views/`, `Models/`, and `Services/`. Do not create a root `Controllers/` directory.
+- `Sources/Views/` owns SwiftUI views and UIKit/AppKit view surfaces. Use `Sources/Views/Shared`, `Sources/Views/macOS`, and `Sources/Views/iOS` so shared, macOS-specific, and iOS/iPadOS-specific UI have clear homes.
+- Use bare prefixed names such as `GEAWhatever.swift` for runtime/domain values. Reserve `GEAWhateverModel.swift` for persistence, and use `GEAWhateverRecord.swift` or `GEAWhateverDTO.swift` only for genuinely additional representations.
+- `Sources/Models/` owns Core Data and SwiftData persistence models plus additional record or transfer representations.
+- `Sources/Services/` owns direct concrete feature and boundary services. Use `Consumed/` for external capabilities the app calls, `Internal/` for app-owned feature services, and `Provided/` for services the app exposes to extensions, helpers, plugins, integrations, or other clients. These directories describe ownership and direction; they do not justify wrapper layers or an app-wide service container.
+- Name a service for its capability, such as `GEADownloadService.swift` or `GEAImportService.swift`. Do not create `GEAAppService.swift` as an umbrella service by default; `GEAApp.swift` remains the lifecycle-entry special case.
+- Use `xcodebuild` for Apple platform integration validation, including scheme, destination or SDK, and configuration-specific build or test runs.
+- Keep `xcodebuild` invocations reproducible in automation by passing explicit schemes, destinations or SDKs, and configurations when relevant.
+- For Codex GUI worktree-first Xcode repos, use a portable `.codex/environments/*.toml` local environment file when the repo wants shared app setup or action buttons. Start from `apple-dev-skills/templates/codex-local-environments/xcode-project.toml`, keep paths repo-relative, and prefer `-derivedDataPath ./DerivedData` or another ignored repo-local build directory instead of user-global DerivedData.
+- When scripts or terminal workflows add files on disk, verify that Xcode project membership, target membership, build-phase membership, and resource-bundle inclusion all match the intended result; files appearing in the directory tree alone are not enough.
+- Direct filesystem edits outside `.pbxproj` are generally safe when Xcode is closed or when the current project is not open in Xcode, but still verify that the Xcode project picks up the intended files and memberships afterward.
+- Prefer Debug builds for everyday edit-build-test loops, but validate Release builds explicitly when optimization, packaging, launch behavior, watchdog timing, or deployment realism matters.
+- Treat tagged releases as a signal to validate both the normal Debug path and a Release artifact path, and when shipping apps or deliverables test the Release behavior without relying on an attached debugger.
+- Prefer direct filesystem edits in Xcode-managed scope only when the workflow already accounts for project-file and scheme integrity.
+- Never edit `.pbxproj` files directly. If a project-file change is needed and no safe project-aware tool is available, stop and ask for an Xcode-mediated project change instead. When `.pbxproj` is tracked and Xcode, XcodeGen, or another project-aware workflow legitimately changes it, treat that diff as critical project state: review it, stage it, and commit it with the branch before any push, merge, release, or cleanup.
+
+## XcodeGen and Build Configuration Defaults
+
+- For new Xcode app, framework, and workspace repositories, prefer an XcodeGen-backed project by default unless the user explicitly asks for a hand-managed Xcode project or the repository has a concrete reason to avoid a generator dependency.
+- If the repo contains `project.yml`, `project.yaml`, or clearly named included XcodeGen spec files, treat the XcodeGen spec set as the source of truth for generated project structure.
+- For XcodeGen-backed repos, make target membership, resource membership, schemes, Swift package declarations, test-plan references, project references, build configurations, configuration-file wiring, generation options, and project-level settings in the XcodeGen specs instead of editing the generated `.pbxproj`.
+- Before running `xcodegen generate`, inspect the current git diff for generated `.xcodeproj` or `.pbxproj` changes. Treat existing project-file diffs as intentional user or Xcode GUI changes by default, not disposable generator drift.
+- When Xcode GUI changes added build settings, signing settings, capabilities, `Info.plist` build setting overrides, file membership, scheme changes, or entitlement wiring to `.pbxproj`, preserve the user intent by moving each intentional value to the owning tracked source first: XcodeGen spec for structure, `.xcconfig` for build settings, `.entitlements` for entitlement keys, `Info.plist` for plist keys, `.xcscheme` or scheme spec for scheme behavior, and `.xctestplan` for test-plan content.
+- Only regenerate after that promotion is complete, then review the generated project diff to confirm XcodeGen preserved the intended behavior instead of deleting it. If the owning tracked file is ambiguous, stop and ask before regenerating.
+- For new XcodeGen-backed app scaffolds, start from the maintained `apple-dev-skills/templates/xcodegen/` templates when available instead of inventing a fresh project-spec shape from memory.
+- Keep `minimumXcodeGenVersion` on a recent validated release for new scaffolds. Prefer updating the template and validation together when the repo intentionally raises the baseline.
+- For Xcode 16 or newer project formats, prefer XcodeGen `syncedFolder` roots at the broad top-level directory boundary so file creation, deletion, and organization stay synchronized between Xcode and the filesystem without hand-listing every source file in YAML.
+- Do not fragment ordinary XcodeGen source roots by subdirectory. A standard app target gets one `Sources` source entry that includes all app source, resource, support, generated plist, entitlement, and nested feature folders, plus one `Shared` source entry when shared app/extension code exists. A standard test target gets one `Tests` source entry that includes all test subdirectories. Extension targets use one `Extensions/<ExtensionName>` source entry per extension target. If a project has another separate top-level logical root, use one top-level entry for that root, not one entry per child folder.
+- Never split `Sources/App`, `Sources/Resources`, `Sources/Support`, feature folders, or `Tests/<TargetName>Tests` into separate XcodeGen source entries unless a specific non-ordinary file or folder truly needs custom compiler flags, build-phase routing, destination filters, or target membership that cannot be represented from the broad root.
+- If `syncedFolder` behaves poorly for a repo, fall back to the same broad top-level recursive paths such as `Sources`, `Tests`, or `Resources` with explicit `includes` and `excludes`; do not fall back to subdirectory-level fragmentation or one YAML entry per ordinary source file.
+- Keep XcodeGen specs readable as project structure, not as a dumping ground for every build setting. Use `configs`, `configFiles`, `targets`, `schemes`, `packages`, `projectReferences`, `targetTemplates`, and `schemeTemplates` deliberately so future edits have an obvious owner.
+- Prefer explicit top-level schemes for app scaffolds once scheme behavior matters. Put build, run, test, profile, analyze, archive, environment variables, command-line arguments, and test-plan references in the scheme spec rather than relying on hidden generated defaults.
+- Prefer external `.xcconfig` files as the default home for nontrivial build settings. Keep build settings in XcodeGen inline settings only when they are small, local, and clearer there.
+- Use `.xcconfig` files for settings that vary by Debug, Release, CI, local development, signing, bundle identity, compiler flags, Swift settings, deployment variants, or environment-specific behavior.
+- Keep configuration layering explicit. Prefer a small shared base config, target-level configs for app/test/extension identity, then per-configuration configs that include the narrower target config and override only what changes.
+- In XcodeGen specs, wire build configurations to their matching `.xcconfig` files instead of duplicating the same settings across generated project objects.
+- Prefer checked-in external `.entitlements` files for app, extension, and capability-bearing targets, with `CODE_SIGN_ENTITLEMENTS` declared in the owning target's `.xcconfig`. Let Xcode capabilities update the entitlement plist when possible, then review and commit the entitlement diff; keep XcodeGen responsible for wiring the file, not regenerating its contents from inline YAML.
+- Do not assume Xcode's Build Settings UI writes edited values back into `.xcconfig` files. When a build setting should remain tracked in `.xcconfig`, inspect the generated project diff after GUI changes and move intentional build-setting overrides from `.pbxproj` back into the owning `.xcconfig` before regenerating.
+- Keep secrets, personal team IDs, local machine paths, provisioning profiles, API tokens, and private signing material out of committed `.xcconfig` files. Use build settings only for non-secret configuration values, safe placeholders, references to externally supplied values, or local developer placeholders that are safe to commit.
+- Before changing generated project structure, inspect the root spec plus any `include` entries so the edit lands in the owning spec rather than duplicating settings in the wrong file. Remember that included specs merge into the root spec, and local overrides may intentionally replace arrays or maps.
+- After changing XcodeGen specs, `.xcconfig` files, or entitlement-file wiring, run `xcodegen generate` from the spec root, or `xcodegen generate --spec <path>` when the project uses a non-default spec path.
+- If the spec uses environment variables or generation hooks, preserve and document the required environment before regenerating so CI and other contributors can reproduce the project.
+- Review the spec diff, `.xcconfig` diff, and generated `.xcodeproj` diff after regeneration. Generated `.pbxproj` changes are acceptable output when they come from XcodeGen, but they should still be reviewed for unintended target, scheme, signing, package, build-setting, or file-membership churn.
+- Validate regenerated projects with explicit `xcodebuild` commands for the affected scheme, destination or SDK, and configuration.
+- For existing hand-managed Xcode projects, do not migrate to XcodeGen or externalize build settings into `.xcconfig` files unless the user explicitly asks for that migration. When they do, treat it as a project-structure migration with before/after validation.

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/source-apis-and-translator-context.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/source-apis-and-translator-context.md
@@ -1,0 +1,34 @@
+# Source APIs and Translator Context
+
+## Select the API from the output you need
+
+| Need | Preferred shape |
+| --- | --- |
+| SwiftUI text in a view | `Text("Continue", comment: "Moves to the next setup step")` |
+| Resolved Foundation string | `String(localized: "Welcome, \\(name)!", comment: "Greeting on the account screen")` |
+| Localized attributed or Markdown text | `AttributedString(localized: "Read the [guide](...)" )` |
+| Deferred resource for an API/process boundary | `LocalizedStringResource("Retry", comment: "Retries the failed upload")` |
+| Explicit stable key and evolving default | `String(localized: "settings.signOut", defaultValue: "Sign Out", comment: "Account menu action")` |
+
+For a named catalog, use `tableName` in SwiftUI and `table` in Foundation. For framework or Swift Package resources, use the owning bundle. A source call must contain static extractable values; Xcode cannot discover a key, table, default, or comment assembled at runtime.
+
+## Good source shape
+
+```swift
+Text("\\(itemCount) saved items", comment: "Count shown in the Saved tab")
+
+let message = String(
+    localized: "Unable to save \\(documentName).",
+    table: "Errors",
+    bundle: .module,
+    comment: "Error after a document save request fails"
+)
+```
+
+The first entry lets the catalog model plural categories. The second tells Xcode, translators, and future maintainers which catalog and resource bundle own the text.
+
+## Context is part of the interface
+
+Comments should explain what a translator cannot infer from the words alone: control role, surrounding screen, placeholder meaning, grammatical gender, character limit, product terminology, and whether a name stays untranslated. A generated screenshot can add visual context to an XLIFF handoff, but it does not replace a concise source comment or a project glossary.
+
+Apple documents the Foundation localizable initializers and their comments in [Preparing your app's text for translation](https://developer.apple.com/documentation/xcode/preparing-your-apps-text-for-translation), and documents catalog-generated `LocalizedStringResource` symbols in [Using generated localizable symbols in your code](https://developer.apple.com/documentation/xcode/using-generated-localizable-symbols-in-your-code).

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/string-catalog-foundations.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/string-catalog-foundations.md
@@ -1,0 +1,25 @@
+# String Catalog Foundations
+
+## What a catalog solves
+
+An Xcode String Catalog is a versioned `.xcstrings` source file that keeps a development-language string, its translations, state, and supported variations together. Xcode updates it from recognized localizable APIs during a build. It is the right default for current Xcode projects because it keeps source extraction, language coverage, plural forms, device-specific wording, and translation editing in one reviewed artifact.
+
+It does not replace internationalization. The source must still pass full sentences, typed values, and meaningful context to localizable APIs; dates, numbers, measurements, lists, and names must still use locale-aware Foundation formatting; and the UI must still accommodate translated length and direction.
+
+## Minimal adoption sequence
+
+1. Add a String Catalog from Xcode's Resource template, normally named `Localizable.xcstrings`.
+2. Build each target that owns user-visible strings.
+3. Inspect new extracted entries, source locations, and comments.
+4. Add each requested language or language-and-region variant.
+5. Translate directly or export/import an Xcode Localization Catalog (`.xcloc`).
+6. Review translation state and the source-control diff.
+7. Test the running app in each relevant locale and layout direction.
+
+## Variations
+
+For a count, localize one interpolated sentence and add plural variants in the catalog. Xcode supplies the plural categories for each language; a language can have categories beyond English's one and other. Add a device variant only when product wording is intentionally different on that device class. Do not use a device variant to conceal clipped text, and do not use a plural variant for arbitrary conditional copy.
+
+## Source evidence
+
+Apple documents the catalog setup, build-based extraction, language/region additions, comments, tables, plurals, device variants, and translation state in [Localizing and varying text with a string catalog](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog). Apple identifies String Catalogs as the recommended Xcode 15-and-later plural-localization path in [Localizing strings that contain plurals](https://developer.apple.com/documentation/xcode/localizing-strings-that-contain-plurals).

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/translation-review-and-validation.md
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/references/translation-review-and-validation.md
@@ -1,0 +1,28 @@
+# Translation Review and Validation
+
+## Translation handoff
+
+Use the catalog editor for small, directly reviewed language updates. For a localization service or language reviewer, export Xcode localizations as an `.xcloc` package, include the glossary and relevant screenshots, and import only the reviewed result. Check the import comparison editor and the repository diff before accepting the change.
+
+Track, for every language and region:
+
+- source language and catalog/table owner;
+- translator or translation-service provenance;
+- reviewer identity or explicit review gap;
+- terminology and non-translatable names;
+- unresolved entries, placeholder errors, and source changes after translation.
+
+## Validation matrix
+
+Run the narrowest relevant build and tests first, then inspect the app with the target language and region active. Cover at least the changed entry points plus:
+
+- long labels and buttons at normal and large Dynamic Type sizes;
+- plural values that exercise each meaningful form;
+- date, number, measurement, currency, list, and name formatting;
+- empty, loading, success, error, and destructive-confirmation states;
+- a right-to-left language when the product supports one;
+- compact and regular device classes when wording or layout differs.
+
+Keep automated tests and visual inspection distinct. A test can prove a formatting or lookup contract; it cannot establish terminology quality, clipped text, bidirectional mirroring, or cultural suitability.
+
+Apple documents localization export and import in [Exporting localizations](https://developer.apple.com/documentation/xcode/exporting-localizations) and [Importing localizations](https://developer.apple.com/documentation/xcode/importing-localizations).

--- a/plugins/apple-dev-skills/skills/xcode-localization-workflow/scripts/customization_config.py
+++ b/plugins/apple-dev-skills/skills/xcode-localization-workflow/scripts/customization_config.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "PyYAML>=6.0.2,<7",
+# ]
+# ///
+"""Load and persist per-skill customization state."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+SCHEMA_VERSION = 1
+SKILL_NAME = "xcode-localization-workflow"
+CONFIG_HOME_ENV = "APPLE_DEV_SKILLS_CONFIG_HOME"
+DEFAULT_CONFIG_ROOT = "~/.config/gaelic-ghost/apple-dev-skills"
+ALLOWED_TOP_LEVEL = {"schemaVersion", "isCustomized", "settings"}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def quote_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def encode_scalar(value) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return quote_string("")
+    return quote_string(str(value))
+
+
+def parse_yaml(path: Path) -> dict:
+    if not path.exists():
+        fail(f"Missing YAML file: {path}")
+
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        fail(f"Invalid YAML in {path}: {exc}")
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        fail(f"Top-level YAML document must be a mapping in {path}")
+
+    if isinstance(loaded.get("settings"), dict):
+        loaded["settings"] = {
+            key: ("" if value is None else value) for key, value in loaded["settings"].items()
+        }
+
+    return loaded
+
+
+def validate_config(config: dict, *, allow_partial: bool) -> None:
+    unknown = set(config.keys()) - ALLOWED_TOP_LEVEL
+    if unknown:
+        fail(f"Unknown top-level keys: {', '.join(sorted(unknown))}")
+
+    if not allow_partial:
+        for required in ("schemaVersion", "isCustomized", "settings"):
+            if required not in config:
+                fail(f"Missing required key: {required}")
+
+    if "schemaVersion" in config and config["schemaVersion"] != SCHEMA_VERSION:
+        fail(f"schemaVersion must be {SCHEMA_VERSION}")
+
+    if "isCustomized" in config and not isinstance(config["isCustomized"], bool):
+        fail("isCustomized must be boolean")
+
+    if "settings" in config:
+        if not isinstance(config["settings"], dict):
+            fail("settings must be a mapping")
+        for key, value in config["settings"].items():
+            if not re.fullmatch(r"[A-Za-z0-9_]+", key):
+                fail(f"Invalid settings key: {key}")
+            if isinstance(value, (dict, list)):
+                fail(f"settings values must be scalar: {key}")
+
+
+def merge_configs(base: dict, overlay: dict) -> dict:
+    merged = {
+        "schemaVersion": base.get("schemaVersion", SCHEMA_VERSION),
+        "isCustomized": base.get("isCustomized", False),
+        "settings": copy.deepcopy(base.get("settings", {})),
+    }
+
+    if "schemaVersion" in overlay:
+        merged["schemaVersion"] = overlay["schemaVersion"]
+    if "isCustomized" in overlay:
+        merged["isCustomized"] = overlay["isCustomized"]
+    if "settings" in overlay:
+        merged["settings"].update(overlay["settings"])
+
+    return merged
+
+
+def dump_yaml(config: dict) -> str:
+    lines = [
+        f"schemaVersion: {int(config['schemaVersion'])}",
+        f"isCustomized: {'true' if config['isCustomized'] else 'false'}",
+        "settings:",
+    ]
+    for key in sorted(config["settings"].keys()):
+        lines.append(f"  {key}: {encode_scalar(config['settings'][key])}")
+    return "\n".join(lines) + "\n"
+
+
+def template_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "references" / "customization.template.yaml"
+
+
+def config_root() -> Path:
+    root = os.environ.get(CONFIG_HOME_ENV, DEFAULT_CONFIG_ROOT)
+    return Path(root).expanduser()
+
+
+def durable_path() -> Path:
+    return config_root() / SKILL_NAME / "customization.yaml"
+
+
+def load_template() -> dict:
+    cfg = parse_yaml(template_path())
+    validate_config(cfg, allow_partial=False)
+    return cfg
+
+
+def load_durable() -> dict:
+    path = durable_path()
+    if not path.exists():
+        return {}
+    cfg = parse_yaml(path)
+    validate_config(cfg, allow_partial=False)
+    return cfg
+
+
+def cmd_path(_: argparse.Namespace) -> None:
+    print(durable_path())
+
+
+def cmd_effective(_: argparse.Namespace) -> None:
+    effective = merge_configs(load_template(), load_durable())
+    validate_config(effective, allow_partial=False)
+    print(dump_yaml(effective), end="")
+
+
+def cmd_apply(args: argparse.Namespace) -> None:
+    template = load_template()
+    current = merge_configs(template, load_durable())
+    incoming = parse_yaml(Path(args.input))
+    validate_config(incoming, allow_partial=True)
+
+    updated = merge_configs(current, incoming)
+    updated["schemaVersion"] = SCHEMA_VERSION
+    updated["isCustomized"] = True
+    validate_config(updated, allow_partial=False)
+
+    target = durable_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(dump_yaml(updated), encoding="utf-8")
+    print(target)
+
+
+def cmd_reset(_: argparse.Namespace) -> None:
+    target = durable_path()
+    if target.exists():
+        target.unlink()
+    print(target)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage per-skill customization config")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_path = subparsers.add_parser("path", help="Print durable config path")
+    parser_path.set_defaults(func=cmd_path)
+
+    parser_effective = subparsers.add_parser("effective", help="Print merged effective config")
+    parser_effective.set_defaults(func=cmd_effective)
+
+    parser_apply = subparsers.add_parser("apply", help="Apply and persist config overrides")
+    parser_apply.add_argument("--input", required=True, help="Path to YAML overrides")
+    parser_apply.set_defaults(func=cmd_apply)
+
+    parser_reset = subparsers.add_parser("reset", help="Delete durable config for this skill")
+    parser_reset.set_defaults(func=cmd_reset)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/apple-dev-skills/tests/test_apple_developer_provisioning_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_apple_developer_provisioning_workflow.py
@@ -55,7 +55,7 @@ class AppleDeveloperProvisioningWorkflowTests(unittest.TestCase):
         self.assertIn("apple-developer-provisioning-workflow", readme)
         self.assertIn("Apple Developer provisioning", plugin)
         self.assertIn("./skills/apple-developer-provisioning-workflow/SKILL.md", validator)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn("Milestone 54: Apple Developer Provisioning and CloudKit Workflow - Completed", roadmap)
 
     def test_customization_cli_preserves_shared_apply_and_reset_verbs(self) -> None:

--- a/plugins/apple-dev-skills/tests/test_arkit_spatial_face_body_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_arkit_spatial_face_body_workflows.py
@@ -109,7 +109,7 @@ class ARKitSpatialFaceBodyWorkflowTests(unittest.TestCase):
             )
         self.assertIn("ARKit", plugin)
         self.assertIn("LiDAR", plugin)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn("arkit-spatial-sensing-workflow", self.read("skills/camera-capture-depth-workflow/SKILL.md"))
         self.assertIn("arkit-face-body-tracking-workflow", self.read("skills/vision-image-analysis-workflow/SKILL.md"))
         self.assertIn("arkit-spatial-sensing-workflow", self.read("skills/apple-ui-accessibility-workflow/SKILL.md"))

--- a/plugins/apple-dev-skills/tests/test_camera_capture_depth_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_camera_capture_depth_workflow.py
@@ -93,7 +93,7 @@ class CameraCaptureDepthWorkflowTests(unittest.TestCase):
         )
         self.assertIn("camera", plugin.lower())
         self.assertIn("depth", plugin.lower())
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn(skill, self.read("skills/avfoundation-media-pipeline-workflow/SKILL.md"))
         self.assertIn(skill, self.read("skills/vision-image-analysis-workflow/SKILL.md"))
 

--- a/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
+++ b/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
@@ -66,8 +66,8 @@ class CustomizationConsolidationReviewTests(unittest.TestCase):
         knob_count = _count_template_knobs()
         runtime_enforced, policy_only = _count_statuses()
 
-        self.assertEqual(template_count, 48)
-        self.assertEqual(script_count, 48)
+        self.assertEqual(template_count, 49)
+        self.assertEqual(script_count, 49)
         self.assertEqual(knob_count, 21)
         self.assertEqual(runtime_enforced, 20)
         self.assertEqual(policy_only, 1)

--- a/plugins/apple-dev-skills/tests/test_devicecheck_app_attest_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_devicecheck_app_attest_workflow.py
@@ -71,7 +71,7 @@ class DeviceCheckAppAttestWorkflowTests(unittest.TestCase):
         self.assertIn("DeviceCheck", plugin)
         self.assertIn("App Attest", plugin)
         self.assertIn("./skills/devicecheck-app-attest-workflow/SKILL.md", validator)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn("Milestone 53: DeviceCheck and App Attest Workflow - Completed", roadmap)
 
 

--- a/plugins/apple-dev-skills/tests/test_imaging_foundation_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_imaging_foundation_workflows.py
@@ -95,7 +95,7 @@ class ImagingFoundationWorkflowTests(unittest.TestCase):
 
         self.assertIn("Core Image", plugin)
         self.assertIn("Image I/O", plugin)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
 
 
 if __name__ == "__main__":

--- a/plugins/apple-dev-skills/tests/test_photos_library_editing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_photos_library_editing_workflow.py
@@ -95,7 +95,7 @@ class PhotosLibraryEditingWorkflowTests(unittest.TestCase):
         )
         self.assertIn("PhotosUI", plugin)
         self.assertIn("PhotoKit", plugin)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn(name, self.read("skills/apple-image-representation-workflow/SKILL.md"))
         self.assertIn(name, self.read("skills/core-image-processing-workflow/SKILL.md"))
         self.assertIn(name, self.read("skills/avfoundation-media-pipeline-workflow/SKILL.md"))

--- a/plugins/apple-dev-skills/tests/test_tipkit_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_tipkit_workflow.py
@@ -52,7 +52,7 @@ class TipKitWorkflowTests(unittest.TestCase):
         self.assertIn("tipkit-workflow", readme)
         self.assertIn("TipKit", plugin)
         self.assertIn("./skills/tipkit-workflow/SKILL.md", validator)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn("Milestone 55: TipKit Workflow", roadmap)
 
 

--- a/plugins/apple-dev-skills/tests/test_video_codec_processing_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_video_codec_processing_workflow.py
@@ -92,7 +92,7 @@ class VideoCodecProcessingWorkflowTests(unittest.TestCase):
         )
         self.assertIn("VideoToolbox", plugin)
         self.assertIn("Core Video", plugin)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
         self.assertIn(name, self.read("skills/avfoundation-media-pipeline-workflow/SKILL.md"))
         self.assertIn(name, self.read("skills/coremedia-timing-samplebuffer-workflow/SKILL.md"))
 

--- a/plugins/apple-dev-skills/tests/test_vision_recognition_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_vision_recognition_workflows.py
@@ -89,7 +89,7 @@ class VisionRecognitionWorkflowTests(unittest.TestCase):
             )
         self.assertIn("Apple Vision", plugin)
         self.assertIn("Core ML", plugin)
-        self.assertIn("Expected exactly 48 active skills", validator)
+        self.assertIn("Expected exactly 49 active skills", validator)
 
 
 if __name__ == "__main__":

--- a/plugins/apple-dev-skills/tests/test_xcode_localization_workflow.py
+++ b/plugins/apple-dev-skills/tests/test_xcode_localization_workflow.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class XcodeLocalizationWorkflowTests(unittest.TestCase):
+    def read(self, path: str) -> str:
+        return (ROOT / path).read_text(encoding="utf-8")
+
+    def test_catalog_first_workflow_covers_source_translation_and_validation(self) -> None:
+        skill = self.read("skills/xcode-localization-workflow/SKILL.md")
+        foundations = self.read("skills/xcode-localization-workflow/references/string-catalog-foundations.md")
+        source = self.read("skills/xcode-localization-workflow/references/source-apis-and-translator-context.md")
+        validation = self.read("skills/xcode-localization-workflow/references/translation-review-and-validation.md")
+
+        for term in (
+            "String Catalogs (`.xcstrings`)",
+            "String(localized:table:bundle:locale:comment:)",
+            "LocalizedStringResource",
+            "Vary by Plural",
+            "XLIFF",
+            "right-to-left",
+            "human-review",
+        ):
+            self.assertIn(term, skill + foundations + source + validation)
+
+        self.assertIn("xcode-build-run-workflow", skill)
+        self.assertIn("xcode-testing-workflow", skill)
+        self.assertIn("xcode-device-hub-workflow", skill)
+        self.assertIn("apple-ui-accessibility-workflow", skill)
+        self.assertIn("xcode-coding-intelligence-workflow", skill)
+
+    def test_agent_translation_is_optional_and_beta_scoped(self) -> None:
+        skill = self.read("skills/xcode-localization-workflow/SKILL.md")
+        agent = self.read("skills/xcode-localization-workflow/references/agent-assisted-translation.md")
+
+        self.assertIn("optional beta-era acceleration", skill)
+        self.assertIn("Do not present agent output as human-reviewed translation.", skill)
+        self.assertIn("optional beta-era workflow", agent)
+        self.assertIn("machine-translation provenance", agent)
+
+    def test_inventory_metadata_and_roadmap_name_the_shipped_skill(self) -> None:
+        readme = self.read("README.md")
+        manifest = self.read(".codex-plugin/plugin.json")
+        roadmap = self.read("ROADMAP.md")
+        validator = self.read(".github/scripts/validate_repo_docs.sh")
+
+        for text in (readme, roadmap, validator):
+            self.assertIn("xcode-localization-workflow", text)
+        self.assertIn("String Catalog localization", manifest)
+        self.assertIn('"string-catalog"', manifest)
+        self.assertIn("Expected exactly 49 active skills", validator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a stable catalog-first Xcode localization workflow
- cover source APIs, catalog variants, XLIFF review, and locale validation
- retain Xcode 27 agent translation as an optional, human-reviewed path

## Verification
- bash plugins/apple-dev-skills/.github/scripts/validate_repo_docs.sh
- uv run pytest (plugins/apple-dev-skills: 247 passed)
- uv run scripts/validate_socket_metadata.py
- uv run pytest (root: 81 passed, 1 skipped)