### PR TITLE
skill: add feedback assistant workflow

### DIFF
--- a/plugins/apple-dev-skills/README.md
+++ b/plugins/apple-dev-skills/README.md
@@ -161,6 +161,7 @@ uv run pytest
 - `apple-developer-provisioning-workflow`
 - `apple-runtime-telemetry-workflow`
 - `explore-apple-swift-docs`
+- `feedback-assistant-workflow`
 - `format-swift-sources`
 - `icon-composer-app-icon-workflow`
 - `ios-runtime-forensics-workflow`

--- a/plugins/apple-dev-skills/ROADMAP.md
+++ b/plugins/apple-dev-skills/ROADMAP.md
@@ -41,6 +41,7 @@ Swift naming and persistence ownership are now standardized: each project explic
 - [Milestone 62: Media Expansion Audit and Socket Major Release](#milestone-62-media-expansion-audit-and-socket-major-release)
 - [Milestone 63: System Integration, Runtime Evidence, and Distribution](#milestone-63-system-integration-runtime-evidence-and-distribution)
 - [Milestone 64: Xcode String Catalog Localization Workflow](#milestone-64-xcode-string-catalog-localization-workflow)
+- [Milestone 65: Feedback Assistant Workflow](#milestone-65-feedback-assistant-workflow)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
 
@@ -100,6 +101,7 @@ Swift naming and persistence ownership are now standardized: each project explic
 - Milestone 62: Media Expansion Audit and Socket Major Release - Completed
 - Milestone 63: System Integration, Runtime Evidence, and Distribution - In Progress
 - Milestone 64: Xcode String Catalog Localization Workflow - Completed
+- Milestone 65: Feedback Assistant Workflow - Completed
 
 ## Milestone 21: Swift Cleanup Automation Exploration
 
@@ -1213,6 +1215,24 @@ Completed
 - [x] Targeted tests prove the catalog-first, human-review, and beta-boundary contracts.
 
 Completed Milestone 64 by shipping `xcode-localization-workflow` as the durable owner of String Catalog localization. The workflow makes stable source extraction, catalog organization, translator context, plural/device variants, XLIFF review, and locale-aware validation the core path, defaults new XcodeGen app projects to `Sources/Resources/Localizable.xcstrings`, audits that baseline in existing projects, and treats Xcode 27 agent translation only as an explicitly bounded optional enhancement.
+
+## Milestone 65: Feedback Assistant Workflow
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add `feedback-assistant-workflow` for Apple bug, crash, enhancement, documentation, and Foundation Models feedback preparation.
+- [x] Make the macOS app, web, report-ID, team-mailbox, attachment-review, and just-in-time submission boundaries explicit.
+- [x] Document the public Foundation Models feedback-attachment API without claiming a general Feedback Assistant submission API.
+
+### Exit Criteria
+
+- [x] The repository ships a privacy-reviewed, app-grounded workflow that prepares one actionable Feedback Assistant report at a time and requires user confirmation before transmission.
+
+Completed Milestone 65 by shipping `feedback-assistant-workflow` with Apple-aligned report and diagnostic guidance, a live signed-in macOS app fixture, strict attachment and submission gates, and `LanguageModelSession.logFeedbackAttachment` guidance for Foundation Models session feedback.
 
 ## Backlog Candidates
 

--- a/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
+++ b/plugins/apple-dev-skills/docs/maintainers/customization-consolidation-review.md
@@ -8,8 +8,8 @@ Record the Milestone 20 audit of the current customization system, decide whethe
 
 ## Current State Summary
 
-- The active skill surface ships `50` separate `references/customization.template.yaml` files.
-- The active skill surface ships `50` separate `scripts/customization_config.py` entrypoints.
+- The active skill surface ships `51` separate `references/customization.template.yaml` files.
+- The active skill surface ships `51` separate `scripts/customization_config.py` entrypoints.
 - Those `customization_config.py` files are functionally identical and exist only because installed skills are expected to keep runtime resources inside the skill directory.
 - The current templates expose `21` knobs total:
   - `20` are documented as `runtime-enforced`

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/SKILL.md
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: feedback-assistant-workflow
+description: Prepare, stage, and safely submit high-signal Apple Feedback Assistant bug reports, crash reports, enhancement requests, and Foundation Models feedback attachments. Use when Codex needs to gather reproducible evidence for Apple software, SDKs, developer tools, hardware, documentation, beta releases, or system-model behavior; operate the Feedback Assistant app or website; or turn a Foundation Models session into a reviewable feedback attachment.
+---
+
+# Feedback Assistant Workflow
+
+## Purpose
+
+Prepare one actionable Apple report at a time. Own report quality, evidence selection, privacy review, and the Feedback Assistant handoff; do not replace the specialist workflow that diagnoses the underlying problem.
+
+## Required Evidence
+
+1. Classify the report as a bug, crash, regression, enhancement, documentation issue, or Foundation Models behavior issue. Route security and privacy vulnerabilities to Apple's security reporting program instead of ordinary Feedback Assistant.
+2. State one concise title, environment, minimal reproduction, expected result, actual result, frequency, and regression range when known. Keep unrelated issues in separate reports.
+3. Build an attachment manifest before opening the submit path. Include source, collection time, purpose, and privacy review for each log, sample project, System Information Report, recording, screenshot, or `.json` feedback attachment.
+4. Hand off diagnosis to the owning workflow when needed: `ios-runtime-forensics-workflow` for runtime evidence, `xcode-debugger-mcp-workflow` for a debugging session, `xcode-device-hub-workflow` for connected-device evidence, and `explore-apple-swift-docs` for API routing.
+
+## Feedback Assistant App And Web Workflow
+
+1. Prefer the Feedback Assistant app on Mac, iPhone, or iPad when timely diagnostics matter. Use the website only when the evidence was captured manually or the app is unavailable.
+2. On this Mac, inspect `com.apple.appleseed.FeedbackAssistant`. Its signed-in main window exposes Inbox, Drafts, Submitted, Requests, team mailboxes when available, search, and New Feedback.
+3. Select the narrowest topic and product area. Verify the report describes one issue before drafting or staging it.
+4. Keep a staged report in Drafts until its prose and attachment manifest have been reviewed. Record the Feedback Assistant ID only after a report has been submitted.
+5. If Apple requests more information, preserve the original report's scope and attach only the requested, reviewed evidence.
+
+## Submission And Privacy Gate
+
+- Never accept license terms, create a report, attach a file, send a message, or submit feedback unless the user asked for that specific action.
+- Before attaching potentially sensitive evidence or typing it into the app or website, show the exact files or data, identify Apple as the recipient, explain the diagnostic purpose, and obtain confirmation at that point.
+- Immediately before submission, restate the title, destination, report type, and complete attachment manifest, then obtain confirmation. Submission represents the user to Apple and can transmit diagnostics, identifiers, prompts, transcripts, crash data, and other personal or confidential information.
+- Do not copy seed-program material, private logs, report text, IDs, or attachments into a repository, issue tracker, shared note, or chat unless the user explicitly asks for that separate disclosure.
+- Do not use undocumented Feedback Assistant protocols, automate a private API, or claim a public report-submission API exists. Apple's documented general surfaces are the app, website, and `applefeedback://` URL scheme.
+
+## Foundation Models Attachments
+
+Use `LanguageModelSession.logFeedbackAttachment` only for Foundation Models behavior. It serializes a structured JSON attachment containing session transcript material and feedback metadata; it does not submit a report. Read `references/foundation-models-feedback-attachments.md`, review the resulting content, save it deliberately, and attach it through Feedback Assistant only after the privacy and submission gates above.
+
+## Outputs
+
+- report classification and selected product/topic
+- reproducibility statement and environment ledger
+- report draft with expected and actual results
+- attachment manifest with review status
+- state: `prepared`, `staged`, `submitted`, or `blocked`
+- Feedback Assistant ID and follow-up owner only when present in the live app
+
+## References
+
+- `references/report-quality-and-evidence.md`
+- `references/live-app-and-api-boundaries.md`
+- `references/foundation-models-feedback-attachments.md`
+- `references/customization-flow.md`

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/agents/openai.yaml
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Feedback Assistant"
+  short_description: "Prepare Apple bug and crash reports"
+  default_prompt: "Use $feedback-assistant-workflow to prepare a privacy-reviewed Apple Feedback Assistant report."

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/customization-flow.md
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/customization-flow.md
@@ -1,0 +1,5 @@
+# Feedback Assistant Workflow Customization Contract
+
+The first version defines no runtime-enforced knobs. `scripts/customization_config.py` preserves the shared Apple Dev Skills customization contract; future settings must be documented here and in `SKILL.md` before runtime behavior depends on them.
+
+Inspect settings with `scripts/customization_config.py effective`, persist a documented change with `apply --input <yaml-file>`, and verify the effective result afterward.

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/customization.template.yaml
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/customization.template.yaml
@@ -1,0 +1,3 @@
+schemaVersion: 1
+isCustomized: false
+settings: {}

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/foundation-models-feedback-attachments.md
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/foundation-models-feedback-attachments.md
@@ -1,0 +1,23 @@
+# Foundation Models Feedback Attachments
+
+`LanguageModelFeedback` describes structured Foundation Models feedback. `LanguageModelSession.logFeedbackAttachment(sentiment:issues:desiredOutput:)` returns JSON `Data` that includes session transcript material, feedback sentiment, identified issues, and optional desired output.
+
+```swift
+let attachment = session.logFeedbackAttachment(
+    sentiment: .negative,
+    issues: [
+        .init(category: .incorrect, explanation: "State the observed mismatch.")
+    ],
+    desiredOutput: expectedResponse
+)
+try attachment.write(to: feedbackURL)
+```
+
+This API creates an attachment only. It does not create or submit a Feedback Assistant report. Review the resulting JSON for prompts, responses, or other private content before saving it or attaching it to Feedback Assistant.
+
+Apple documents that multiple feedback attachments can be combined in one JSON file, but only combine artifacts that belong to the same report and have passed the same privacy review.
+
+## Sources
+
+- Apple Developer, [`LanguageModelFeedback`](https://developer.apple.com/documentation/foundationmodels/languagemodelfeedback)
+- Apple Developer, [`logFeedbackAttachment(sentiment:issues:desiredOutput:)`](https://developer.apple.com/documentation/foundationmodels/languagemodelsession/logfeedbackattachment(sentiment:issues:desiredoutput:))

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/live-app-and-api-boundaries.md
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/live-app-and-api-boundaries.md
@@ -1,0 +1,15 @@
+# Live App and API Boundaries
+
+## Observed Mac Surface
+
+On 2026-07-13, the signed-in `com.apple.appleseed.FeedbackAssistant` app opened its Inbox window. The sidebar exposed Recent Activity, Requests, All, News, Inbox, Drafts, and Submitted; the toolbar exposed search, More, and New Feedback. This is a live-app fixture, not a promise that every account has the same mailbox or team access.
+
+Use the app or [Feedback Assistant on the web](https://feedbackassistant.apple.com) for report creation and follow-up. Apple documents `applefeedback://` as a launch URL scheme, not as a report-submission API.
+
+## General API Boundary
+
+No Apple-documented general API for creating, reading, updating, or submitting Feedback Assistant reports was found during this skill's 2026-07-13 research. Do not reverse engineer, invoke, or rely on private Feedback Assistant services. Re-check Apple's documentation when a future task depends on this boundary.
+
+## Transmission Boundary
+
+Diagnostics may contain account, network, location, content, crash, and device data. Always review the exact attachment list with the user before sending data to Apple. A successful submission produces a Feedback Assistant ID that can be used to track the report.

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/report-quality-and-evidence.md
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/references/report-quality-and-evidence.md
@@ -1,0 +1,22 @@
+# Feedback Report Quality and Evidence
+
+## Report Shape
+
+File one issue per report. Use a concise title that names the symptom and the conditions that matter, then provide:
+
+1. Product, OS, build, hardware, and app/tool version.
+2. Minimal reproduction steps that start from a known state.
+3. Expected result and actual result.
+4. Frequency, first known build, and last known good build when available.
+5. A narrowly selected evidence manifest.
+
+Apple recommends filing promptly because the app can collect time-sensitive diagnostics. For a UI issue, include a screenshot or recording. For an app/API issue, include a minimal sample project or focused code example when it can demonstrate the behavior.
+
+## Crash And System Evidence
+
+Use the Feedback Assistant app when practical: Apple documents that it automatically attaches a sysdiagnose for each report. For Mac crashes, kernel panics, hardware bugs, and printing issues, include a Mac System Information Report. Do not assume a larger log is better: keep the report focused, explain why each attachment is relevant, and review it for private data first.
+
+## Sources
+
+- Apple Developer, [Feedback Assistant](https://developer.apple.com/feedback-assistant/)
+- Apple Support, [Feedback Assistant User Guide for Mac](https://support.apple.com/guide/feedback-assistant/welcome/mac)

--- a/plugins/apple-dev-skills/skills/feedback-assistant-workflow/scripts/customization_config.py
+++ b/plugins/apple-dev-skills/skills/feedback-assistant-workflow/scripts/customization_config.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["PyYAML>=6.0.2,<7"]
+# ///
+"""Manage Feedback Assistant Workflow customization state."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import yaml
+
+SKILL_NAME = "feedback-assistant-workflow"
+CONFIG_HOME_ENV = "APPLE_DEV_SKILLS_CONFIG_HOME"
+DEFAULT_CONFIG_ROOT = "~/.config/gaelic-ghost/apple-dev-skills"
+DEFAULT = {"schemaVersion": 1, "isCustomized": False, "settings": {}}
+
+
+def config_path() -> Path:
+    root = Path(os.environ.get(CONFIG_HOME_ENV, DEFAULT_CONFIG_ROOT)).expanduser()
+    return root / SKILL_NAME / "customization.yaml"
+
+
+def load(path: Path, *, partial: bool = False) -> dict:
+    if not path.exists():
+        return {} if partial else DEFAULT.copy()
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Customization must be a YAML mapping: {path}")
+    unknown = set(data) - set(DEFAULT)
+    if unknown:
+        raise ValueError(f"Unsupported customization keys: {', '.join(sorted(unknown))}")
+    if not partial and set(data) != set(DEFAULT):
+        raise ValueError(f"Customization must contain schemaVersion, isCustomized, and settings: {path}")
+    if "schemaVersion" in data and data["schemaVersion"] != 1:
+        raise ValueError("schemaVersion must be 1")
+    if "isCustomized" in data and not isinstance(data["isCustomized"], bool):
+        raise ValueError("isCustomized must be boolean")
+    if "settings" in data and not isinstance(data["settings"], dict):
+        raise ValueError("settings must be a mapping")
+    return data
+
+
+def merged() -> dict:
+    result = {"schemaVersion": 1, "isCustomized": False, "settings": {}}
+    result.update(load(config_path(), partial=True))
+    result["settings"] = dict(result.get("settings", {}))
+    return result
+
+
+def write(value: dict) -> None:
+    target = config_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+    print(target)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage Feedback Assistant Workflow customization")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("path")
+    commands.add_parser("effective")
+    apply = commands.add_parser("apply")
+    apply.add_argument("--input", required=True)
+    commands.add_parser("reset")
+    args = parser.parse_args()
+    if args.command == "path":
+        print(config_path())
+    elif args.command == "effective":
+        print(yaml.safe_dump(merged(), sort_keys=False), end="")
+    elif args.command == "apply":
+        update = load(Path(args.input), partial=True)
+        value = merged()
+        value.update(update)
+        value["settings"] = {**merged()["settings"], **update.get("settings", {})}
+        value["schemaVersion"] = 1
+        value["isCustomized"] = True
+        write(value)
+    else:
+        target = config_path()
+        target.unlink(missing_ok=True)
+        print(target)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
+++ b/plugins/apple-dev-skills/tests/test_customization_consolidation_review.py
@@ -66,8 +66,8 @@ class CustomizationConsolidationReviewTests(unittest.TestCase):
         knob_count = _count_template_knobs()
         runtime_enforced, policy_only = _count_statuses()
 
-        self.assertEqual(template_count, 50)
-        self.assertEqual(script_count, 50)
+        self.assertEqual(template_count, 51)
+        self.assertEqual(script_count, 51)
         self.assertEqual(knob_count, 21)
         self.assertEqual(runtime_enforced, 20)
         self.assertEqual(policy_only, 1)

--- a/plugins/apple-dev-skills/tests/test_milestone24_system_ui_workflows.py
+++ b/plugins/apple-dev-skills/tests/test_milestone24_system_ui_workflows.py
@@ -68,6 +68,21 @@ class Milestone24SystemUIWorkflowTests(unittest.TestCase):
         self.assertIn("explore-apple-swift-docs", reference)
         self.assertIn("$tips-helpviewer-workflow", prompt)
 
+    def test_feedback_assistant_workflow_keeps_submission_and_api_boundaries_explicit(self) -> None:
+        skill = self.read("skills/feedback-assistant-workflow/SKILL.md")
+        app_reference = self.read("skills/feedback-assistant-workflow/references/live-app-and-api-boundaries.md")
+        foundation_reference = self.read("skills/feedback-assistant-workflow/references/foundation-models-feedback-attachments.md")
+        prompt = self.read("skills/feedback-assistant-workflow/agents/openai.yaml")
+        customization = self.read("skills/feedback-assistant-workflow/scripts/customization_config.py")
+
+        for term in ("com.apple.appleseed.FeedbackAssistant", "one issue", "attachment manifest", "Immediately before submission"):
+            self.assertIn(term, skill)
+        self.assertIn("No Apple-documented general API", app_reference)
+        self.assertIn("LanguageModelSession.logFeedbackAttachment", foundation_reference)
+        self.assertIn("does not create or submit", foundation_reference)
+        self.assertIn("$feedback-assistant-workflow", prompt)
+        self.assertIn('SKILL_NAME = "feedback-assistant-workflow"', customization)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add the Apple Feedback Assistant workflow with privacy and submission gates.
- Document crash-report evidence, live app boundaries, and Foundation Models attachments.
- Add skill inventory, roadmap, and validation coverage.

## Verification

- `uv run pytest` (81 passed, 1 skipped)
- `bash .github/scripts/validate_repo_docs.sh` from `plugins/apple-dev-skills`
- `uv run pytest` from `plugins/apple-dev-skills` (250 passed)
- `uv run scripts/validate_socket_metadata.py`
