### PR TITLE
plugin: add Creator Studio workflow skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -42,6 +42,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "apple-creator-studio-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/apple-creator-studio-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "cardhop-app",
       "source": {
         "source": "local",

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Currently available from the catalog:
 
 - `agent-portability-skills`
 - `android-dev-skills`
+- `apple-creator-studio-skills`
 - `apple-dev-skills`
 - `cardhop-app`
 - `cloud-deployment-skills`
@@ -112,6 +113,7 @@ Current Socket catalog shape:
 
 - `agent-portability-skills`: maintainer skills plus a source-bundled guidance-sync custom-agent definition for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance
 - `android-dev-skills`: Android, Kotlin, Java, Gradle, Android Gradle Plugin, Compose/XML UI, testing, lint, emulator-aware validation handoff, and release-readiness workflow guidance
+- `apple-creator-studio-skills`: source-preserving Compressor delivery, Logic Pro production, and MainStage concert workflows with local Help Viewer discovery, explicit Computer Use safeguards, and artifact or rehearsal verification
 - `apple-dev-skills`: Apple, Swift, Core Image and Image I/O, Vision and Core ML recognition, AVFoundation camera and depth capture, ARKit spatial sensing, VideoToolbox and Core Video codecs, PhotosUI and PhotoKit, AVFAudio, Core Media, Core Audio, SwiftUI, AppKit, Xcode, Safari, OpenAPI, and DocC workflows, plus the source-bundled `swift-steward` custom-agent definition with its own roadmap
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `cloud-deployment-skills`: cloud provider deployment routing, official provider plugin selection, credential and mutation boundary checks, and AWS handoff to the official AWS Agent Toolkit rather than duplicated AWS MCP, CLI, or SAM setup

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Current Socket catalog shape:
 
 - `agent-portability-skills`: maintainer skills plus a source-bundled guidance-sync custom-agent definition for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance
 - `android-dev-skills`: Android, Kotlin, Java, Gradle, Android Gradle Plugin, Compose/XML UI, testing, lint, emulator-aware validation handoff, and release-readiness workflow guidance
-- `apple-creator-studio-skills`: source-preserving Compressor delivery, Logic Pro production, and MainStage concert workflows with local Help Viewer discovery, explicit Computer Use safeguards, and artifact or rehearsal verification
+- `apple-creator-studio-skills`: source-preserving Compressor delivery, Logic Pro production, MainStage concert, and GarageBand project workflows with local Help Viewer discovery, explicit Computer Use safeguards, and artifact or rehearsal verification
 - `apple-dev-skills`: Apple, Swift, Core Image and Image I/O, Vision and Core ML recognition, AVFoundation camera and depth capture, ARKit spatial sensing, VideoToolbox and Core Video codecs, PhotosUI and PhotoKit, AVFAudio, Core Media, Core Audio, SwiftUI, AppKit, Xcode, Safari, OpenAPI, and DocC workflows, plus the source-bundled `swift-steward` custom-agent definition with its own roadmap
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `cloud-deployment-skills`: cloud provider deployment routing, official provider plugin selection, credential and mutation boundary checks, and AWS handoff to the official AWS Agent Toolkit rather than duplicated AWS MCP, CLI, or SAM setup

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Current Socket catalog shape:
 
 - `agent-portability-skills`: maintainer skills plus a source-bundled guidance-sync custom-agent definition for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance
 - `android-dev-skills`: Android, Kotlin, Java, Gradle, Android Gradle Plugin, Compose/XML UI, testing, lint, emulator-aware validation handoff, and release-readiness workflow guidance
-- `apple-creator-studio-skills`: source-preserving Compressor delivery, Logic Pro production, MainStage concert, and GarageBand project workflows with local Help Viewer discovery, explicit Computer Use safeguards, and artifact or rehearsal verification
+- `apple-creator-studio-skills`: source-preserving Final Cut Pro editing, Motion template, Compressor delivery, Logic Pro production, MainStage concert, and GarageBand project workflows with local Help Viewer discovery, explicit Computer Use safeguards, and artifact or rehearsal verification
 - `apple-dev-skills`: Apple, Swift, Core Image and Image I/O, Vision and Core ML recognition, AVFoundation camera and depth capture, ARKit spatial sensing, VideoToolbox and Core Video codecs, PhotosUI and PhotoKit, AVFAudio, Core Media, Core Audio, SwiftUI, AppKit, Xcode, Safari, OpenAPI, and DocC workflows, plus the source-bundled `swift-steward` custom-agent definition with its own roadmap
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `cloud-deployment-skills`: cloud provider deployment routing, official provider plugin selection, credential and mutation boundary checks, and AWS handoff to the official AWS Agent Toolkit rather than duplicated AWS MCP, CLI, or SAM setup

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,7 @@
 - [Milestone 22: Network Protocol Skills plugin](#milestone-22-network-protocol-skills-plugin)
 - [Milestone 23: Cloud Inference Skills plugin](#milestone-23-cloud-inference-skills-plugin)
 - [Milestone 24: Apple system integration, runtime evidence, and distribution workflows](#milestone-24-apple-system-integration-runtime-evidence-and-distribution-workflows)
+- [Milestone 25: Apple Creator Studio operator workflows](#milestone-25-apple-creator-studio-operator-workflows)
 - [Small Tickets](#small-tickets)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
@@ -63,6 +64,7 @@
 - Milestone 22: Network Protocol Skills plugin - Completed
 - Milestone 23: Cloud Inference Skills plugin - Completed
 - Milestone 24: Apple system integration, runtime evidence, and distribution workflows - Planned
+- Milestone 25: Apple Creator Studio operator workflows - Planned
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -778,6 +780,38 @@ Planned
 - [ ] Each runtime or distribution workflow states its evidence boundary: code-level suspicion, simulator trace, memgraph ownership proof, signed artifact inspection, or notarization result.
 - [ ] The new skills pass their targeted tests, the Apple Dev Skills validation suite, shared-snippet checks, repository-doc validation, and root Socket metadata validation.
 - [ ] The simulator-browser and hot-reload investigation remains an explicit post-implementation conversation with Gale rather than an assumed dependency or unreviewed bundled runtime.
+
+## Milestone 25: Apple Creator Studio operator workflows
+
+### Status
+
+Planned
+
+### Scope
+
+- [ ] Add a dedicated `apple-creator-studio-skills` child plugin for safe, human-readable, Computer Use-aware workflows in Apple’s creative applications. Keep it separate from `apple-dev-skills`, which owns Apple framework, Swift, Xcode, and media-code work.
+- [ ] Treat this as a durable guidance plugin, not an app-control daemon or macro runner. Do not bundle undocumented automation, a media-processing runtime, machine-local app paths, a local service, or copied Apple help content.
+- [ ] Ship Creator Studio coverage in focused skills: Final Cut Pro, Motion, Compressor, Logic Pro, MainStage, and Pixelmator Pro. Treat GarageBand as a companion skill because it is not currently a Creator Studio subscription app.
+- [ ] Keep Acorn and RetroBatch outside this plugin. Evaluate a future independent `mac-image-workflows` plugin only after their common operator workflows, ownership boundaries, and validation fixtures are concrete.
+
+### Tickets
+
+- [ ] Use [`docs/maintainers/apple-creator-studio-skills-plugin-plan.md`](./docs/maintainers/apple-creator-studio-skills-plugin-plan.md) as the implementation source of truth.
+- [ ] Implement `compressor-workflow` first, then `logic-pro-workflow`, with official-help research, Computer Use safety checkpoints, reusable fixture contracts, and focused skill validation.
+- [ ] Decide whether the first two validated skills justify creating the child plugin and adding its marketplace entry, or whether the plan needs revision before an installable surface exists.
+- [ ] Implement Final Cut Pro and Motion only after Compressor handoff/relink/export contracts are proven in a real fixture project.
+- [ ] Implement MainStage only with explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
+- [ ] Implement Pixelmator Pro after Mac/iPad scope, source-layer preservation, and cross-app image handoff requirements are tested.
+- [ ] Consider GarageBand after Logic Pro’s project/import/export handoffs are stable; do not imply GarageBand is included in Apple Creator Studio.
+- [ ] Publish `mac-image-workflows` only if Acorn and RetroBatch share enough durable asset-preparation contracts to earn a common owner without absorbing Pixelmator Pro or generic image-code workflows.
+- [ ] Update root README, marketplace metadata, active-skill inventory tests, plugin metadata, and validation only when a real installable plugin surface ships.
+
+### Exit Criteria
+
+- [ ] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
+- [ ] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
+- [ ] Compressor and Logic Pro have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
+- [ ] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
 
 ## Small Tickets
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -804,6 +804,7 @@ Planned
 - [ ] Implement Pixelmator Pro after Mac/iPad scope, source-layer preservation, and cross-app image handoff requirements are tested.
 - [ ] Consider GarageBand after Logic Pro’s project/import/export handoffs are stable; do not imply GarageBand is included in Apple Creator Studio.
 - [ ] Publish `mac-image-workflows` only if Acorn and RetroBatch share enough durable asset-preparation contracts to earn a common owner without absorbing Pixelmator Pro or generic image-code workflows.
+- [ ] Investigate a `tips-app-workflow` skill after the first Creator Studio skills ship. Verify whether macOS Tips exposes current, task-specific content for Creator Studio and other Apple apps through an accessible, stable Computer Use surface; compare it against in-app Help and official user guides, preserve Tips as an optional discovery aid rather than an authoritative documentation source, and do not add a plugin or skill until a real fixture proves its value.
 - [ ] Update root README, marketplace metadata, active-skill inventory tests, plugin metadata, and validation only when a real installable plugin surface ships.
 
 ### Exit Criteria

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -792,7 +792,7 @@ Planned
 
 - [x] Add a dedicated `apple-creator-studio-skills` child plugin for safe, human-readable, Computer Use-aware workflows in Apple’s creative applications. Keep it separate from `apple-dev-skills`, which owns Apple framework, Swift, Xcode, and media-code work.
 - [x] Treat this as a durable guidance plugin, not an app-control daemon or macro runner. Do not bundle undocumented automation, a media-processing runtime, machine-local app paths, a local service, or copied Apple help content.
-- [ ] Ship Creator Studio coverage in focused skills: Final Cut Pro, Motion, Compressor, Logic Pro, MainStage, and Pixelmator Pro. Treat GarageBand as a companion skill because it is not currently a Creator Studio subscription app.
+- [ ] Ship Creator Studio coverage in focused skills: Final Cut Pro, Motion, Compressor, Logic Pro, MainStage, and Pixelmator Pro. Treat GarageBand as a companion skill because it is not currently a Creator Studio subscription app. Final Cut Pro and Motion are complete; Pixelmator Pro remains.
 - [ ] Keep Acorn and RetroBatch outside this plugin. Evaluate a future independent `mac-image-workflows` plugin only after their common operator workflows, ownership boundaries, and validation fixtures are concrete.
 
 ### Tickets
@@ -800,7 +800,7 @@ Planned
 - [x] Use [`docs/maintainers/apple-creator-studio-skills-plugin-plan.md`](./docs/maintainers/apple-creator-studio-skills-plugin-plan.md) as the implementation source of truth.
 - [x] Implement the first Creator Studio slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with official-help research, Computer Use safety checkpoints, reusable fixture contracts, and focused skill validation.
 - [x] Decide that the three validated initial-slice skills justify the child plugin and marketplace entry.
-- [ ] Implement Final Cut Pro and Motion only after Compressor handoff/relink/export contracts are proven in a real fixture project.
+- [x] Implement Final Cut Pro and Motion after Compressor handoff/relink/export contracts were proven in controlled disposable fixtures. Keep library, source-project, template-publication, and delivery confirmation boundaries explicit.
 - [x] Require MainStage’s initial implementation to include explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
 - [ ] Implement Pixelmator Pro after Mac/iPad scope, source-layer preservation, and cross-app image handoff requirements are tested.
 - [x] Add `garageband-workflow` as a companion workflow after Logic Pro. Keep its project/import/export handoffs explicit and do not imply GarageBand is included in Apple Creator Studio.
@@ -812,7 +812,7 @@ Planned
 
 - [x] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
 - [x] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
-- [ ] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
+- [x] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
 - [ ] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
 
 ## Small Tickets

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -813,7 +813,7 @@ Planned
 - [x] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
 - [x] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
 - [x] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
-- [ ] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
+- [x] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
 
 ## Small Tickets
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -790,28 +790,28 @@ Planned
 
 ### Scope
 
-- [ ] Add a dedicated `apple-creator-studio-skills` child plugin for safe, human-readable, Computer Use-aware workflows in Apple’s creative applications. Keep it separate from `apple-dev-skills`, which owns Apple framework, Swift, Xcode, and media-code work.
-- [ ] Treat this as a durable guidance plugin, not an app-control daemon or macro runner. Do not bundle undocumented automation, a media-processing runtime, machine-local app paths, a local service, or copied Apple help content.
+- [x] Add a dedicated `apple-creator-studio-skills` child plugin for safe, human-readable, Computer Use-aware workflows in Apple’s creative applications. Keep it separate from `apple-dev-skills`, which owns Apple framework, Swift, Xcode, and media-code work.
+- [x] Treat this as a durable guidance plugin, not an app-control daemon or macro runner. Do not bundle undocumented automation, a media-processing runtime, machine-local app paths, a local service, or copied Apple help content.
 - [ ] Ship Creator Studio coverage in focused skills: Final Cut Pro, Motion, Compressor, Logic Pro, MainStage, and Pixelmator Pro. Treat GarageBand as a companion skill because it is not currently a Creator Studio subscription app.
 - [ ] Keep Acorn and RetroBatch outside this plugin. Evaluate a future independent `mac-image-workflows` plugin only after their common operator workflows, ownership boundaries, and validation fixtures are concrete.
 
 ### Tickets
 
-- [ ] Use [`docs/maintainers/apple-creator-studio-skills-plugin-plan.md`](./docs/maintainers/apple-creator-studio-skills-plugin-plan.md) as the implementation source of truth.
+- [x] Use [`docs/maintainers/apple-creator-studio-skills-plugin-plan.md`](./docs/maintainers/apple-creator-studio-skills-plugin-plan.md) as the implementation source of truth.
 - [x] Implement the first Creator Studio slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with official-help research, Computer Use safety checkpoints, reusable fixture contracts, and focused skill validation.
 - [x] Decide that the three validated initial-slice skills justify the child plugin and marketplace entry.
 - [ ] Implement Final Cut Pro and Motion only after Compressor handoff/relink/export contracts are proven in a real fixture project.
-- [ ] Require MainStage’s initial implementation to include explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
+- [x] Require MainStage’s initial implementation to include explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
 - [ ] Implement Pixelmator Pro after Mac/iPad scope, source-layer preservation, and cross-app image handoff requirements are tested.
-- [ ] Consider GarageBand after Logic Pro’s project/import/export handoffs are stable; do not imply GarageBand is included in Apple Creator Studio.
+- [x] Add `garageband-workflow` as a companion workflow after Logic Pro. Keep its project/import/export handoffs explicit and do not imply GarageBand is included in Apple Creator Studio.
 - [ ] Publish `mac-image-workflows` only if Acorn and RetroBatch share enough durable asset-preparation contracts to earn a common owner without absorbing Pixelmator Pro or generic image-code workflows.
 - [ ] Investigate a `tips-app-workflow` skill after the first Creator Studio skills ship. Verify whether macOS Tips exposes current, task-specific content for Creator Studio and other Apple apps through an accessible, stable Computer Use surface; compare it against in-app Help and official user guides, preserve Tips as an optional discovery aid rather than an authoritative documentation source, and do not add a plugin or skill until a real fixture proves its value.
-- [ ] Update root README, marketplace metadata, active-skill inventory tests, plugin metadata, and validation only when a real installable plugin surface ships.
+- [x] Update root README, marketplace metadata, plugin metadata, and validation now that the installable plugin surface has shipped. Add active-skill inventory tests only when a Socket-level inventory assertion becomes necessary.
 
 ### Exit Criteria
 
-- [ ] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
-- [ ] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
+- [x] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
+- [x] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
 - [ ] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
 - [ ] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -771,6 +771,7 @@ Planned
 - [ ] Add `apple-dev-skills:swiftui-performance-audit` for code-first diagnosis of invalidation fan-out, unstable identity, heavy body work, layout churn, image cost, and broad animation. Require a clear distinction between suspected code smells and trace-backed evidence, then hand Instruments and `xctrace` capture to `xcode-testing-workflow` or `swift-package-testing-workflow`.
 - [ ] Add `apple-dev-skills:ios-runtime-forensics-workflow` with explicit `performance-trace` and `memory-graph` modes for simulator ETTrace/symbolication and memgraph/leak ownership evidence. Keep it focused on reproducible before/after runtime proof, and route normal simulator build, launch, UI driving, and logs through `xcode-build-run-workflow`.
 - [ ] Add `apple-dev-skills:macos-distribution-workflow` for exported-artifact inspection, signing identities, entitlements, hardened runtime, nested-code signatures, Gatekeeper assessment, notarization readiness/failure classification, stapling, and release-only validation. Keep developer-account provisioning, certificate/profile creation, and Xcode project signing changes with `apple-developer-provisioning-workflow` and `xcode-build-run-workflow`.
+- [ ] Add `apple-dev-skills:tips-helpviewer-workflow` for consistent local discovery of user guides for installed Apple apps. Use the `com.apple.helpviewer` Tips catalog as the primary UI target rather than the empty `com.apple.tips` shell observed on this Mac; route exact app/version help searches through the catalog, verify the opened guide matches the installed app, and keep official in-app Help, Xcode-local docs, Dash, and vendor documentation as the authoritative sources when the catalog is unavailable or incomplete.
 - [ ] Add skill-local references, deterministic validation expectations, handoff contracts, and targeted tests for all five workflows. Update Apple Dev Skills inventory, root documentation, and marketplace metadata only if the exported skill surface changes.
 - [ ] After the five workflows are implemented and validated, explore the installed iOS Simulator browser and SwiftUI hot-reload surface with Gale in a dedicated research pass. Decide together whether it belongs as a Socket workflow, a documented external-tool handoff, or no durable Socket addition; do not bundle or install browser/runtime tooling before that decision.
 
@@ -797,10 +798,10 @@ Planned
 ### Tickets
 
 - [ ] Use [`docs/maintainers/apple-creator-studio-skills-plugin-plan.md`](./docs/maintainers/apple-creator-studio-skills-plugin-plan.md) as the implementation source of truth.
-- [ ] Implement `compressor-workflow` first, then `logic-pro-workflow`, with official-help research, Computer Use safety checkpoints, reusable fixture contracts, and focused skill validation.
-- [ ] Decide whether the first two validated skills justify creating the child plugin and adding its marketplace entry, or whether the plan needs revision before an installable surface exists.
+- [x] Implement the first Creator Studio slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with official-help research, Computer Use safety checkpoints, reusable fixture contracts, and focused skill validation.
+- [x] Decide that the three validated initial-slice skills justify the child plugin and marketplace entry.
 - [ ] Implement Final Cut Pro and Motion only after Compressor handoff/relink/export contracts are proven in a real fixture project.
-- [ ] Implement MainStage only with explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
+- [ ] Require MainStage’s initial implementation to include explicit live-performance safety, audio/MIDI device preflight, and no-surprise-change controls.
 - [ ] Implement Pixelmator Pro after Mac/iPad scope, source-layer preservation, and cross-app image handoff requirements are tested.
 - [ ] Consider GarageBand after Logic Pro’s project/import/export handoffs are stable; do not imply GarageBand is included in Apple Creator Studio.
 - [ ] Publish `mac-image-workflows` only if Acorn and RetroBatch share enough durable asset-preparation contracts to earn a common owner without absorbing Pixelmator Pro or generic image-code workflows.
@@ -811,7 +812,7 @@ Planned
 
 - [ ] Every shipped skill has one concrete operator domain, authoritative Apple or vendor documentation anchors, a readable human path, and a Computer Use execution contract.
 - [ ] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
-- [ ] Compressor and Logic Pro have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
+- [ ] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
 - [ ] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
 
 ## Small Tickets

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -224,6 +224,16 @@ On 2026-07-13, the initial workflows were exercised against the installed Mac ap
 
 This is a limited manual-forward-test, not a claim of full cross-version automation. The Compressor artifact verifies the full source-to-delivery contract for a controlled fixture. GarageBand, Logic Pro, and MainStage verify safe entry, template/project creation, and visible default state; their record, bounce/export, routing, and live-performance gates remain confirmation-required workflow paths.
 
+On 2026-07-13, the second slice was forward-tested entirely inside the same untracked temporary fixture directory.
+
+| App | Installed version | Controlled fixture evidence | Result and boundary |
+| --- | --- | --- | --- |
+| Motion Creator Studio | 6.3 | Created a blank one-second 1920x1080, 29.97 fps standard-gamut composition and rendered it as a distinct ProRes MOV. | Rendered output existed and reported ProRes video, 1920x1080 dimensions, 29.97 fps, and 1.001-second duration. No source media was linked, replaced, published, or saved as a reusable Final Cut Pro template. |
+| Final Cut Pro Creator Studio | 12.3 | Created a temporary library and project, copied the Motion-rendered fixture into the library, appended the one-second clip, and shared a distinct ProRes MOV. | The shared output existed and reported ProRes video, 1920x1080 dimensions, 29.97 fps, and 1.001-second duration. No existing library, event, project, media, role, caption, or delivery was opened or modified. |
+| Compressor Creator Studio | 5.3 | Submitted the temporary Final Cut Pro share to the built-in `HD 720p` preset with a distinct output name in the same temporary directory. | Completed successfully. The delivery output reported H.264 video, 1280x720 dimensions, 29.97 fps, and 1.001-second duration. |
+
+The observed chain is Motion render -> Final Cut Pro import and project share -> Compressor delivery. It validates source-preserving entry, explicit output naming, temporary destinations, and artifact inspection; it does not establish template publishing, captions/roles, managed-media repair, or production color/audio-delivery behavior as automated-safe paths.
+
 ## Open Questions
 
 - What initial visual identity should the plugin use: consistent with Apple Dev Skills, or a distinct creative-suite mark?

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -4,7 +4,7 @@ This plan records the durable shape for a Socket-hosted `apple-creator-studio-sk
 
 ## Recommendation
 
-Create a separate `apple-creator-studio-skills` child plugin for the initial slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with `garageband-workflow` as its companion-app extension.
+Create a separate `apple-creator-studio-skills` child plugin for the initial slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with `garageband-workflow` as its companion-app extension. The second slice adds `final-cut-pro-workflow` and `motion-workflow` after controlled Compressor delivery fixtures proved the cross-app output boundary.
 
 This is a durable building-block change. It gives creative-app operation a clear install, documentation, validation, and ownership boundary without turning `apple-dev-skills` into a catch-all for both media-code implementation and professional-app operation.
 
@@ -125,19 +125,19 @@ Implement with a real device and rehearsal fixture, but keep all live-performanc
 
 Own beginner-friendly project setup, capture, arrangement, Apple Loops, automation, soundtrack work, safe export, and explicit GarageBand-to-Logic Pro handoffs. Keep it outside Creator Studio subscription claims.
 
-### Follow-Up Creator Studio Skills
+### Implemented Second Slice
 
 #### `final-cut-pro-workflow`
 
 Own Final Cut library safety, import and media organization, proxy/optimized media decisions, edit structures, captions, roles, titles/effects handoffs, color/export decisions, sharing, and relink/recovery guidance.
 
-Start only after Compressor proves the export and output-verification contract. [Final Cut Pro User Guide for Mac](https://support.apple.com/guide/final-cut-pro/welcome-ver92663661d/mac)
+Implemented after Compressor proved the export and output-verification contract. [Final Cut Pro User Guide for Mac](https://support.apple.com/guide/final-cut-pro/welcome-ver92663661d/mac)
 
 #### `motion-workflow`
 
 Own Motion project setup, behaviors/keyframes, generators, titles, effects, template publication for Final Cut Pro, parameter exposure, render/export, and source-project preservation.
 
-Start after the Final Cut and Compressor handoff contracts are proven. [Motion User Guide](https://support.apple.com/guide/motion/welcome/mac)
+Implemented after the Final Cut and Compressor handoff contracts were proven. [Motion User Guide](https://support.apple.com/guide/motion/welcome/mac)
 
 #### `pixelmator-pro-workflow`
 
@@ -200,7 +200,6 @@ Decision checkpoint: create `mac-image-workflows` only when at least two indepen
 
 ### Slice 5: Follow-Up Apps
 
-- Add Final Cut Pro and Motion together when their cross-app project/template/export flow has a tested fixture.
 - Add Pixelmator Pro only after Mac/iPad scope and source-layer preservation are proven.
 - Keep GarageBand handoff behavior under the same fixture gate as the rest of the plugin and do not claim full project parity with Logic Pro without an observed handoff.
 

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -4,7 +4,7 @@ This plan records the durable shape for a Socket-hosted `apple-creator-studio-sk
 
 ## Recommendation
 
-Create a separate `apple-creator-studio-skills` child plugin for the initial slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`.
+Create a separate `apple-creator-studio-skills` child plugin for the initial slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`, with `garageband-workflow` as its companion-app extension.
 
 This is a durable building-block change. It gives creative-app operation a clear install, documentation, validation, and ownership boundary without turning `apple-dev-skills` into a catch-all for both media-code implementation and professional-app operation.
 
@@ -119,6 +119,12 @@ Guide concert/set/patch structure, audio and MIDI device configuration, channel-
 
 Implement with a real device and rehearsal fixture, but keep all live-performance mutations behind visible user checkpoints. Apple’s support resource provides the [MainStage User Guide and release notes](https://support.apple.com/en-us/docs/software/134085).
 
+### Companion-App Extension
+
+#### `garageband-workflow`
+
+Own beginner-friendly project setup, capture, arrangement, Apple Loops, automation, soundtrack work, safe export, and explicit GarageBand-to-Logic Pro handoffs. Keep it outside Creator Studio subscription claims.
+
 ### Follow-Up Creator Studio Skills
 
 #### `final-cut-pro-workflow`
@@ -138,10 +144,6 @@ Start after the Final Cut and Compressor handoff contracts are proven. [Motion U
 Own document/layer preservation, nondestructive editing decisions, color/profile-aware output, export variants, asset naming, and handoffs to Final Cut Pro, Motion, and other creative-app surfaces.
 
 Start after confirming Mac/iPad feature boundaries and durable source-versus-delivery conventions.
-
-#### `garageband-workflow`
-
-Own beginner-friendly capture, songwriting, basic mix, and safe project/export handoffs into Logic Pro. Keep it out of Creator Studio subscription claims.
 
 ## Future Mac Image Workflows Plugin Candidate
 
@@ -200,7 +202,7 @@ Decision checkpoint: create `mac-image-workflows` only when at least two indepen
 
 - Add Final Cut Pro and Motion together when their cross-app project/template/export flow has a tested fixture.
 - Add Pixelmator Pro only after Mac/iPad scope and source-layer preservation are proven.
-- Add GarageBand only after Logic handoff behavior is concretely validated.
+- Keep GarageBand handoff behavior under the same fixture gate as the rest of the plugin and do not claim full project parity with Logic Pro without an observed handoff.
 
 ## Validation Strategy
 

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -212,6 +212,19 @@ Decision checkpoint: create `mac-image-workflows` only when at least two indepen
 - Forward-test each skill through a disposable fixture task with a fresh agent context after its initial draft. Do not pass the intended solution or hidden fixture result to the tester.
 - Treat visual/manual app verification as an explicit evidence type. Record the app version, the operation, the output artifact, and any limitation rather than asserting that a UI flow is stable across all releases.
 
+## Live Application Evidence
+
+On 2026-07-13, the initial workflows were exercised against the installed Mac applications with no pre-existing user project, library, session, or concert opened.
+
+| App | Installed version | Disposable fixture evidence | Result and boundary |
+| --- | --- | --- | --- |
+| Compressor Creator Studio | 5.3 | Submitted a self-created one-second H.264/AAC MOV through the built-in `HD 720p` preset to an untracked temporary fixture directory. | Completed successfully. The distinct output MOV was present, reported H.264/AAC streams, 320x180 video, and a 1.0-second duration. |
+| GarageBand | 10.4.14 | After initial content installation completed, created an empty `Untitled.band` project with one default software-instrument track. | Project opened with recording disabled and no regions. No recording, export, save-as, share, device, or existing-project action was taken. |
+| Logic Pro Creator Studio | 12.3 | Created an empty `Untitled.logicx` project with one default software-instrument track. | Project opened with record enable and transport recording disabled and no regions. No bounce, export, save-as, routing, device, or existing-project action was taken. |
+| MainStage Creator Studio | 4.3 | Created the Quick Start Keyboard `Untitled Concert` fixture. | The template requested a separate optional 1.85 GB sound-pack download; it was declined. No MIDI/audio routing, mappings, patch selection, playback, recording, or concert save occurred. |
+
+This is a limited manual-forward-test, not a claim of full cross-version automation. The Compressor artifact verifies the full source-to-delivery contract for a controlled fixture. GarageBand, Logic Pro, and MainStage verify safe entry, template/project creation, and visible default state; their record, bounce/export, routing, and live-performance gates remain confirmation-required workflow paths.
+
 ## Open Questions
 
 - What initial visual identity should the plugin use: consistent with Apple Dev Skills, or a distinct creative-suite mark?

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -1,0 +1,221 @@
+# Apple Creator Studio Skills Plugin Plan
+
+This plan records the durable shape for a Socket-hosted `apple-creator-studio-skills` plugin: operator guidance for people and agents using Apple’s creative applications.
+
+## Recommendation
+
+Create a separate `apple-creator-studio-skills` child plugin once its first two workflows are implemented and validated. Start with `compressor-workflow`, then `logic-pro-workflow`.
+
+This is a durable building-block change. It gives creative-app operation a clear install, documentation, validation, and ownership boundary without turning `apple-dev-skills` into a catch-all for both media-code implementation and professional-app operation.
+
+The simpler extension path—adding these workflows to `apple-dev-skills`—was considered first. It would be misleading: that plugin owns Swift, Xcode, Apple frameworks, and low-level media-code behavior; Creator Studio skills own libraries, projects, presets, app UI, exports, performance rigs, source artifacts, and human-in-the-loop Computer Use. Keeping the boundaries separate makes requests easier to route and preserves the existing AVFoundation, AVFAudio, Core Media, Core Audio, and VideoToolbox owners.
+
+## Product Boundary
+
+Apple Creator Studio currently includes Final Cut Pro, Logic Pro, Pixelmator Pro, Motion, Compressor, and MainStage. It also provides subscription-only premium features and content in Keynote, Pages, Numbers, and Freeform. Existing one-time-purchase versions of the six Mac creative apps remain usable. [Apple Creator Studio](https://support.apple.com/en-us/125029)
+
+This plugin covers the six dedicated creative applications as operator workflows. It does not automatically absorb productivity-app work, image-code implementation, audio-code implementation, generic video processing, or generic desktop automation.
+
+GarageBand is not an Apple Creator Studio subscription app. It remains a worthwhile companion workflow for accessible music capture and project handoff into Logic Pro, but must be represented accurately in plugin metadata and user-facing wording.
+
+## Ownership And Handoffs
+
+| Request | Owner | Reason |
+| --- | --- | --- |
+| Edit a Final Cut library, construct a Motion template, transcode in Compressor, mix in Logic, prepare a MainStage concert, or preserve Pixelmator source layers | `apple-creator-studio-skills` | The task is application operation and creative-artifact safety. |
+| Implement Swift media capture, playback, export, audio graphs, sample timing, codecs, image processing, or photo-library access | `apple-dev-skills` | The task is Apple framework or Xcode code behavior. |
+| Make a deterministic command-line conversion where Compressor’s app path is unavailable or unsuitable | A separate `ffmpeg` or shell workflow | Do not claim a stable Compressor CLI contract without verified current behavior. |
+| Automate windows, inspect menus, or drive the app after a user authorizes interaction | The applicable Creator Studio skill plus Computer Use | The creative-app skill owns the decision and safety contract; Computer Use owns UI interaction. |
+| Prepare assets in Acorn or RetroBatch | Future `mac-image-workflows` candidate | Those apps are not Creator Studio apps and should not be hidden within an Apple subscription plugin. |
+
+## Design Principles
+
+- Write for both a creator operating the app and an agent helping through Computer Use.
+- Preserve source media, project files, libraries, sessions, patches, and layered documents by default.
+- Treat render, export, batch submission, external-device changes, library consolidation, relinking, deletion, and publishing as confirmation checkpoints.
+- Use the real visible app state as the source of truth. Inspect before acting; do not rely on fixed screen coordinates, assumed panel layouts, or stale menu paths.
+- Put app-version, macOS-version, device, plug-in, media, codec, and destination assumptions in the run record when they affect a result.
+- Give every workflow one clear artifact contract: inputs, source-preservation policy, target output, destination, and verification method.
+- Keep help text concise and procedural. Store app-specific command tables, export settings, and fixture details in skill references, not in a giant shared overview.
+- Use official Apple Help, release notes, and support material first. Treat product behavior as version-sensitive and refresh the documentation anchors before adding a new app feature claim.
+
+## Computer Use Contract
+
+Each skill must include these agent-facing rules:
+
+1. Inspect the active app, document, project/library/session state, selected item, and destination before editing.
+2. State the proposed mutation in plain language before performing an action that can overwrite, delete, relink, change a live patch, start an expensive render, or publish/share an artifact.
+3. Use a visible save-as/copy/duplicate path or a user-confirmed backup when the application supports it and the task risks source loss.
+4. Confirm the exact output name, format, destination, and overwrite behavior immediately before exporting, transcoding, bouncing, rendering, or sharing.
+5. Verify the resulting artifact in the app or Finder with the concrete condition that matters: a completed job, expected duration/resolution/codec, audible stem, loaded patch, preserved source layer, or readable project.
+6. Stop rather than improvising when a modal warning, missing media, missing plug-in, account prompt, permission prompt, unfamiliar destructive dialog, or mismatched project version changes the operation.
+7. Keep live MainStage performance surfaces especially conservative: no device routing, patch selection, concert save, or playback/record action without an explicit user-visible checkpoint.
+
+Computer Use is a UI-driving aid, not a promise that every task is safe to run unattended. Skills should describe a human-readable manual route even when the agent can operate the app.
+
+## Shared Artifact Convention
+
+Every workflow should ask for or establish this minimum record:
+
+- source artifact and its location;
+- working copy or source-preservation decision;
+- app and version; macOS version when it changes behavior;
+- intended deliverable and target audience/platform;
+- output directory and overwrite policy;
+- required constraints: duration, sample rate, resolution, color/HDR, loudness, file size, codec, captioning, stems, or performance hardware;
+- verification evidence and any remaining uncertainty.
+
+Never rely on a machine-local path in shipped documentation or plugin metadata. Paths may appear only in a user’s current interactive task or in untracked fixture instructions.
+
+## Skill Inventory
+
+### First Release
+
+#### `compressor-workflow`
+
+Guide media import, presets, settings, destinations, batches, watch-folder decisions, Final Cut Pro/Motion handoff, submission, job monitoring, and verified delivery artifacts.
+
+Primary use cases:
+
+- make a share-ready deliverable from a known source;
+- choose or safely customize a preset for a target platform;
+- set batch destinations and prevent source/output confusion;
+- diagnose a failed, stalled, or unexpected transcode from visible job evidence;
+- send Final Cut Pro or Motion work through Compressor deliberately;
+- verify codec, resolution, duration, audio, and destination after completion.
+
+Not owned:
+
+- low-level codec code or VideoToolbox session configuration;
+- a guaranteed CLI interface;
+- replacing a user’s encoding judgment when target delivery requirements are unknown.
+
+Primary source: [Compressor User Guide](https://support.apple.com/guide/compressor/imf-package-fields-cpsra358c67e/mac).
+
+#### `logic-pro-workflow`
+
+Guide projects, audio/MIDI device preflight, recording, editing, arrangement, session-player decisions, routing, mixing, export/bounce, stem delivery, and safe Logic/MainStage handoffs.
+
+Primary use cases:
+
+- begin or stabilize a production session without losing existing media;
+- configure an interface, input, monitoring, tempo, and project rate intentionally;
+- record or edit audio/MIDI while preserving takes and recoverability;
+- organize tracks, buses, plug-ins, automation, and gain staging into a comprehensible mix;
+- bounce a master or stems with an explicit deliverable contract;
+- prepare a Logic patch/project handoff for MainStage only after device and live-performance constraints are clear.
+
+Not owned:
+
+- custom audio-engine programming;
+- unattended recording or destructive session cleanup;
+- assertions about plug-in availability without inspecting the actual project and installed system.
+
+Primary source: [Logic Pro User Guide for Mac](https://support.apple.com/en-gb/guide/logicpro/welcome/mac).
+
+### Follow-Up Creator Studio Skills
+
+#### `final-cut-pro-workflow`
+
+Own Final Cut library safety, import and media organization, proxy/optimized media decisions, edit structures, captions, roles, titles/effects handoffs, color/export decisions, sharing, and relink/recovery guidance.
+
+Start only after Compressor proves the export and output-verification contract. [Final Cut Pro User Guide for Mac](https://support.apple.com/guide/final-cut-pro/welcome-ver92663661d/mac)
+
+#### `motion-workflow`
+
+Own Motion project setup, behaviors/keyframes, generators, titles, effects, template publication for Final Cut Pro, parameter exposure, render/export, and source-project preservation.
+
+Start after the Final Cut and Compressor handoff contracts are proven. [Motion User Guide](https://support.apple.com/guide/motion/welcome/mac)
+
+#### `mainstage-workflow`
+
+Own concert/set/patch structure, audio and MIDI device configuration, channel-strip and plug-in routing, mappings, rehearsal checks, backup copies, and explicit live-performance confirmation gates.
+
+Start only with a real device and rehearsal fixture. Apple’s support resource provides the [MainStage User Guide and release notes](https://support.apple.com/en-us/docs/software/134085).
+
+#### `pixelmator-pro-workflow`
+
+Own document/layer preservation, nondestructive editing decisions, color/profile-aware output, export variants, asset naming, and handoffs to Final Cut Pro, Motion, and other creative-app surfaces.
+
+Start after confirming Mac/iPad feature boundaries and durable source-versus-delivery conventions.
+
+#### `garageband-workflow`
+
+Own beginner-friendly capture, songwriting, basic mix, and safe project/export handoffs into Logic Pro. Keep it out of Creator Studio subscription claims.
+
+## Future Mac Image Workflows Plugin Candidate
+
+Acorn and RetroBatch should remain separate from Creator Studio for now. The likely future home is `mac-image-workflows`, but it should only be created when common work justifies it.
+
+Potential skills:
+
+- `acorn-workflow`: layers, selections, non-destructive source policy, batch-safe exports, and reproducible image edits.
+- `retrobatch-workflow`: input sets, filters, naming templates, metadata policy, batch previews, destination safety, queue completion, and sampled output verification.
+- `mac-image-asset-handoff`: a narrow shared workflow for source assets, variants, color profiles, format decisions, naming, metadata, and transfer into video/app-icon/web surfaces.
+
+Do not include Pixelmator Pro in that plugin. It belongs with Creator Studio because its project, install, and support surface is part of the Apple collection. Do not include Core Image, Image I/O, or app image-code tasks there; those belong in `apple-dev-skills`.
+
+Decision checkpoint: create `mac-image-workflows` only when at least two independent app workflows have reusable references, fixture needs, validation contracts, and user-facing value. Otherwise retain the plan without an empty install surface.
+
+## First Implementation Sequence
+
+### Slice 0: Shared Preparation
+
+- Confirm the exact plugin path and local validation convention by following the closest existing child-plugin shape.
+- Record the application versions available on the validation Mac; do not place machine-local paths in the repository.
+- Collect official Apple Help anchors and current release notes for Compressor and Logic Pro.
+- Define disposable fixture inputs: a short licensed or self-created video/audio source, a simple Logic project, expected export contracts, and an untracked local output directory.
+- Define how a run records source preservation, output location, complete-job status, and artifact verification.
+
+### Slice 1: `compressor-workflow`
+
+- Initialize the new skill using the standard skill scaffold only after the child-plugin directory is deliberately created.
+- Write a compact `SKILL.md` covering request classification, preflight, source-preserving job setup, preset/destination selection, submission, monitoring, verification, recovery, and handoffs.
+- Add only the references that make the workflow repeatable: job/preset/destination decision table, failure/recovery states, and artifact-verification checklist.
+- Keep a clear fallback boundary: use a separate command-line encoding workflow when an actual reproducible CLI contract is required; do not misrepresent the installed Compressor app as a supported CLI tool.
+- Validate with at least one controlled transcode and one destination/preset inspection pass. Capture app version and actual output evidence.
+
+### Slice 2: `logic-pro-workflow`
+
+- Write a compact `SKILL.md` for project preflight, audio/MIDI device state, project settings, recording/arrangement, routing/mix decisions, bounce/stem output, verification, and MainStage handoff.
+- Add references for session ownership, recording safety, routing/bus checklist, delivery decision table, and recovery states for missing media/device/plug-in warnings.
+- Require explicit confirmation before recording, replacing takes, changing audio devices, freezing/flattening, destructive editing, or bouncing over an existing file.
+- Validate with a disposable Logic project: inspect configuration, make a non-destructive edit, create a defined output, and verify it opens/plays as expected.
+
+### Slice 3: Plugin Packaging And Release Readiness
+
+- Add child `AGENTS.md`, `.codex-plugin/plugin.json`, authored `skills/`, and only required test/validation files.
+- Add the root marketplace entry only after Compressor and Logic are real, validated skill folders.
+- Update root README, roadmap, active-skill inventory, plugin metadata, and tests in the same pass.
+- Run child validation, root metadata validation, and focused fixture checks serially.
+
+### Slice 4: Follow-Up Apps
+
+- Add Final Cut Pro and Motion together when their cross-app project/template/export flow has a tested fixture.
+- Add MainStage in a separate pass with actual interface/controller/rehearsal evidence.
+- Add Pixelmator Pro only after Mac/iPad scope and source-layer preservation are proven.
+- Add GarageBand only after Logic handoff behavior is concretely validated.
+
+## Validation Strategy
+
+- Validate every new skill folder with the standard skill validator.
+- Add focused repository tests that inspect required frontmatter, reference links, metadata/skill inventory agreement, and safety-language requirements without attempting to automate professional creative apps in CI.
+- Run deterministic repository checks serially: child checks first, then root metadata validation.
+- Forward-test each skill through a disposable fixture task with a fresh agent context after its initial draft. Do not pass the intended solution or hidden fixture result to the tester.
+- Treat visual/manual app verification as an explicit evidence type. Record the app version, the operation, the output artifact, and any limitation rather than asserting that a UI flow is stable across all releases.
+
+## Open Questions
+
+- What initial visual identity should the plugin use: consistent with Apple Dev Skills, or a distinct creative-suite mark?
+- Should the first release offer Mac-only guidance, or provide iPad-specific Final Cut Pro and Logic Pro paths immediately where Apple’s help distinguishes them?
+- Which real first fixtures best fit Gale’s creative work: screen-recording delivery, a short educational video package, a nightcore/remix Logic session, or a simple MainStage rehearsal project?
+- Should the first Compressor release include a project-local helper for artifact inspection, or keep output verification manual/standard-tool based until a deterministic need recurs?
+- Does Pixelmator Pro belong in the first Creator Studio release after the two initial skills, or should it wait until the Acorn/RetroBatch decision establishes a stronger image-workflow boundary?
+
+## Non-Goals
+
+- Do not bundle Apple apps, paid content, plug-ins, codecs, media, third-party presets, or license-restricted documentation.
+- Do not create a generic “Creative Studio automation” skill that obscures app-specific safety and artifact contracts.
+- Do not treat a Computer Use action as verification; require observed state or an inspected output artifact.
+- Do not promise that all app operations are scriptable, stable across versions, or safe without human review.
+- Do not modify a user’s source project/library/session in a training or validation pass.

--- a/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
+++ b/docs/maintainers/apple-creator-studio-skills-plugin-plan.md
@@ -4,7 +4,7 @@ This plan records the durable shape for a Socket-hosted `apple-creator-studio-sk
 
 ## Recommendation
 
-Create a separate `apple-creator-studio-skills` child plugin once its first two workflows are implemented and validated. Start with `compressor-workflow`, then `logic-pro-workflow`.
+Create a separate `apple-creator-studio-skills` child plugin for the initial slice: `compressor-workflow`, `logic-pro-workflow`, and `mainstage-workflow`.
 
 This is a durable building-block change. It gives creative-app operation a clear install, documentation, validation, and ownership boundary without turning `apple-dev-skills` into a catch-all for both media-code implementation and professional-app operation.
 
@@ -69,7 +69,7 @@ Never rely on a machine-local path in shipped documentation or plugin metadata. 
 
 ## Skill Inventory
 
-### First Release
+### Initial Slice
 
 #### `compressor-workflow`
 
@@ -113,6 +113,12 @@ Not owned:
 
 Primary source: [Logic Pro User Guide for Mac](https://support.apple.com/en-gb/guide/logicpro/welcome/mac).
 
+#### `mainstage-workflow`
+
+Guide concert/set/patch structure, audio and MIDI device configuration, channel-strip and plug-in routing, mappings, rehearsal checks, backup copies, and explicit live-performance confirmation gates.
+
+Implement with a real device and rehearsal fixture, but keep all live-performance mutations behind visible user checkpoints. Apple’s support resource provides the [MainStage User Guide and release notes](https://support.apple.com/en-us/docs/software/134085).
+
 ### Follow-Up Creator Studio Skills
 
 #### `final-cut-pro-workflow`
@@ -126,12 +132,6 @@ Start only after Compressor proves the export and output-verification contract. 
 Own Motion project setup, behaviors/keyframes, generators, titles, effects, template publication for Final Cut Pro, parameter exposure, render/export, and source-project preservation.
 
 Start after the Final Cut and Compressor handoff contracts are proven. [Motion User Guide](https://support.apple.com/guide/motion/welcome/mac)
-
-#### `mainstage-workflow`
-
-Own concert/set/patch structure, audio and MIDI device configuration, channel-strip and plug-in routing, mappings, rehearsal checks, backup copies, and explicit live-performance confirmation gates.
-
-Start only with a real device and rehearsal fixture. Apple’s support resource provides the [MainStage User Guide and release notes](https://support.apple.com/en-us/docs/software/134085).
 
 #### `pixelmator-pro-workflow`
 
@@ -182,17 +182,23 @@ Decision checkpoint: create `mac-image-workflows` only when at least two indepen
 - Require explicit confirmation before recording, replacing takes, changing audio devices, freezing/flattening, destructive editing, or bouncing over an existing file.
 - Validate with a disposable Logic project: inspect configuration, make a non-destructive edit, create a defined output, and verify it opens/plays as expected.
 
-### Slice 3: Plugin Packaging And Release Readiness
+### Slice 3: `mainstage-workflow`
+
+- Write a compact `SKILL.md` for concert/set/patch structure, audio/MIDI device preflight, channel strips, mappings, rehearsal, backup, and live-performance confirmation gates.
+- Add references for device/routing state, concert backup, patch-change safety, rehearsal checklist, and recovery from missing device or plug-in conditions.
+- Require explicit confirmation before changing selected patches, audio/MIDI routing, mappings, concert files, playback, or recording on a live-performance surface.
+- Validate with a disposable rehearsal concert and real available audio/MIDI evidence; do not alter an active performance configuration during validation.
+
+### Slice 4: Plugin Packaging And Release Readiness
 
 - Add child `AGENTS.md`, `.codex-plugin/plugin.json`, authored `skills/`, and only required test/validation files.
-- Add the root marketplace entry only after Compressor and Logic are real, validated skill folders.
+- Add the root marketplace entry only after Compressor, Logic Pro, and MainStage are real, validated skill folders.
 - Update root README, roadmap, active-skill inventory, plugin metadata, and tests in the same pass.
 - Run child validation, root metadata validation, and focused fixture checks serially.
 
-### Slice 4: Follow-Up Apps
+### Slice 5: Follow-Up Apps
 
 - Add Final Cut Pro and Motion together when their cross-app project/template/export flow has a tested fixture.
-- Add MainStage in a separate pass with actual interface/controller/rehearsal evidence.
 - Add Pixelmator Pro only after Mac/iPad scope and source-layer preservation are proven.
 - Add GarageBand only after Logic handoff behavior is concretely validated.
 

--- a/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-creator-studio-skills",
   "version": "9.4.1",
-  "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Compressor delivery, Logic Pro production, and MainStage concert preparation.",
+  "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Compressor delivery, Logic Pro production, MainStage concert preparation, and GarageBand projects.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -16,6 +16,7 @@
     "compressor",
     "logic-pro",
     "mainstage",
+    "garageband",
     "audio",
     "video",
     "creative-workflows",
@@ -27,7 +28,7 @@
   "interface": {
     "displayName": "Apple Creator Studio Skills",
     "shortDescription": "Safe creative-app workflows for Codex.",
-    "longDescription": "Guide people and Codex agents through source-preserving Apple Creator Studio workflows for Compressor delivery jobs, Logic Pro production sessions, and MainStage concert preparation. Each workflow combines local app Help discovery, explicit Computer Use safeguards, artifact verification, and handoffs to Apple framework skills when code work is the real task.",
+    "longDescription": "Guide people and Codex agents through source-preserving Apple Creator Studio workflows for Compressor delivery jobs, Logic Pro production sessions, MainStage concert preparation, and GarageBand projects. GarageBand is a companion app rather than an Apple Creator Studio subscription app. Each workflow combines local app Help discovery, explicit Computer Use safeguards, artifact verification, and handoffs to Apple framework skills when code work is the real task.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -38,7 +39,8 @@
     "defaultPrompt": [
       "Prepare a Compressor batch and verify its exported delivery artifacts without overwriting source media.",
       "Set up or repair this Logic Pro session, then bounce a defined master or stem delivery safely.",
-      "Prepare this MainStage concert for rehearsal with explicit audio, MIDI, patch, and live-performance safety checks."
+      "Prepare this MainStage concert for rehearsal with explicit audio, MIDI, patch, and live-performance safety checks.",
+      "Prepare or export this GarageBand project while preserving recordings, tracks, and source media."
     ],
     "brandColor": "#C18CFF"
   }

--- a/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "apple-creator-studio-skills",
+  "version": "9.4.1",
+  "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Compressor delivery, Logic Pro production, and MainStage concert preparation.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "homepage": "https://github.com/gaelic-ghost/socket/tree/main/plugins/apple-creator-studio-skills",
+  "repository": "https://github.com/gaelic-ghost/socket",
+  "license": "Apache-2.0",
+  "keywords": [
+    "apple",
+    "creator-studio",
+    "compressor",
+    "logic-pro",
+    "mainstage",
+    "audio",
+    "video",
+    "creative-workflows",
+    "computer-use",
+    "codex",
+    "skills"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Apple Creator Studio Skills",
+    "shortDescription": "Safe creative-app workflows for Codex.",
+    "longDescription": "Guide people and Codex agents through source-preserving Apple Creator Studio workflows for Compressor delivery jobs, Logic Pro production sessions, and MainStage concert preparation. Each workflow combines local app Help discovery, explicit Computer Use safeguards, artifact verification, and handoffs to Apple framework skills when code work is the real task.",
+    "developerName": "Gale",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/apple-creator-studio-skills",
+    "defaultPrompt": [
+      "Prepare a Compressor batch and verify its exported delivery artifacts without overwriting source media.",
+      "Set up or repair this Logic Pro session, then bounce a defined master or stem delivery safely.",
+      "Prepare this MainStage concert for rehearsal with explicit audio, MIDI, patch, and live-performance safety checks."
+    ],
+    "brandColor": "#C18CFF"
+  }
+}

--- a/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-creator-studio-skills",
   "version": "9.4.1",
-  "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Compressor delivery, Logic Pro production, MainStage concert preparation, and GarageBand projects.",
+  "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Final Cut Pro editing, Motion templates, Compressor delivery, Logic Pro production, MainStage concert preparation, and GarageBand projects.",
   "author": {
     "name": "Gale",
     "email": "mail@galewilliams.com",
@@ -14,8 +14,10 @@
     "apple",
     "creator-studio",
     "compressor",
+    "final-cut-pro",
     "logic-pro",
     "mainstage",
+    "motion",
     "garageband",
     "audio",
     "video",
@@ -28,7 +30,7 @@
   "interface": {
     "displayName": "Apple Creator Studio Skills",
     "shortDescription": "Safe creative-app workflows for Codex.",
-    "longDescription": "Guide people and Codex agents through source-preserving Apple Creator Studio workflows for Compressor delivery jobs, Logic Pro production sessions, MainStage concert preparation, and GarageBand projects. GarageBand is a companion app rather than an Apple Creator Studio subscription app. Each workflow combines local app Help discovery, explicit Computer Use safeguards, artifact verification, and handoffs to Apple framework skills when code work is the real task.",
+    "longDescription": "Guide people and Codex agents through source-preserving Apple Creator Studio workflows for Final Cut Pro libraries and edits, Motion projects and templates, Compressor delivery jobs, Logic Pro production sessions, MainStage concert preparation, and GarageBand projects. GarageBand is a companion app rather than an Apple Creator Studio subscription app. Each workflow combines local app Help discovery, explicit Computer Use safeguards, artifact verification, and handoffs to Apple framework skills when code work is the real task.",
     "developerName": "Gale",
     "category": "Developer Tools",
     "capabilities": [
@@ -38,6 +40,8 @@
     "websiteURL": "https://github.com/gaelic-ghost/socket/tree/main/plugins/apple-creator-studio-skills",
     "defaultPrompt": [
       "Prepare a Compressor batch and verify its exported delivery artifacts without overwriting source media.",
+      "Prepare this Final Cut Pro library or project safely, then verify a defined share or Compressor handoff.",
+      "Prepare this Motion project or Final Cut Pro template while preserving the editable source.",
       "Set up or repair this Logic Pro session, then bounce a defined master or stem delivery safely.",
       "Prepare this MainStage concert for rehearsal with explicit audio, MIDI, patch, and live-performance safety checks.",
       "Prepare or export this GarageBand project while preserving recordings, tracks, and source media."

--- a/plugins/apple-creator-studio-skills/AGENTS.md
+++ b/plugins/apple-creator-studio-skills/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+This file is the Apple Creator Studio Skills child-repo override for work done from `socket`. Follow the root `socket` guidance for general Git, documentation, release, and validation workflow.
+
+## Scope
+
+- `apple-creator-studio-skills` owns human-facing and Computer Use-aware operation of Apple Creator Studio applications.
+- Root `skills/` is the authored workflow surface.
+- The first shipped skills own Compressor delivery jobs, Logic Pro production sessions, and MainStage concert preparation.
+- This is a guidance plugin, not an unattended app-control daemon, media-processing runtime, or bundled copy of Apple Help.
+
+## Boundaries
+
+- Use `apple-dev-skills` for Swift, Xcode, Apple framework, AVFoundation, AVFAudio, Core Media, Core Audio, VideoToolbox, Core Image, and Image I/O implementation work.
+- Use this plugin when the task operates an app project, library, session, concert, set, patch, preset, batch, destination, export, bounce, or delivery artifact.
+- Use the local Tips/Help Viewer catalog and the app's Help menu to find installed-app guides when available. Confirm the opened guide matches the installed app and version; use official Apple support material when the local guide is missing or incomplete.
+- Do not claim the `com.apple.tips` shell is the usable documentation surface on this Mac. The observed usable surface is `com.apple.helpviewer`, which displays the Tips/user-guide catalog.
+
+## Safety
+
+- Inspect the active app, selected document/project, output destination, and overwrite behavior before mutations.
+- Preserve source media, sessions, concerts, patches, libraries, and projects by default.
+- Require a visible user confirmation before actions that overwrite, delete, relink, replace takes, change routing or mappings, render, bounce, transcode, publish, record, or alter a live-performance configuration.
+- Treat a completed UI action as insufficient proof. Verify the resulting artifact, job status, route, patch, or playback state.
+- Never validate against a user’s live performance configuration. Use a disposable rehearsal fixture and observed device evidence.
+
+## Validation
+
+Run skill validation for every changed workflow:
+
+```bash
+uv run python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/<skill-name>
+```
+
+When manifest, marketplace, or root documentation changes, also run:
+
+```bash
+uv run scripts/validate_socket_metadata.py
+```

--- a/plugins/apple-creator-studio-skills/AGENTS.md
+++ b/plugins/apple-creator-studio-skills/AGENTS.md
@@ -4,9 +4,9 @@ This file is the Apple Creator Studio Skills child-repo override for work done f
 
 ## Scope
 
-- `apple-creator-studio-skills` owns human-facing and Computer Use-aware operation of Apple Creator Studio applications.
+- `apple-creator-studio-skills` owns human-facing and Computer Use-aware operation of Apple Creator Studio applications plus the GarageBand companion workflow.
 - Root `skills/` is the authored workflow surface.
-- The first shipped skills own Compressor delivery jobs, Logic Pro production sessions, and MainStage concert preparation.
+- The shipped skills own Compressor delivery jobs, Logic Pro production sessions, MainStage concert preparation, and GarageBand project workflows.
 - This is a guidance plugin, not an unattended app-control daemon, media-processing runtime, or bundled copy of Apple Help.
 
 ## Boundaries

--- a/plugins/apple-creator-studio-skills/skills/compressor-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/compressor-workflow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: compressor-workflow
+description: Guide safe Apple Compressor projects, presets, destinations, batches, watch-folder decisions, Final Cut Pro or Motion handoffs, job monitoring, and delivery-artifact verification. Use when a user needs to transcode or package media in Compressor without losing source media or overwriting the wrong output.
+---
+
+# Compressor Workflow
+
+Use this skill for Compressor app operation, not low-level codec code or an assumed Compressor command-line interface.
+
+## Source Check
+
+Open Compressor Help or search the local Tips/Help Viewer catalog for `Compressor`. Confirm that the guide matches the installed app/version before relying on a menu path, preset behavior, or automation feature. Read `references/job-and-delivery-contract.md` for the shared preflight and verification contract.
+
+## Workflow
+
+1. Classify the task: one-off export, batch, preset customization, destination setup, watch-folder decision, Final Cut Pro/Motion handoff, failed job, or artifact verification.
+2. Establish the artifact contract: source location, whether it must stay untouched, codec/container, dimensions, frame rate, audio layout/sample rate, captions/HDR/metadata requirements, destination, overwrite rule, and delivery target.
+3. Inspect the active Compressor project before changing it: selected jobs, applied settings, destinations, job actions, output names, and any warning or missing-media state.
+4. Preserve source state. Prefer a new project or duplicate when altering an existing reusable preset/job. Do not relink, remove jobs, replace source media, or overwrite a prior delivery without a visible user confirmation.
+5. Choose the smallest correct setting/preset and destination. Explain any tradeoff between delivery requirements, quality, file size, compatibility, and time. Do not invent a platform specification the user has not supplied.
+6. Before submitting, state the exact input, output name, destination, overwrite behavior, setting, and any batch/watch-folder effect. Get confirmation before starting a render, transcode, or operation that can overwrite an artifact.
+7. Monitor the job and stop on an unexpected alert, missing-media/extension condition, failed status, or output-location mismatch. Report the concrete job, setting, destination, and error context.
+8. Verify the completed artifact against the contract: existence, destination, file name, duration, dimensions, codec/container, audio, and any required captions/HDR/metadata. Record limits that require target-platform testing.
+
+## Guards
+
+- Do not treat the `Compressor Creator Studio` executable as a supported CLI. Use a separately verified command-line media workflow when reproducible CLI encoding is the requirement.
+- Do not mistake a completed job for an acceptable delivery; inspect the artifact.
+- Do not apply a preset merely because its label sounds right. Check its actual settings and target requirements.
+- Do not turn on watch folders or job actions without explaining their persistent or automatic behavior and receiving confirmation.
+- Hand framework code, custom readers/writers, or per-frame codec work to `apple-dev-skills` media workflows.
+
+## Handoffs
+
+- `logic-pro-workflow` for music/stem preparation before final delivery.
+- Future Final Cut Pro or Motion workflows for editing and template authoring; Compressor owns the transcode/delivery step.
+- `apple-dev-skills:video-codec-processing-workflow` or `avfoundation-media-pipeline-workflow` for code-level media processing.
+- A verified `ffmpeg` workflow when a CLI artifact contract is explicitly required.

--- a/plugins/apple-creator-studio-skills/skills/compressor-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/compressor-workflow/SKILL.md
@@ -33,6 +33,6 @@ Open Compressor Help or search the local Tips/Help Viewer catalog for `Compresso
 ## Handoffs
 
 - `logic-pro-workflow` for music/stem preparation before final delivery.
-- Future Final Cut Pro or Motion workflows for editing and template authoring; Compressor owns the transcode/delivery step.
+- `final-cut-pro-workflow` for editing, sharing, and source-master preparation; `motion-workflow` for composition and template authoring. Compressor owns the transcode/delivery step.
 - `apple-dev-skills:video-codec-processing-workflow` or `avfoundation-media-pipeline-workflow` for code-level media processing.
 - A verified `ffmpeg` workflow when a CLI artifact contract is explicitly required.

--- a/plugins/apple-creator-studio-skills/skills/compressor-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/compressor-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compressor Workflow"
+  short_description: "Safe Compressor delivery workflows"
+  default_prompt: "Use $compressor-workflow to prepare and verify this Compressor export."

--- a/plugins/apple-creator-studio-skills/skills/compressor-workflow/references/job-and-delivery-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/compressor-workflow/references/job-and-delivery-contract.md
@@ -1,0 +1,34 @@
+# Compressor Job And Delivery Contract
+
+Use this reference when preparing, changing, or verifying a Compressor job.
+
+## Preflight
+
+- Identify the source file or upstream Final Cut Pro/Motion deliverable.
+- Say whether the source must remain unchanged and where the new artifact belongs.
+- Record the delivery requirements: platform, container, codec, resolution, frame rate, audio, captions, HDR/color, metadata, file-size target, and deadline.
+- Inspect existing jobs, selected settings, destinations, actions, output names, and warnings before editing.
+
+## Decision Rules
+
+| Situation | Safe default |
+| --- | --- |
+| Existing reusable job or preset | Duplicate or make a new project before changing it. |
+| Unknown delivery platform requirements | Ask for the target or produce a clearly labeled review master; do not guess social/platform presets. |
+| Existing output name in destination | Stop and ask whether to overwrite, version, or choose a new directory. |
+| Batch input | List every source and destination before submission. |
+| Watch folder | Explain ongoing automation, input handling, and output location before enabling or changing it. |
+| Failed/stalled job | Capture job name, input, setting, destination, warning/error text, and whether output was partially written. |
+
+## Verification
+
+Inspect the completed output rather than relying only on the job list:
+
+- correct directory and final file name;
+- expected duration and dimensions;
+- expected container and codec;
+- audio presence, layout, and sample rate when relevant;
+- required captions, metadata, color/HDR, or packaging behavior;
+- no accidental overwrite of the source or previous delivery.
+
+Use target-platform playback/testing when compatibility is the actual requirement.

--- a/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: final-cut-pro-workflow
+description: Guide safe Final Cut Pro libraries, events, projects, media imports, proxy and optimized-media decisions, timeline edits, roles, captions, shares, and Compressor/Motion handoffs. Use when a user needs to inspect, edit, repair, export, or hand off a Final Cut Pro project while preserving source media and existing libraries.
+---
+
+# Final Cut Pro Workflow
+
+Use this skill for Final Cut Pro app operation, not AVFoundation or custom media-code work.
+
+## Source Check
+
+Open Final Cut Pro Help or search the local Tips/Help Viewer catalog for `Final Cut Pro`. Confirm the guide matches the installed app/version before relying on an import, library, proxy, share, or relink path. Read `references/library-and-delivery-contract.md` before changing a library, event, project, media relationship, or delivery artifact.
+
+## Workflow
+
+1. Classify the task: inspection, library/event organization, import, proxy or optimized-media decision, edit, captions/roles, missing-media repair, Motion handoff, share/export, Compressor delivery, or output verification.
+2. Establish the artifact contract: library/project path, source-media policy, managed-versus-external media state, intended timeline/range, target platform, format, roles/captions, destination, overwrite rule, and deliverable owner.
+3. Inspect before action: selected library/event/project, active timeline, media locations, missing-media/proxy state, render/share state, connected storage, selected ranges, and existing destination contents.
+4. Preserve source state. Use a duplicate library/project or explicit backup before consolidation, relinking, deleting generated files, changing media location, or making wide timeline changes. Do not infer that a generated proxy, optimized copy, or render file is safe to remove.
+5. Make the smallest correct edit. Keep project, event, library, media, and role boundaries clear; explain any tradeoff in proxy quality, optimized-media storage, color/HDR, captions, or sharing settings.
+6. Confirm immediately before importing into a managed library, relinking, consolidating, deleting generated/original media, modifying a shared timeline, rendering, sharing, exporting, or replacing an existing delivery. State the exact source/range, destination, name, format, and overwrite behavior.
+7. Verify the result: inspect library/project state after edits, or inspect the exported artifact for name, location, duration, dimensions, codec/container, audio, captions/roles, color/HDR, and target playback where required.
+
+## Guards
+
+- Do not open, modify, consolidate, or repair an unfamiliar library as a probe.
+- Do not confuse deleting generated media with a harmless operation; inspect whether original, optimized, proxy, render, or cache assets are selected.
+- Do not relink or reveal missing media by guessing a replacement path.
+- Do not claim a Motion template is installed or a Compressor delivery is valid until the receiving app or output artifact has been checked.
+- Hand source-code media processing, codecs, and application implementation to `apple-dev-skills`.
+
+## Handoffs
+
+- `motion-workflow` for titles, effects, generators, and transitions authored for Final Cut Pro.
+- `compressor-workflow` for an explicit delivery preset, batch, and artifact verification after Final Cut Pro creates the source master.
+- `apple-dev-skills:avfoundation-media-pipeline-workflow` or `video-codec-processing-workflow` for code-level media handling.

--- a/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Final Cut Pro Workflow"
+  short_description: "Safe Final Cut Pro editing workflows"
+  default_prompt: "Use $final-cut-pro-workflow to prepare this Final Cut Pro library safely."

--- a/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/references/library-and-delivery-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/final-cut-pro-workflow/references/library-and-delivery-contract.md
@@ -1,0 +1,27 @@
+# Final Cut Pro Library And Delivery Contract
+
+Use this reference before changing media relationships, a timeline, a library, or an exported artifact.
+
+## Preflight
+
+- Identify the library, event, project, active timeline, storage volumes, and source-media policy.
+- Inspect whether media is managed or external and whether proxies, optimized media, render files, captions, roles, or missing-media warnings are present.
+- Record the intended project/range, target platform, format, color/HDR, captions/roles, destination, and overwrite rule.
+
+## Always Confirm
+
+Ask immediately before:
+
+- importing media into a managed library or moving/copying managed media;
+- relinking, consolidating, revealing, or replacing missing media;
+- deleting original, proxy, optimized, render, cache, event, project, or library content;
+- changing a shared timeline, role assignment, caption content, color state, or audio layout with a broad delivery effect;
+- creating a share/export, rendering, or replacing an existing output.
+
+## Handoff And Verification
+
+For a Motion handoff, identify the exact template type, saved/published location, category, and receiving Final Cut Pro evidence. For a Compressor handoff, record the source master, chosen setting, destination, and overwrite policy. Verify the receiving template or final artifact rather than assuming the handoff succeeded.
+
+## Failure Evidence
+
+For missing media, proxy, render, share, plug-in, or storage failures, record the visible warning, affected library/event/project, media state, selected destination, and available storage location before proposing repair.

--- a/plugins/apple-creator-studio-skills/skills/garageband-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/garageband-workflow/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: garageband-workflow
+description: Guide safe GarageBand projects, audio and MIDI recording, Apple Loops, arrangement, automation, movie soundtrack work, export, and Logic Pro handoffs. Use when a user needs to operate GarageBand while preserving recordings, tracks, project media, and final delivery artifacts.
+---
+
+# GarageBand Workflow
+
+Use this skill for GarageBand app operation. GarageBand is a companion workflow, not an Apple Creator Studio subscription-app claim.
+
+## Source Check
+
+Search the local Tips/Help Viewer catalog for `GarageBand` or open GarageBand Help. Confirm the guide matches the installed app/version. Read `references/project-and-handoff-contract.md` before recording, replacing regions, changing audio devices, exporting, or moving work into Logic Pro.
+
+## Workflow
+
+1. Classify the task: project setup, device/input issue, recording, software instrument/MIDI, Apple Loops, arrangement, automation, movie soundtrack, mix, export, missing content, or Logic Pro handoff.
+2. Establish the project contract: project location, source-preservation decision, tempo/key/sample-rate intent, device/input/monitoring requirements, target deliverable, output location, and overwrite rule.
+3. Inspect before changing: project settings, tracks, regions/takes, selected track controls, automation, plug-in state, audio/MIDI device state, existing media, unresolved warnings, and export state.
+4. Preserve recordings and project media. Use an explicit copy or non-destructive path before replacing recordings, deleting tracks/regions, flattening project decisions, or making broad routing changes.
+5. Configure only the needed audio/MIDI path. State the device, input, output, monitoring, and likely interruption consequence. Get confirmation immediately before recording or changing an audio-device/routing state.
+6. Make arrangement, loop, automation, or mix changes with a stated purpose. Do not replace a region, take, or loop selection merely to experiment unless the user has approved that edit.
+7. Before exporting or sharing, state the range, output type, quality settings, output name, destination, overwrite behavior, and whether the result is a review mix, final audio file, or a movie soundtrack. Get confirmation before writing output.
+8. Verify the resulting artifact exists in the intended directory, opens or plays, matches the intended range/format, and leaves the source project intact. For Logic Pro handoffs, state what transferred and what still needs inspection in Logic.
+
+## Guards
+
+- Do not claim GarageBand belongs to Apple Creator Studio; it is an adjacent companion app.
+- Do not begin recording, replace takes/regions, change audio devices, delete content, or overwrite an export without a visible user confirmation.
+- Do not claim an interface, plug-in, input, or MIDI controller is available without inspecting the actual project/system state.
+- Do not promise a lossless GarageBand-to-Logic transfer without checking the available project/export handoff route and the specific project content.
+- Hand custom audio-engine, Core Audio, or Audio Unit code to `apple-dev-skills`.
+
+## Handoffs
+
+- `logic-pro-workflow` when a GarageBand project or export needs more advanced recording, routing, editing, mixing, mastering, or stem delivery.
+- `compressor-workflow` for final audio/video packaging after GarageBand creates the source deliverable.
+- `apple-dev-skills:avaudio-engine-workflow`, `avfaudio-session-workflow`, or `coreaudio-modernization-repair-workflow` for application-code audio behavior.

--- a/plugins/apple-creator-studio-skills/skills/garageband-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/garageband-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GarageBand Workflow"
+  short_description: "Safe GarageBand project workflows"
+  default_prompt: "Use $garageband-workflow to prepare and export this GarageBand project safely."

--- a/plugins/apple-creator-studio-skills/skills/garageband-workflow/references/project-and-handoff-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/garageband-workflow/references/project-and-handoff-contract.md
@@ -1,0 +1,27 @@
+# GarageBand Project And Handoff Contract
+
+Use this reference before a GarageBand project mutation, export, soundtrack delivery, or Logic Pro handoff.
+
+## Project Preflight
+
+- Identify the project and whether recordings, regions, loops, and imported media must remain untouched.
+- Inspect tempo, key, selected tracks, regions, automation, device/input/output, monitoring, plug-ins, and unresolved warnings.
+- State whether the task affects recording, arrangement, loops, automation, routing, movie audio, or only export.
+
+## Always Confirm
+
+Ask immediately before:
+
+- recording or replacing takes/regions;
+- deleting tracks, regions, loops, or imported media;
+- changing audio/MIDI devices, monitoring, routing, or output assignment;
+- changing automation or a shared track/plug-in state with a broad audible effect;
+- exporting or replacing an existing audio/movie artifact.
+
+## Export And Logic Pro Handoff
+
+Record the intended range, output type, quality settings, name, destination, and overwrite rule. Verify each output exists and plays/opens as intended. For a Logic Pro handoff, identify the specific project/export route used and require a follow-up inspection in Logic before claiming session, plug-in, routing, or automation parity.
+
+## Failure Evidence
+
+For missing media, device, plug-in, loops, recording, or export failures, record the visible warning, affected track/region, selected device/output, and destination before proposing a repair.

--- a/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: logic-pro-workflow
+description: Guide safe Logic Pro projects, audio and MIDI device preflight, recording, arrangement, routing, mixing, bounce and stem delivery, and MainStage handoffs. Use when a user needs to operate or stabilize a Logic Pro session while preserving recordings, takes, project media, and delivery artifacts.
+---
+
+# Logic Pro Workflow
+
+Use this skill for Logic Pro app/session operation. Hand custom audio-engine or Apple audio-framework code to `apple-dev-skills`.
+
+## Source Check
+
+Open Logic Pro Help or search the local Tips/Help Viewer catalog for `Logic Pro`, then confirm the guide matches the installed app/version. Read `references/session-and-delivery-contract.md` before recording, routing, freezing, bouncing, or replacing session material.
+
+## Workflow
+
+1. Classify the task: project setup, device/input issue, recording, MIDI/audio editing, arrangement, routing/mix, stem/master bounce, missing media/plug-in, or MainStage handoff.
+2. Establish the session contract: project location, source-preservation decision, tempo/key/sample-rate intent, device/input/monitoring requirements, target deliverable, output location, and overwrite rule.
+3. Inspect the project before changing it: project settings, tracks, selected channel strips, routing, automation, plug-in state, audio/MIDI device state, existing takes, unresolved warnings, and current output settings.
+4. Preserve recordings and project media. Create a copy or use an explicit non-destructive path before replacing takes, flattening/freeze-related changes, destructive edits, track deletion, or broad routing changes.
+5. Configure only the required audio/MIDI path. State the device, input, output, monitoring, and latency consequence. Get confirmation immediately before recording or changing audio-device/routing state that could disrupt the session.
+6. Make arrangement, mix, or routing changes with clear ownership: tracks feed buses, buses feed outputs, and any plug-in/automation change has a stated audible or delivery purpose.
+7. Before bouncing, state master-versus-stems, range, format, sample rate/bit depth, normalization/dither policy when relevant, destination, exact file names, and overwrite behavior. Get confirmation before writing outputs.
+8. Verify the bounce or stems: files exist in the intended directory, play/open correctly, meet the requested duration/range and format, and preserve the source project.
+
+## Guards
+
+- Do not begin recording, replace takes, change audio devices, freeze/flatten, delete tracks, or overwrite a bounce without a visible user confirmation.
+- Do not claim an interface, plug-in, input, or MIDI controller is available without inspecting the current session/system state.
+- Do not hide a broad routing change behind vague “cleanup”; describe the affected tracks, buses, and outputs.
+- Do not recommend loudness, normalization, dither, or mastering settings without knowing the delivery target.
+- Do not substitute this skill for AVAudioEngine, Core Audio, Audio Unit, or file-processing implementation guidance.
+
+## Handoffs
+
+- `mainstage-workflow` for rehearsal concert, set, patch, mapping, and live-performance preparation.
+- `compressor-workflow` for video/audio delivery packaging after a final export or bounce exists.
+- `apple-dev-skills:avaudio-engine-workflow`, `avfaudio-session-workflow`, or `coreaudio-modernization-repair-workflow` for code-level audio behavior.

--- a/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Logic Pro Workflow"
+  short_description: "Safe Logic production workflows"
+  default_prompt: "Use $logic-pro-workflow to prepare and verify this Logic Pro session."

--- a/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/references/session-and-delivery-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/logic-pro-workflow/references/session-and-delivery-contract.md
@@ -1,0 +1,28 @@
+# Logic Pro Session And Delivery Contract
+
+Use this reference for a safe session preflight and bounce handoff.
+
+## Session Preflight
+
+- Identify the project and whether source media/recordings must remain untouched.
+- Inspect project tempo, key, sample rate, active devices, input, output, monitoring, track selection, routing, and unresolved warnings.
+- State whether the task changes recording, routing, automation, takes, plug-ins, arrangement, or only output.
+- Confirm a device/routing change before applying it; it can interrupt monitoring or change what reaches a live output.
+
+## Mutation Checkpoints
+
+Ask before:
+
+- recording or replacing takes;
+- deleting, flattening, freezing, or destructively editing content;
+- changing audio/MIDI devices, monitoring, routing, or output assignment;
+- changing a shared plug-in/preset/automation state with broad audible effect;
+- bouncing over an existing file.
+
+## Bounce Contract
+
+Record master or stem intent, range, file format, sample rate/bit depth, dither/normalization policy if relevant, names, destination, and overwrite rule. Verify each output exists, opens or plays, matches the intended range/format, and did not replace the project/source media.
+
+## Failure Evidence
+
+For missing media, device, plug-in, or bounce failures, capture the visible warning, project state, affected track/channel strip, selected device/output, and destination before proposing a repair.

--- a/plugins/apple-creator-studio-skills/skills/mainstage-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/mainstage-workflow/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: mainstage-workflow
+description: Guide safe MainStage concert, set, patch, channel-strip, audio and MIDI device, mapping, rehearsal, backup, and live-performance preparation. Use when a user needs to prepare or troubleshoot MainStage while avoiding surprise routing, patch, playback, recording, or concert-file changes.
+---
+
+# MainStage Workflow
+
+Use this skill for MainStage app operation and rehearsal preparation. Treat an active performance configuration as high risk.
+
+## Source Check
+
+Search the local Tips/Help Viewer catalog for `MainStage` or open MainStage Help. Confirm the guide matches the installed app/version. Read `references/concert-safety-contract.md` before changing concert, set, patch, device, mapping, playback, or recording state.
+
+## Workflow
+
+1. Classify the request: inspect, rehearsal preparation, concert/set/patch organization, audio/MIDI device setup, channel-strip routing, mapping, missing device/plug-in repair, backup, or live-performance issue.
+2. Establish the performance contract: whether the configuration is live, rehearsal-only, or disposable; available audio/MIDI hardware; intended inputs/outputs; selected concert/set/patch; backup location; and what must not change.
+3. Inspect before action: active mode, selected set/patch, concert path, audio device, MIDI devices/controllers, channel strips, output routing, mappings, missing plug-ins/media, and current playback/record state.
+4. Preserve the concert. For configuration changes, use a duplicate or explicit backup. Do not save over an active performance file without confirmation.
+5. Confirm immediately before changing selected patches, audio or MIDI devices, channel-strip output routes, mappings, playback, recording, or concert file state. State the user-visible effect and recovery path.
+6. Prepare one rehearsal path: verify audio input/output, MIDI response, patch selection, mappings, level/mute behavior, and any backing-track/transport behavior using observed device evidence.
+7. Report the ready/not-ready state with the specific concert/set/patch, connected devices, tested routes, untested components, backup status, and next safe action.
+
+## Guards
+
+- Never validate against a live show without explicit confirmation at the moment of the potentially disruptive action.
+- Do not change a concert, patch, mapping, or audio/MIDI device merely to see what happens.
+- Do not claim hardware routing, controller response, latency, or sound-check readiness without observed device evidence.
+- Do not perform unattended playback, recording, or device reconfiguration.
+- Do not treat missing plug-ins/media as something to replace automatically; identify the exact dependency and stop for direction.
+
+## Handoffs
+
+- `logic-pro-workflow` for Logic session/bounce preparation before a MainStage handoff.
+- `apple-dev-skills:avfaudio-session-workflow` or `avaudio-engine-workflow` for application-code audio routing or engine issues.
+- `apple-dev-skills:xcode-build-run-workflow` only when MainStage-related work actually concerns an Apple app or plug-in project build/run surface.

--- a/plugins/apple-creator-studio-skills/skills/mainstage-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/mainstage-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MainStage Workflow"
+  short_description: "Safe MainStage concert workflows"
+  default_prompt: "Use $mainstage-workflow to prepare this MainStage concert safely."

--- a/plugins/apple-creator-studio-skills/skills/mainstage-workflow/references/concert-safety-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/mainstage-workflow/references/concert-safety-contract.md
@@ -1,0 +1,33 @@
+# MainStage Concert Safety Contract
+
+Use this reference whenever MainStage could affect a rehearsal or live-performance configuration.
+
+## Before Any Change
+
+- Identify the active concert, selected set and patch, current mode, and whether the system is live, rehearsing, or disposable.
+- Identify active audio device, inputs, outputs, MIDI controllers, mappings, channel-strip routes, and any backing-track/transport behavior.
+- Create or confirm a backup/duplicate before editing a configuration that matters.
+
+## Always Confirm
+
+Ask immediately before changing:
+
+- audio or MIDI devices;
+- selected set or patch;
+- channel-strip routing, levels, mute/solo, or plug-in state;
+- mappings and screen controls;
+- playback or recording;
+- concert save/overwrite behavior.
+
+## Rehearsal Verification
+
+Use observed, non-live evidence to verify:
+
+- expected input reaches the intended channel strip;
+- the intended output receives sound;
+- controller mappings affect the intended parameter;
+- the selected patch/set is correct;
+- level, mute, and transport behavior is understood;
+- the backup and recovery route are known.
+
+Report unknowns instead of inferring live readiness.

--- a/plugins/apple-creator-studio-skills/skills/motion-workflow/SKILL.md
+++ b/plugins/apple-creator-studio-skills/skills/motion-workflow/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: motion-workflow
+description: Guide safe Motion projects, compositions, behaviors, keyframes, generators, titles, effects, Final Cut Pro templates, publishing, render/export, and source-project preservation. Use when a user needs to create, inspect, edit, publish, or deliver a Motion project or Final Cut Pro template without losing the editable source.
+---
+
+# Motion Workflow
+
+Use this skill for Motion app operation and Final Cut Pro template authoring, not Core Animation, AVFoundation, or custom graphics-code work.
+
+## Source Check
+
+Open Motion Help or search the local Tips/Help Viewer catalog for `Motion`. Confirm the guide matches the installed app/version before relying on project-type, publish, template, or render behavior. Read `references/project-template-and-render-contract.md` before changing a source project, publishing a template, or rendering an artifact.
+
+## Workflow
+
+1. Classify the task: composition, Final Cut title/effect/generator/transition, source-project repair, behavior/keyframe animation, parameter publishing, media replacement, render/export, or Final Cut Pro handoff.
+2. Establish the artifact contract: editable source location, project type, resolution/frame rate/duration/color space, media policy, intended published parameters/category, render format, destination, overwrite rule, and receiving app/version.
+3. Inspect before action: project type, current preset/timing/color state, selected layers/groups/behaviors/keyframes, source-media links, template publish state, and output destination.
+4. Preserve the source project. Duplicate or use a new project before changing a reusable template, replacing media, flattening/rebuilding layers, or publishing a revision that can replace an installed Final Cut Pro template.
+5. Keep parameters and timing intentional. Expose only user-meaningful Final Cut Pro controls, use clear names/defaults/ranges, and distinguish an editable Motion source from a rendered deliverable or published template.
+6. Confirm immediately before replacing media, deleting layers/assets, publishing/updating a Final Cut Pro template, rendering/exporting, or overwriting a source/delivery/template revision. State the exact target, destination, category, name, and recovery path.
+7. Verify in the relevant surface: inspect Motion project state, reopen a render, or confirm that the intended Final Cut Pro template category/controls load correctly. For delivery, inspect name, location, duration, dimensions, codec/container, alpha/color, and audio where applicable.
+
+## Guards
+
+- Do not publish a template merely to test whether Final Cut Pro sees it; use a disposable name/category or obtain confirmation.
+- Do not replace linked media, remove layers, or flatten source state without a source-preservation decision.
+- Do not claim template parameter behavior, alpha, color, timing, or Final Cut Pro availability without observed evidence.
+- Do not silently inherit a high-resolution, high-frame-rate, or long-duration project preset when the target is unspecified.
+- Hand custom graphics, rendering, video, or image processing code to `apple-dev-skills`.
+
+## Handoffs
+
+- `final-cut-pro-workflow` for receiving, placing, and verifying a published Motion template in an edit.
+- `compressor-workflow` for final delivery packaging after a Motion render exists.
+- `apple-dev-skills:core-animation-layer-workflow`, `core-image-processing-workflow`, or `avfoundation-media-pipeline-workflow` for code-level implementation.

--- a/plugins/apple-creator-studio-skills/skills/motion-workflow/agents/openai.yaml
+++ b/plugins/apple-creator-studio-skills/skills/motion-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Motion Workflow"
+  short_description: "Safe Motion project and template workflows"
+  default_prompt: "Use $motion-workflow to prepare this Motion project or Final Cut template safely."

--- a/plugins/apple-creator-studio-skills/skills/motion-workflow/references/project-template-and-render-contract.md
+++ b/plugins/apple-creator-studio-skills/skills/motion-workflow/references/project-template-and-render-contract.md
@@ -1,0 +1,27 @@
+# Motion Project, Template, And Render Contract
+
+Use this reference before a Motion source-project mutation, Final Cut Pro template publication, or render/export.
+
+## Preflight
+
+- Identify the source project and whether it is reusable, shared, or a disposable fixture.
+- Record project type, resolution, frame rate, duration, projection/color state, linked media, target app, output/template category, destination, and overwrite policy.
+- Inspect layers/groups, behaviors, keyframes, filters, generators, published parameters, media links, and existing template/output state.
+
+## Always Confirm
+
+Ask immediately before:
+
+- replacing or relinking source media;
+- deleting layers, groups, objects, behaviors, keyframes, or source assets;
+- changing project timing/color settings that affect a shared source or delivery;
+- publishing or replacing a Final Cut Pro title, effect, generator, or transition;
+- rendering/exporting or replacing an existing output.
+
+## Final Cut Pro Template Handoff
+
+Record the template type, category, name, project source, published parameter names/defaults/ranges, and destination. Verify in Final Cut Pro that the template appears where expected and that its exposed controls are usable before claiming a handoff is complete.
+
+## Failure Evidence
+
+For missing media, plug-ins, template publication, render, or color/timing failures, record the visible warning, project type, affected object, selected output/template target, and source-media state before proposing repair.


### PR DESCRIPTION
## Summary

- add Compressor, Logic Pro, MainStage, GarageBand, Final Cut Pro, and Motion workflow skills with app-specific safety contracts
- document the staged Creator Studio roadmap, local HelpViewer/Tips research route, and live fixture evidence
- forward-test a controlled Motion to Final Cut Pro to Compressor delivery chain using temporary artifacts only

## Verification

- six skill-creator quick validations
- Validating root marketplace presence...
Validating marketplace entries...
Socket marketplace validation passed.
- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/galew/Workspace/gaelic-ghost/socket
configfile: pyproject.toml
testpaths: tests, plugins/agent-portability-skills/skills/bootstrap-skills-plugin-repo/tests, plugins/agent-portability-skills/skills/sync-skills-repo-guidance/tests, plugins/productivity-skills/skills/maintain-project-repo/tests
collected 82 items

tests/test_audit_skill_surfaces.py .......                               [  8%]
tests/test_cleanup_legacy_socket_installs.py .....                       [ 14%]
tests/test_release_version.py .............                              [ 30%]
tests/test_spi_add_package.py ..........                                 [ 42%]
tests/test_swiftasb_skills_install.py ..                                 [ 45%]
tests/test_validate_socket_metadata.py ..................                [ 67%]
plugins/agent-portability-skills/skills/bootstrap-skills-plugin-repo/tests/test_bootstrap_skills_plugin_repo.py . [ 68%]
...                                                                      [ 71%]
plugins/agent-portability-skills/skills/sync-skills-repo-guidance/tests/test_sync_skills_repo_guidance.py . [ 73%]
.....                                                                    [ 79%]
plugins/productivity-skills/skills/maintain-project-repo/tests/test_maintain_project_repo_workflow.py . [ 80%]
..............s.                                                         [100%]

======================== 81 passed, 1 skipped in 1.28s ========================= (81 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Apple Creator Studio Skills plugin to the available catalog.
  * Introduced guided workflows for Compressor, Final Cut Pro, GarageBand, Logic Pro, MainStage, and Motion.
  * Added practical checklists for project preparation, exports, handoffs, verification, and safe handling of impactful actions.

* **Documentation**
  * Added plugin usage guidance, workflow references, maintenance instructions, and artifact verification requirements.
  * Added a planned roadmap milestone for Apple Creator Studio operator workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->