### PR TITLE
plugin: add messaging collaboration skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -286,6 +286,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "messaging-collaboration-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/messaging-collaboration-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Currently available from the catalog:
 - `cardhop-app`
 - `cloud-deployment-skills`
 - `cloud-inference-skills`
+- `messaging-collaboration-skills`
 - `agentdeck`
 - `dotnet-skills`
 - `game-dev-skills`
@@ -118,6 +119,7 @@ Current Socket catalog shape:
 - `cardhop-app`: mixed skill plus bundled MCP server for Cardhop.app contact workflows
 - `cloud-deployment-skills`: cloud provider deployment routing, official provider plugin selection, credential and mutation boundary checks, and AWS handoff to the official AWS Agent Toolkit rather than duplicated AWS MCP, CLI, or SAM setup
 - `cloud-inference-skills`: cloud AI inference, training, model conversion, and GPU infrastructure routing for Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers, with bundled Runpod MCP server configuration, upstream Runpod skill mirrors, and first-party Hugging Face/AWS handoffs
+- `messaging-collaboration-skills`: chat-app, bot, business-messaging, meeting-collaboration, iMessage-collaboration, and Apple VoIP decision and implementation workflows for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, and Apple communication surfaces, with explicit Signal and Mac operator-automation boundaries
 - `agentdeck`: local Codex runtime utilities, starting with hooks that prefix generated Codex thread titles with the project directory name
 - `dotnet-skills`: .NET, F#, and C# project-shape, bootstrap, implementation, test, package, diagnostics, ASP.NET Core, interop, CI, upgrade, and tooling guidance
 - `game-dev-skills`: Apple platform game development workflows for SpriteKit, SceneKit, GameplayKit simulation, Game Controller input, Core Haptics feedback, Xcode game profiling, game-stack routing, and device-aware validation handoffs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,7 @@
 - [Milestone 23: Cloud Inference Skills plugin](#milestone-23-cloud-inference-skills-plugin)
 - [Milestone 24: Apple system integration, runtime evidence, and distribution workflows](#milestone-24-apple-system-integration-runtime-evidence-and-distribution-workflows)
 - [Milestone 25: Apple Creator Studio operator workflows](#milestone-25-apple-creator-studio-operator-workflows)
+- [Milestone 26: Messaging collaboration skills plugin](#milestone-26-messaging-collaboration-skills-plugin)
 - [Small Tickets](#small-tickets)
 - [Backlog Candidates](#backlog-candidates)
 - [History](#history)
@@ -65,6 +66,7 @@
 - Milestone 23: Cloud Inference Skills plugin - Completed
 - Milestone 24: Apple system integration, runtime evidence, and distribution workflows - Planned
 - Milestone 25: Apple Creator Studio operator workflows - Planned
+- Milestone 26: Messaging collaboration skills plugin - Completed
 
 ## Milestone 5: SwiftASB skills plugin
 
@@ -814,6 +816,33 @@ Planned
 - [x] Every write or destructive UI action has a visible confirmation, output path, source-preservation rule, and post-action verification requirement.
 - [x] Compressor, Logic Pro, and MainStage have been forward-tested against disposable, version-recorded fixtures before broader app coverage ships.
 - [x] The plugin neither duplicates Apple Dev Skills framework guidance nor makes unsafe claims about unattended creative-app automation.
+
+## Milestone 26: Messaging Collaboration Skills plugin
+
+### Status
+
+Completed
+
+### Scope
+
+- [x] Add `messaging-collaboration-skills` as an installable Socket child plugin for supported chat, calling, business messaging, and collaboration integration workflows.
+- [x] Keep the initial release companion guidance only: no universal SDK, webhook daemon, credential store, bundled MCP server, or Mac Phone/Messages automation bridge.
+- [x] Record the durable platform-boundary and phased implementation plan in [`docs/maintainers/messaging-collaboration-skills-plugin-plan.md`](./docs/maintainers/messaging-collaboration-skills-plugin-plan.md).
+
+### Tickets
+
+- [x] Add Phase 1 foundation skills for platform selection, webhook/event lifecycle, conversation state and human handoff, and Apple communication routing.
+- [x] Add Phase 2 workflows for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, and Google Meet.
+- [x] Make Apple calling, iMessage, Shared with You collaboration, and Mac Phone/Messages MCP evaluation boundaries explicit without claiming undocumented automation support.
+- [x] Add the child manifest, icon, local guidance, root marketplace entry, README inventory, and Roadmap status together.
+- [x] Validate every authored skill and the root marketplace metadata before release.
+
+### Exit Criteria
+
+- [x] The Socket marketplace exposes `messaging-collaboration-skills` as an installable child plugin.
+- [x] Agents can route a request to a supported platform workflow before implementation and identify unsupported or policy-gated paths plainly.
+- [x] Apple VoIP, Messages-extension, Shared with You, and Mac operator surfaces have distinct supported-boundary guidance.
+- [x] The root documentation, marketplace, plan, and validation agree on the shipped inventory.
 
 ## Small Tickets
 

--- a/docs/maintainers/messaging-collaboration-skills-plugin-plan.md
+++ b/docs/maintainers/messaging-collaboration-skills-plugin-plan.md
@@ -1,0 +1,85 @@
+# Messaging Collaboration Skills Plugin Plan
+
+## Intent
+
+`messaging-collaboration-skills` helps Codex choose, build, test, and maintain user-facing communication integrations without treating distinct platform policies as one interchangeable chat API. It covers server bots, workspace apps, business messaging agents, meeting add-ons, iMessage collaboration, and native VoIP calling.
+
+The first release is a companion guidance plugin. It does not ship an MCP server, a webhook relay, a credential store, a daemon, a provider-neutral client library, or a Mac Phone/Messages automation bridge.
+
+That deliberately small shape unlocks two immediate use cases: an agent can correctly select and bootstrap a platform integration, and it can hand the resulting implementation to the owning server, web, Android, or Apple workflow. It removes the current duplication of rediscovering platform identity, webhook, consent, and human-handoff constraints. The simpler alternative—adding only platform bookmarks—was considered, but would not give Codex a shared decision path or safe implementation boundaries.
+
+## Packaging Direction
+
+Package this as the independent Socket child plugin at `plugins/messaging-collaboration-skills/`. Its root owns the Codex-facing manifest, authored `skills/`, local `AGENTS.md`, and branded assets. Socket's root marketplace lists it as a normal local child plugin.
+
+The plugin must remain a guidance surface until two real projects demonstrate a repeated, compatible need for executable shared support. If that happens, assess a narrow reference library or MCP bridge in a separate design decision; do not retrofit a universal SDK into these skills.
+
+## Platform Boundary Map
+
+| Surface | Supported integration shape | Explicit boundary |
+| --- | --- | --- |
+| Discord | Installed app, HTTP/Gateway interaction bot, Activity | Commands and interaction responses are not generic webhooks. |
+| Telegram | HTTPS Bot API, webhook or polling, Mini App | A bot cannot initiate a private conversation before the user starts or adds it. |
+| Slack | Workspace app with OAuth, Events API, interactivity, Socket Mode | Workspace scopes and installation are core product behavior. |
+| Teams | Teams SDK or Microsoft 365 Agents SDK bot/agent | Microsoft Entra and tenant deployment are first-class boundaries. |
+| WhatsApp | WhatsApp Business Platform or an approved provider | Business onboarding, templates, policy windows, and verification must be rechecked at implementation time. |
+| SMS/MMS/RCS | Carrier/CPaaS or RCS for Business agent | Consent, sender registration, regional rules, and fallback are required design inputs. |
+| Google Meet | Add-on, REST conference/artifact integration, Media API preview | Meet is collaboration/conferencing, not a generic chat-bot target. |
+| iMessage and Messages collaboration | Messages app extension and Shared with You collaboration | No general server-side iMessage bot API. |
+| Apple Phone and VoIP | CallKit, PushKit, AVFAudio, App Intents phone schemas | The macOS Phone app is an operator surface, not an automation API. |
+| Signal | No official bot workflow | Do not route users to unofficial account automation as a supported Signal integration. |
+
+## Apple Communication Scope
+
+The Apple workflow has three independent lanes:
+
+1. **VoIP calling app** — CallKit owns native call UI and action transactions; PushKit is the incoming-call wakeup boundary; AVFAudio owns the active call audio-session policy; App Intents can expose a real calling app's user-recognizable actions.
+2. **iMessage user app and collaboration** — Messages extensions create interactive messages; Shared with You Core connects a first-party app's collaboration metadata to Messages, Mail, and FaceTime.
+3. **Mac operator apps and third-party MCP products** — mention these only as discovery and evaluation targets. A skill must not claim an Apple-provided Messages or Phone control API, must never automate a user's personal messages or calls without explicit authorization, and must require a source, privacy, capability, and live-behavior review before recommending an external MCP package.
+
+## Phase 1: Cross-Platform Foundations
+
+- `messaging:choose-platform-integration`: classify the desired surface, scope, user identity, installation, deployment, and runtime owner before implementation.
+- `messaging:webhook-and-event-lifecycle`: model signature verification, idempotency, acknowledgement deadlines, retries, ordering, rate limits, observability, and secret handling.
+- `messaging:conversation-state-human-handoff`: define per-platform identity mapping, durable state, consent, escalation, transcript boundaries, and operator-visible failures.
+- `messaging:apple-communication-workflow`: choose among CallKit/PushKit/AVFAudio/App Intents, Messages extensions, Shared with You, and Mac operator/discovery surfaces.
+
+Phase 1 exit criteria: a new integration can be accurately routed without introducing a universal runtime abstraction, and Apple calling/Messages requests are separated into documented supported lanes.
+
+## Phase 2: Supported Platform Workflows
+
+- `messaging:discord-app-workflow`
+- `messaging:telegram-bot-workflow`
+- `messaging:slack-app-workflow`
+- `messaging:teams-agent-workflow`
+- `messaging:whatsapp-business-workflow`
+- `messaging:sms-mms-rcs-workflow`
+- `messaging:google-meet-collaboration-workflow`
+
+Phase 2 exit criteria: each workflow starts from official current documentation, identifies the correct app identity and inbound event model, covers authentication/installation/consent, and hands implementation to an owning Socket stack plugin without inventing an SDK.
+
+## Deferred Phases
+
+### Phase 3: Executable Reference Work
+
+Only after repeated implementation evidence, assess narrow helpers for webhook verification fixtures, event replay tests, or platform-local samples. Do not create a shared service unless its ownership, credentials, state, and failure behavior are proven common across at least two live consumers.
+
+### Phase 4: MCP Evaluation And Operator Workflows
+
+Evaluate external messaging MCP products by source, supported API, data access, authorization model, auditability, and runtime proof. A bundled MCP server remains out of scope until a concrete, maintainable operator need is approved.
+
+### Phase 5: Expansion And Release Maintenance
+
+Consider Google Chat, Zoom, Matrix, customer-support systems, carrier-specific routes, and verified provider adapters. Recheck platform policies, availability, and SDK lifecycle before each expansion.
+
+## Documentation And Validation
+
+- Use current official platform documentation before making implementation claims.
+- Use Xcode DocumentationSearch or other local Apple documentation sources first for Apple behavior.
+- Keep secrets out of repository files and examples.
+- Run the skill quick validator for every new `SKILL.md` and Socket metadata validation after marketplace or manifest edits.
+- Add root README and ROADMAP inventory language in the same pass as an installable plugin.
+
+## Release Decision
+
+After Phases 1 and 2 validate, release this as a Socket minor version because it adds a new installable plugin and a substantive new capability surface. Phases 3 through 5 require a separate discussion before implementation.

--- a/plugins/agent-portability-skills/.codex-plugin/plugin.json
+++ b/plugins/agent-portability-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-portability-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Maintainer skills for Socket-owned agent skill portability, Codex plugin surfaces, and host adapter guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/agent-portability-skills/pyproject.toml
+++ b/plugins/agent-portability-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-portability-skills-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 description = "Maintainer-only Python tooling baseline for Agent Portability Skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/agent-portability-skills/uv.lock
+++ b/plugins/agent-portability-skills/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-portability-skills-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/agentdeck/.codex-plugin/plugin.json
+++ b/plugins/agentdeck/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentdeck",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Local Codex runtime utilities for thread, hook, and app-server workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/android-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/android-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "android-dev-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Android, Kotlin, Java, Gradle, Android Gradle Plugin, testing, lint, UI implementation, and release-readiness workflow skills.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-creator-studio-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-creator-studio-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Human-facing and Computer Use-aware Apple Creator Studio workflows for Final Cut Pro editing, Motion templates, Compressor delivery, Logic Pro production, MainStage concert preparation, and GarageBand projects.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/apple-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-dev-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Apple development workflows for Codex, including App Intents, Liquid Glass, PhotosUI/PhotoKit, VideoToolbox codecs, ARKit spatial/face/body sensing, camera/depth capture, Core Image, Image I/O, Vision/Core ML recognition, media/audio repair, local Tips/HelpViewer guide discovery, provisioning, CloudKit, TipKit, SwiftData, SwiftUI, XcodeGen, Core Animation, AppKit, Safari, security, OpenAPI, and DocC.",
   "author": {
     "name": "Gale",

--- a/plugins/apple-dev-skills/pyproject.toml
+++ b/plugins/apple-dev-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-dev-skills-maintainer"
-version = "9.7.0"
+version = "9.8.0"
 description = "Maintainer tooling for the apple-dev-skills repository"
 requires-python = ">=3.10"
 dependencies = []

--- a/plugins/apple-dev-skills/uv.lock
+++ b/plugins/apple-dev-skills/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apple-dev-skills-maintainer"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/cardhop-app/.codex-plugin/plugin.json
+++ b/plugins/cardhop-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cardhop-app",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Cardhop.app workflow guidance plus a bundled local MCP server for contact capture and updates on macOS.",
   "author": {
     "name": "Gale",

--- a/plugins/cardhop-app/mcp/pyproject.toml
+++ b/plugins/cardhop-app/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cardhop-app-mcp"
-version = "9.7.0"
+version = "9.8.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/cardhop-app/mcp/uv.lock
+++ b/plugins/cardhop-app/mcp/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cardhop-app-mcp"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-deployment-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-deployment-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for routing cloud deployment work through official provider plugins, MCP servers, CLIs, and Socket-owned deployment guidance.",
   "author": {
     "name": "Gale",

--- a/plugins/cloud-inference-skills/.codex-plugin/plugin.json
+++ b/plugins/cloud-inference-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-inference-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Cloud AI inference workflow skills for routing model serving, training, conversion, and GPU infrastructure work across Runpod, Hugging Face, AWS, Vast.ai, CoreWeave, and similar providers.",
   "author": {
     "name": "Gale",

--- a/plugins/dotnet-skills/.codex-plugin/plugin.json
+++ b/plugins/dotnet-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for choosing, bootstrapping, building, testing, packaging, diagnosing, and maintaining .NET projects with F# and C# as equal first-party languages.",
   "author": {
     "name": "Gale",

--- a/plugins/game-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/game-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "game-dev-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Apple platform game development workflow skills for SpriteKit, SceneKit, GameplayKit, controller input, haptics, profiling, and game-stack routing.",
   "author": {
     "name": "Gale",

--- a/plugins/messaging-collaboration-skills/.codex-plugin/plugin.json
+++ b/plugins/messaging-collaboration-skills/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "messaging-collaboration-skills",
+  "version": "9.8.0",
+  "description": "Codex workflows for chat apps, bots, business messaging, meeting collaboration, iMessage collaboration, and Apple VoIP calling.",
+  "author": {
+    "name": "Gale",
+    "email": "mail@galewilliams.com",
+    "url": "https://github.com/gaelic-ghost"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Messaging Collaboration Skills",
+    "shortDescription": "Build supported chat, calling, and collaboration integrations.",
+    "longDescription": "Guide Codex through supported chat-app, bot, business-messaging, meeting-collaboration, iMessage-collaboration, and Apple VoIP integrations. Start with the platform and policy boundary, then hand implementation to the owning Socket stack workflow without inventing a universal messaging SDK.",
+    "developerName": "gaelic-ghost",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "Choose the correct chat, calling, or collaboration platform integration before implementation.",
+      "Plan a secure, idempotent webhook and event lifecycle for this messaging app.",
+      "Build a Discord, Telegram, Slack, Teams, WhatsApp Business, or SMS/MMS/RCS integration with the platform-specific policy boundary explicit.",
+      "Choose the right Apple path for a VoIP calling app, iMessage extension, Shared with You collaboration feature, or Mac operator workflow."
+    ],
+    "brandColor": "#D946EF",
+    "composerIcon": "./assets/messaging-collaboration-icon.svg",
+    "logo": "./assets/messaging-collaboration-icon.svg"
+  }
+}

--- a/plugins/messaging-collaboration-skills/AGENTS.md
+++ b/plugins/messaging-collaboration-skills/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+This file refines the Socket root guidance for `messaging-collaboration-skills`.
+
+## Scope
+
+- This child plugin is the decision and workflow layer for chat, business messaging, meeting collaboration, iMessage collaboration, and Apple VoIP integrations.
+- `skills/` is the authored source of truth. The plugin is guidance-only; do not bundle an MCP server, daemon, credential store, client SDK, or provider-neutral runtime without an explicit later approval.
+- Route server implementation to the chosen stack plugin, Apple work to `apple-dev-skills`, Android work to `android-dev-skills`, and transport problems to `network-protocol-skills`.
+
+## Platform Rules
+
+- Check current official documentation before asserting supported capabilities, policy windows, product availability, consent requirements, or SDK status.
+- Treat Signal as unsupported for official bot development. Do not recommend unofficial account automation as an equivalent workaround.
+- Treat iMessage as a Messages extension and Shared with You collaboration surface, not a server-side bot API.
+- Treat the macOS Phone and Messages apps as user-operated surfaces. Do not claim they expose a general automation API, and do not recommend a third-party MCP product without first checking its source, privacy model, authorization scope, and live behavior.
+- For Apple VoIP, keep CallKit call actions, PushKit notification handling, AVFAudio session policy, network media, and app UI as explicit separate responsibilities. Do not add a broad call manager or global coordinator unless a real codebase demonstrates the missing ownership boundary.
+- For business messaging, include consent, opt-out, sender/brand verification, template or policy-window requirements, rate limits, delivery states, and human escalation when those apply.
+- Webhook examples must verify authenticity, acknowledge within platform deadlines, make event handling idempotent, and describe retry and duplicate-delivery behavior.
+
+## Validation
+
+```bash
+uv run python "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" skills/<skill-name>
+uv run scripts/validate_socket_metadata.py
+```

--- a/plugins/messaging-collaboration-skills/assets/messaging-collaboration-icon.svg
+++ b/plugins/messaging-collaboration-skills/assets/messaging-collaboration-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Messaging collaboration skills">
+  <rect width="256" height="256" rx="48" fill="#090612"/>
+  <path d="M46 57h114l36 36v67H98l-38 31v-31H46z" fill="none" stroke="#E879F9" stroke-width="12" stroke-linejoin="round"/>
+  <path d="M80 104h82M80 132h54" stroke="#67E8F9" stroke-width="12" stroke-linecap="round"/>
+  <path d="M174 173v-17c0-14 11-25 25-25s25 11 25 25v17c0 12-10 22-22 22h-6c-12 0-22-10-22-22Z" fill="none" stroke="#A78BFA" stroke-width="10"/>
+</svg>

--- a/plugins/messaging-collaboration-skills/skills/apple-communication-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/apple-communication-workflow/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: apple-communication-workflow
+description: Choose and plan Apple communication features across CallKit, PushKit, AVFAudio, App Intents phone schemas, Messages extensions, Shared with You collaboration, and Mac Phone or Messages operator surfaces.
+---
+
+# Apple Communication Workflow
+
+## Purpose
+
+Route an Apple communication feature to the documented framework that owns it. This is a decision and handoff skill; use `apple-dev-skills` for implementation, build, and device validation.
+
+## Supported Lanes
+
+- **VoIP calling app:** CallKit reports and receives system call actions; PushKit handles VoIP notification delivery; AVFAudio configures live-call audio; App Intents can expose a real calling app's calling actions to system experiences.
+- **iMessage app:** a Messages extension creates interactive, app-specific messages in a user conversation.
+- **Collaboration:** Shared with You Core connects app-owned collaboration metadata and settings to Messages, Mail, and FaceTime.
+- **Mac operator surfaces:** Phone and Messages are user-operated apps. Treat external MCP products as optional discovery targets, not native APIs.
+
+## Workflow
+
+1. Use Xcode DocumentationSearch before planning Apple behavior; confirm framework availability and capability requirements.
+2. For a VoIP app, separate CallKit call transactions, PushKit arrival, AVFAudio route/interruption policy, network media, app state, and UI. CallKit acceptance is not permission to begin media before the system activates audio.
+3. For a Messages extension, design an interactive user action and app-specific message payload; do not imply unattended server access to iMessage conversations.
+4. For collaboration, use the app's real collaboration identity and `SWCollaborationCoordinator`; do not introduce a duplicate collaboration store just for Messages.
+5. For Phone or Messages MCP evaluation, inspect public source, supported API, requested permissions, storage, authentication, audit behavior, and live test evidence before recommending it. Never authorize or automate personal calls/messages without the user's explicit instruction.
+6. Hand implementation to CallKit/PushKit, AVFAudio, App Intents, Messages, Shared with You, or Xcode validation workflows as applicable.
+
+## Output
+
+Return the lane, documented behavior, required targets/capabilities or privacy keys, data and authorization boundary, validation device requirement, and the owning Apple skill. Clearly call out any unsupported macOS Phone/Messages automation request.

--- a/plugins/messaging-collaboration-skills/skills/choose-platform-integration/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/choose-platform-integration/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: choose-platform-integration
+description: Choose a supported chat, calling, business-messaging, or collaboration integration shape before implementation. Use for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, iMessage collaboration, and Apple VoIP requests.
+---
+
+# Choose Platform Integration
+
+## Purpose
+
+Choose the real platform surface before code, credentials, or a shared abstraction are added. The result is a documented integration shape and one implementation handoff, not a fictional universal bot SDK.
+
+## Workflow
+
+1. Classify the request as a server bot, workspace app, business messaging agent, meeting add-on, native Messages extension, VoIP calling app, or Mac operator workflow.
+2. Identify the user, installation, identity, inbound-event, outbound-response, and hosting model.
+3. Check current official platform docs for availability, policy, review, consent, and SDK lifecycle.
+4. Select the owning platform workflow and then the owning stack workflow.
+5. Define the minimum secure event contract before implementation: verified source, acknowledgement deadline, idempotency key, retry behavior, state owner, audit boundary, and human handoff.
+
+## Routing
+
+- Discord: installed app and HTTP/Gateway interactions; use `discord-app-workflow`.
+- Telegram: Bot API, webhook or polling, optional Mini App; use `telegram-bot-workflow`.
+- Slack: workspace OAuth app, Events API, interactivity, or Socket Mode; use `slack-app-workflow`.
+- Teams: Teams SDK or Microsoft 365 Agents SDK; use `teams-agent-workflow`.
+- WhatsApp, SMS, MMS, or RCS: business-messaging route; use `whatsapp-business-workflow` or `sms-mms-rcs-workflow`.
+- Google Meet: add-on, REST conference/artifact integration, or explicitly preview media access; use `google-meet-collaboration-workflow`.
+- Apple: CallKit/PushKit/AVFAudio/App Intents, Messages extension, or Shared with You; use `apple-communication-workflow`.
+- Signal: report that no official bot route is supported; do not substitute account automation.
+
+## Output
+
+Return the selected surface, reasons, documented constraints, credential and data boundary, implementation owner, validation plan, and rejected alternatives. Stop if the requested platform capability is unsupported or needs a product-policy decision.

--- a/plugins/messaging-collaboration-skills/skills/conversation-state-human-handoff/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/conversation-state-human-handoff/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: conversation-state-human-handoff
+description: Plan conversation identity, state, consent, escalation, transcript, and human-handoff behavior for bots and business messaging agents.
+---
+
+# Conversation State And Human Handoff
+
+## Purpose
+
+Design a narrow, explainable conversation boundary. Platforms identify people, installations, channels, and conversations differently, so normalize only the application facts needed for the product; do not erase platform identity or policy distinctions.
+
+## Workflow
+
+1. Identify the platform-native sender, conversation, installation or tenant, message, and consent identifiers.
+2. State which identifiers are durable, which can change, and which are sensitive.
+3. Define the minimal state required for the user experience: task progress, user preference, handoff status, and delivery context.
+4. Specify an explicit escalation path: trigger, acknowledgement, operator queue or destination, visible transition, return-to-automation rule, and unavailable-hours behavior.
+5. Apply platform and product consent/retention rules before storing transcripts, media, model inputs, or contact data.
+6. Test interruption, duplicate delivery, human takeover, failed escalation, opt-out, deletion, and resumed conversation behavior.
+
+## Guards
+
+- Do not map identities across platforms as though they represent the same authenticated person without an explicit account-linking flow.
+- Do not let an AI response conceal that a human has joined or left when the platform has a representative-state mechanism.
+- Do not introduce repositories, managers, or state mirrors into an app without a concrete ownership need.

--- a/plugins/messaging-collaboration-skills/skills/discord-app-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/discord-app-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: discord-app-workflow
+description: Plan, build, and validate Discord apps, bots, commands, interactions, Gateway event handling, and Activities using current Discord documentation.
+---
+
+# Discord App Workflow
+
+## Workflow
+
+1. Choose a bot, user-installed app, guild-installed app, or Activity. Do not select Gateway when signed HTTP interactions are sufficient.
+2. Register the application and scope the requested permissions, OAuth installation, commands, and intents to the least access needed.
+3. For interactions, verify Discord's signature, answer the required initial interaction promptly, and use follow-ups or deferred responses for longer work.
+4. For Gateway usage, document intents, privileged-intent approval, reconnect/resume state, sharding threshold, and rate-limit behavior.
+5. Model commands, buttons, selects, and modals as explicit user actions with durable component state and authorization checks.
+6. Validate in a test guild/account with observed command registration, signature verification, retry/duplicate behavior, and permission denial.
+
+## Handoffs
+
+Use `webhook-and-event-lifecycle` for request handling, `conversation-state-human-handoff` for state, and the target server stack skill for implementation. Consult the [Discord application overview](https://docs.discord.com/developers/quick-start/overview-of-apps) and [Interactions documentation](https://docs.discord.com/developers/platform/interactions) before asserting behavior.

--- a/plugins/messaging-collaboration-skills/skills/google-meet-collaboration-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/google-meet-collaboration-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: google-meet-collaboration-workflow
+description: Plan and validate Google Meet add-ons, conference REST integrations, event subscriptions, artifacts, and preview media API work.
+---
+
+# Google Meet Collaboration Workflow
+
+## Workflow
+
+1. Choose the smallest correct surface: web add-on for in-meeting shared collaboration, REST API for meeting spaces and post-conference artifacts, Workspace Events for subscriptions, or the Media API only for an explicitly accepted Developer Preview evaluation.
+2. Define Workspace identity, OAuth scopes, organizer and participant data access, add-on deployment, and data retention before implementation.
+3. For an add-on, design shared state and participant controls as collaboration features rather than as an unattended meeting bot.
+4. For REST/event work, separate meeting-space management from artifact processing and avoid using conference data for user performance evaluation.
+5. For Media API evaluation, record preview status, consent, media handling, cost, and rollback conditions. Do not present preview behavior as production stable.
+6. Validate in a test Workspace and meeting: installation, participant join, shared state, event subscription, artifact availability, authorization failure, and removal.
+
+## Source And Handoffs
+
+Start with the [Google Meet SDK and API overview](https://developers.google.com/workspace/meet/overview). Hand web implementation to the web workflow and backend work to the chosen server skill.

--- a/plugins/messaging-collaboration-skills/skills/slack-app-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/slack-app-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: slack-app-workflow
+description: Plan, build, and validate Slack workspace apps with OAuth, Events API, interactivity, slash commands, modals, and Socket Mode.
+---
+
+# Slack App Workflow
+
+## Workflow
+
+1. Choose a workspace app, distribution model, event delivery route, and a narrow OAuth scope inventory before code.
+2. Use Events API plus a public receiver when the service owns inbound HTTPS; use Socket Mode only when its operational model fits the deployment.
+3. Verify Slack request signatures, acknowledge events and interactive payloads promptly, and use the response URL or Web API only within their documented lifecycle.
+4. Treat workspace, enterprise, channel, user, and installation identities as distinct. Check authorization before acting on a command, shortcut, modal submission, or message event.
+5. Make interactive state explicit and short-lived; never place secrets or unverified authority in action values.
+6. Validate OAuth reinstall, scope changes, signature failures, retry headers, modal errors, and a workspace-admin removal path.
+
+## Handoffs
+
+Start with [Slack apps](https://api.slack.com/docs/apps) and [Bolt](https://api.slack.com/bolt). Use `webhook-and-event-lifecycle` and the selected server stack skill for implementation.

--- a/plugins/messaging-collaboration-skills/skills/sms-mms-rcs-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/sms-mms-rcs-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: sms-mms-rcs-workflow
+description: Plan, build, and validate consent-aware SMS, MMS, and RCS business messaging agents, including sender setup, webhooks, rich content, delivery, and fallback.
+---
+
+# SMS MMS RCS Workflow
+
+## Workflow
+
+1. Classify the requirement as SMS/MMS, RCS for Business, a CPaaS multi-channel route, or an Android/iOS app compose/OTP feature. These are not equivalent APIs.
+2. Define sender ownership, country/carrier coverage, registration and verification, consent evidence, opt-out/help handling, content class, rate limits, and fallback before sending any message.
+3. For RCS for Business, model an agent with an external trigger, HTTP API, webhook responses, device capability check, rich-card fallback, and SMS fallback for unsupported recipients.
+4. Verify inbound signatures, deduplicate events, track delivery states, and prevent a retry from becoming a duplicate user notification.
+5. Keep OTP use limited to an authorized authentication flow; do not treat a client-side SMS/RCS retriever as permission to read ordinary user messages.
+6. Validate a test sender, inbound reply, opt-out, unreachable recipient, fallback, media behavior, and delivery failure path in the intended region.
+
+## Sources And Handoffs
+
+Use [RCS for Business](https://developers.google.com/business-communications/rcs-business-messaging/guides/get-started/how-it-works) for Google's direct route. A provider route may use [Twilio Programmable Messaging](https://www.twilio.com/docs/messaging), but it must retain the provider's sender and consent requirements. Hand Android app work to `android-dev-skills` and backend work to the selected server skill.

--- a/plugins/messaging-collaboration-skills/skills/teams-agent-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/teams-agent-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: teams-agent-workflow
+description: Plan, build, and validate Microsoft Teams bots and agents with Teams SDK or Microsoft 365 Agents SDK, Microsoft Entra, Adaptive Cards, and tenant deployment boundaries.
+---
+
+# Teams Agent Workflow
+
+## Workflow
+
+1. Choose Teams SDK for a Teams-first app or Microsoft 365 Agents SDK for a multi-channel agent runtime; document the reason and current supported language.
+2. Define tenant, Microsoft Entra identity, app registration, manifest, installation, and administrator-consent needs before implementation.
+3. Treat message activities, Adaptive Card actions, task modules, and agent tool calls as separate authorized input surfaces.
+4. Verify inbound activity authenticity using the selected Microsoft runtime, preserve conversation and tenant context, and make outbound/proactive messaging consent-aware.
+5. Provide a clear human escalation and error experience inside Teams rather than leaking runtime failures to users.
+6. Validate sideloaded development behavior, tenant install, identity failure, card-submit authorization, proactive-send preconditions, and production deployment review.
+
+## Handoffs
+
+Use the current [Teams bot overview](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/overview) and the documented SDK comparison before implementation. Hand service code to the selected TypeScript, Python, .NET, Java, or Swift server workflow.

--- a/plugins/messaging-collaboration-skills/skills/telegram-bot-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/telegram-bot-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: telegram-bot-workflow
+description: Plan, build, and validate Telegram Bot API integrations, webhooks or polling, inline interactions, and Mini Apps.
+---
+
+# Telegram Bot Workflow
+
+## Workflow
+
+1. Choose Bot API interaction, inline mode, group behavior, or Mini App. Use MTProto/TDLib only when building a Telegram client rather than a bot.
+2. Register through BotFather and keep the token in the selected secret store; never commit it.
+3. Decide between webhook delivery and polling based on the deployed runtime, public endpoint, and local-development needs. Do not run both against the same update stream.
+4. Account for the initiation boundary: bots cannot begin a private chat before a user starts one or adds the bot to a group.
+5. Use update IDs for idempotency, acknowledge callback queries promptly, and design keyboards or Mini App actions with authorization and expiry checks.
+6. Test private chat, group privacy mode, callback handling, duplicate updates, bot restart, and command discovery.
+
+## Handoffs
+
+Use [Telegram's Bot API](https://core.telegram.org/bots/api) and [Bots introduction](https://core.telegram.org/bots) as primary sources. Hand HTTP service work to the chosen server stack skill.

--- a/plugins/messaging-collaboration-skills/skills/webhook-and-event-lifecycle/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/webhook-and-event-lifecycle/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: webhook-and-event-lifecycle
+description: Design and repair secure inbound events, webhooks, interactions, retries, acknowledgements, and delivery observability for messaging and collaboration platforms.
+---
+
+# Webhook And Event Lifecycle
+
+## Purpose
+
+Make inbound messaging events trustworthy, prompt, idempotent, and diagnosable. This skill owns the event boundary; it does not own application business logic, persistent conversation policy, or a platform transport implementation.
+
+## Workflow
+
+1. Read current official delivery and signature-verification documentation for the selected platform.
+2. Capture the platform's request signature, timestamp/replay guard, response deadline, retry policy, event ID, ordering guarantees, and rate limits.
+3. Verify authenticity before parsing or enqueueing work. Reject an invalid request with a descriptive operator-facing log that identifies the platform, validation stage, and likely cause without exposing secrets.
+4. Deduplicate on the platform event identity before side effects. Persist an explicit processing state when retries can outlive a request.
+5. Acknowledge on time, then execute slow work through the selected app runtime. Use platform-native deferred responses where they exist.
+6. Record correlation IDs, delivery outcome, retry count, and a privacy-safe error summary. Do not log raw message content or tokens by default.
+
+## Required Output
+
+Document the request verifier, acknowledgement path, duplicate rule, retry and failure behavior, ordering assumption, response/update path, and targeted replay test. Hand service implementation to the chosen server stack skill.
+
+## Guards
+
+- Do not use a shared webhook wrapper merely because multiple providers use HTTP.
+- Do not acknowledge an event as successful before a required signature or idempotency check.
+- Do not claim a webhook works without a platform test delivery, local signed fixture, or observed request trace.

--- a/plugins/messaging-collaboration-skills/skills/whatsapp-business-workflow/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/whatsapp-business-workflow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: whatsapp-business-workflow
+description: Plan and validate official WhatsApp Business messaging integrations, including onboarding, webhooks, conversation policy, templates, consent, and provider boundaries.
+---
+
+# WhatsApp Business Workflow
+
+## Workflow
+
+1. Confirm the current official WhatsApp Business Platform path or the chosen approved provider before implementation. Record who owns the business account, phone number, webhook, and credentials.
+2. Recheck current Meta policy for user opt-in, template approval, conversation windows, message categories, and regional restrictions. These rules are release-sensitive and must not be copied from memory.
+3. Verify webhook authenticity, deduplicate status/message events, and separate inbound message handling from delivery/read-status processing.
+4. Treat a WhatsApp phone identity, application account, user consent, template, and conversation window as explicit data inputs.
+5. Design opt-out, human escalation, media retention, and failure fallback before adding AI-generated replies.
+6. Validate with an approved test environment, observed webhook signatures, template state, inbound/outbound behavior, delivery status, and stop/escalation paths.
+
+## Provider Boundary
+
+An approved CPaaS provider can simplify transport but does not remove WhatsApp business policy obligations. Keep provider-specific types and credentials at the provider boundary; do not convert this skill into a universal WhatsApp client.

--- a/plugins/network-protocol-skills/.codex-plugin/plugin.json
+++ b/plugins/network-protocol-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "network-protocol-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for choosing, planning, implementing, and diagnosing modern application transports and real-time networking protocols, including QUIC, HTTP/3, WebRTC, Media over QUIC, WebTransport-adjacent handoffs, protocol maturity checks, and stack-specific implementation routing.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/.codex-plugin/plugin.json
+++ b/plugins/productivity-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "productivity-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Broadly useful productivity workflows for Codex.",
   "author": {
     "name": "Gale",

--- a/plugins/productivity-skills/pyproject.toml
+++ b/plugins/productivity-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "productivity-skills-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 description = "Maintainer-only Python tooling baseline for productivity-skills."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/productivity-skills/uv.lock
+++ b/plugins/productivity-skills/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "productivity-skills-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "python-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Bundled Python-focused Codex skills for uv bootstrapping, project implementation, diagnostics, packaging, tooling, CI, upgrades, FastAPI, FastMCP, and pytest workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/python-skills/pyproject.toml
+++ b/plugins/python-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-skills-maintainer"
-version = "9.7.0"
+version = "9.8.0"
 description = "Maintainer tooling for the python-skills repository"
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/python-skills/uv.lock
+++ b/plugins/python-skills/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "python-skills-maintainer"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
+++ b/plugins/reverse-engineering-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-engineering-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Workflow skills for reverse engineering, decompilation, disassembly, symbol, and artifact-analysis tasks.",
   "skills": "./skills/",
   "author": {

--- a/plugins/rust-skills/.codex-plugin/plugin.json
+++ b/plugins/rust-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Rust, Cargo, rustup, crate, workspace, CLI, library, package, CI, testing, linting, and formatting workflow skills.",
   "skills": "./skills/",
   "author": {

--- a/plugins/server-side-jvm/.codex-plugin/plugin.json
+++ b/plugins/server-side-jvm/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-jvm",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for choosing, building, testing, and maintaining server-side JVM backend projects with Java and Scala as equal first-party languages and future Clojure support planned.",
   "author": {
     "name": "Gale",

--- a/plugins/server-side-swift/.codex-plugin/plugin.json
+++ b/plugins/server-side-swift/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "server-side-swift",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for bootstrapping, syncing, building, running, containerizing, deploying, and maintaining server-side Swift services, including Vapor, Hummingbird, hb, persistence, Swift OpenAPI, RPC-fit decisions, SwiftNIO, observability, auth, app sync, Docker, Apple Containerization, Fly.io, and SwiftPM-first workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/spotify/.codex-plugin/plugin.json
+++ b/plugins/spotify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Placeholder plugin repository for future Spotify-focused Codex workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/swift-lang/.codex-plugin/plugin.json
+++ b/plugins/swift-lang/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-lang",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Shared Swift language skills for API style, error handling, functional pipelines, formatting, source organization, and modernization cleanup.",
   "skills": "./skills/",
   "author": {

--- a/plugins/swiftasb-skills/.codex-plugin/plugin.json
+++ b/plugins/swiftasb-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftasb-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for explaining SwiftASB and building SwiftUI, AppKit, and Swift package integrations on top of it.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/.codex-plugin/plugin.json
+++ b/plugins/things-app/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "things-app",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Things.app skills and a bundled local MCP server for reminders, planning digests, and structured task workflows.",
   "author": {
     "name": "Gale",

--- a/plugins/things-app/mcp/pyproject.toml
+++ b/plugins/things-app/mcp/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "things-mcp"
-version = "9.7.0"
+version = "9.8.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2",

--- a/plugins/things-app/mcp/uv.lock
+++ b/plugins/things-app/mcp/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "things-mcp"
-version = "9.7.0"
+version = "9.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/plugins/things-app/pyproject.toml
+++ b/plugins/things-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "things-app-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 description = "Maintainer-only Python tooling baseline for things-app skills and plugin packaging."
 requires-python = ">=3.11"
 dependencies = []

--- a/plugins/things-app/uv.lock
+++ b/plugins/things-app/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "things-app-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/plugins/web-dev-skills/.codex-plugin/plugin.json
+++ b/plugins/web-dev-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "web-dev-skills",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Codex skills for focused web and Expo native-boundary workflows.",
   "author": {
     "name": "Gale",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "socket-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 description = "Root uv tooling baseline for the socket superproject."
 requires-python = ">=3.11"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "socket-maintenance"
-version = "9.7.0"
+version = "9.8.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add the installable messaging-collaboration-skills Socket plugin
- ship phase 1 foundations and phase 2 platform workflows
- document Apple Phone, CallKit/VoIP, iMessage, Shared with You, and Mac operator boundaries
- align Socket's shared version surfaces to 9.8.0

## Verification
- validated all 11 authored skills
- validated the plugin manifest and Socket marketplace metadata
- confirmed shared version inventory is 9.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a messaging and collaboration skills plugin covering Discord, Slack, Teams, Telegram, WhatsApp, SMS/MMS/RCS, Google Meet, Apple communication workflows, and human handoffs.
  * Added guidance for secure webhooks, consent, identity, authorization, retries, and platform-specific integration choices.

* **Documentation**
  * Updated the catalog, roadmap, and maintainer guidance with plugin availability, scope, validation criteria, and platform boundaries.

* **Chores**
  * Updated the project and plugin release versions to 9.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->