### PR TITLE
plugin: translate Socket MCP configs for Hermes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,13 @@ The export is generated from `plugins/agent-portability-skills/skills/`; do not
 edit root `skills/` by hand. See the [Hermes compatibility guide](./docs/maintainers/hermes-compatibility.md)
 for the supported surface and MCP translation rules.
 
+When a change adds or changes any `plugins/**/.mcp.json` declaration, update
+the matching checked-in fragment under
+[`docs/maintainers/hermes-mcp/`](./docs/maintainers/hermes-mcp/) and its
+inventory entry in `index.yaml`. The Hermes validator requires every declared
+Socket MCP configuration to be accounted for and rejects committed
+machine-local paths or undocumented environment placeholders.
+
 ### Xcode Workspace
 
 The root [`Socket.xcworkspace`](./Socket.xcworkspace) is a browse-only workspace for maintainers who want to use Xcode's file navigator and Markdown editor, especially Xcode 27 beta's WYSIWYG Markdown surface. It references root docs, the marketplace file, `docs/`, `plugins/`, and `scripts/`, but it intentionally has no schemes, targets, package products, or root build settings.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -529,7 +529,8 @@ In progress
 - [ ] Add `agent-portability-skills:audit-agent-surface-portability`.
 - [ ] Add `agent-portability-skills:design-agent-host-adapter`.
 - [ ] Add `agent-portability-skills:maintain-codex-plugin-surface`.
-- [x] Document Hermes MCP `mcp_servers` translations and the rule for when a separate `plugin.yaml` / `register(ctx)` implementation is actually required.
+- [x] Translate every declared Socket `.mcp.json` into checked-in, validated Hermes `mcp_servers` fragments with an explicit setup/status inventory.
+- [x] Document the prioritized native Hermes Python adapter plan, including per-plugin adapter shape, configuration boundary, and validation strategy without adding speculative bridge code.
 - [ ] Add common skill constraint checks for Codex and OpenCode first, then include Zed as an informational follow-up target.
 - [ ] Add a dry-run OpenCode skills export plan for `.agents/skills` and `.opencode/skills`, starting with project-local fixtures and temporary homes.
 - [ ] Evaluate OpenCode adapters for `.opencode/skills`, `opencode.json`, MCP config, permissions, and TypeScript plugin modules.

--- a/docs/maintainers/hermes-compatibility.md
+++ b/docs/maintainers/hermes-compatibility.md
@@ -11,7 +11,7 @@ plugin bundle and does not make Codex-only runtime surfaces portable.
 | Root `skills/` export | GitHub skill tap | Supported |
 | Other Socket skills | Future curated export or local source | Not automatically exported |
 | `.codex-plugin/plugin.json` | None | Not compatible by design |
-| Socket `.mcp.json` | `mcp_servers` in Hermes config | Manual adapter path |
+| Socket `.mcp.json` | Checked-in `mcp_servers` translation fragments | Configuration required |
 | Hooks, apps, and custom agents | Host-specific extension decision | Not automatically compatible |
 | Runtime tools, hooks, commands, or namespaced skills | Python Hermes plugin | Separate implementation |
 
@@ -62,13 +62,22 @@ grouping labels.
 
 The focused validator fails for malformed frontmatter, wrong names, missing
 descriptions, stale generated content, grouping drift, machine-local metadata
-paths, or invalid maintained MCP examples. It warns, without blocking, when a
-description exceeds 240 characters.
+paths, invalid maintained MCP examples, or an unaccounted Socket MCP
+declaration. It warns, without blocking, when a description exceeds 240
+characters.
 
 ## MCP Translation
 
 Socket `.mcp.json` files are Codex declarations, not portable Hermes config.
-Translate the chosen server into the operator's private `~/.hermes/config.yaml`:
+Every declared Socket MCP configuration is translated under
+[`hermes-mcp/`](./hermes-mcp/), with the complete inventory and setup status in
+[`hermes-mcp/index.yaml`](./hermes-mcp/index.yaml). Copy the chosen fragment's
+`mcp_servers` mapping into the operator's private `~/.hermes/config.yaml` and
+complete any listed setup first. The checked-in fragments never require a
+machine-local path: local Cardhop and Things servers instead use documented
+environment variables that the operator sets before starting Hermes.
+
+Hermes config has this shape:
 
 ```yaml
 mcp_servers:
@@ -89,17 +98,21 @@ mcp_servers:
       resources: true
 ```
 
-The checked-in [example YAML](./hermes-mcp-examples.yaml) is syntax-validated.
-Replace placeholders in private configuration, never in Socket. Use a narrow
-tool allowlist for mutation-capable servers, configure required secrets through
-the explicit `env` mapping, and run `hermes mcp test <name>` before use.
+The checked-in [example YAML](./hermes-mcp-examples.yaml) demonstrates optional
+filtering fields, while the per-plugin fragments preserve each Socket server's
+actual name and transport. Replace placeholders in private configuration,
+never in Socket. The translations do not add filtering where no direct
+safety/namespace reason exists. Configure required secrets through the explicit
+`env` mapping or Hermes process environment, then reload MCP configuration with
+`/reload-mcp` and test the enabled server before use.
 
-| Socket declaration | Hermes translation decision |
-| --- | --- |
-| Apple Dev Skills Xcode bridges | Add a stdio `command: "xcrun"` entry with matching bridge arguments only on a Mac with the required Xcode capability. |
-| Cardhop and Things local servers | Use the package's actual server directory and `uv run python app/server.py`; do not infer a path from the Codex declaration. |
-| Cloud Inference Runpod server | Translate the stdio command or remote docs URL separately; provide `RUNPOD_API_KEY` only when required. |
-| Productivity Dice server | Use an HTTP `url` entry; do not assume an API secret for public search. |
+| Socket declaration | Checked-in Hermes translation | Status |
+| --- | --- | --- |
+| Apple Dev Skills Xcode bridges | [`apple-dev-skills.yaml`](./hermes-mcp/apple-dev-skills.yaml) | Manual Xcode setup required |
+| Cardhop local server | [`cardhop-app.yaml`](./hermes-mcp/cardhop-app.yaml) | Local server-directory setup required |
+| Cloud Inference Runpod API and docs servers | [`cloud-inference-skills.yaml`](./hermes-mcp/cloud-inference-skills.yaml) | Ready; API server needs `RUNPOD_API_KEY` |
+| Productivity Dice server | [`productivity-skills.yaml`](./hermes-mcp/productivity-skills.yaml) | Ready; basic public search needs no credential |
+| Things local server | [`things-app.yaml`](./hermes-mcp/things-app.yaml) | Local server-directory setup required; updates need `THINGS_AUTH_TOKEN` |
 
 ## When a Native Hermes Plugin Is Required
 
@@ -112,6 +125,12 @@ and `register(ctx)` entry point, and may call `ctx.register_tool`,
 Do not add a generic Socket bridge or boilerplate plugin merely to mirror Codex
 packaging. Instruction workflows remain skills; external tool servers remain
 MCP. A native plugin is a separate implementation and distribution decision.
+
+The concrete, prioritized future work is in the
+[Hermes native Python plugin adapter plan](./hermes-plugin-adapters.md). It
+classifies each candidate as a tool, hook, slash command, CLI command, bundled
+read-only skill, platform/backend provider, or no adapter, and names the
+required configuration and test shape before any implementation begins.
 
 ## Verification and Limits
 

--- a/docs/maintainers/hermes-mcp/apple-dev-skills.yaml
+++ b/docs/maintainers/hermes-mcp/apple-dev-skills.yaml
@@ -1,0 +1,8 @@
+# Merge this mapping into ~/.hermes/config.yaml on a Mac with the stated Xcode capabilities enabled.
+mcp_servers:
+  xcode:
+    command: xcrun
+    args: [mcpbridge]
+  xcode_lldb:
+    command: xcrun
+    args: [lldb-mcp]

--- a/docs/maintainers/hermes-mcp/cardhop-app.yaml
+++ b/docs/maintainers/hermes-mcp/cardhop-app.yaml
@@ -1,0 +1,5 @@
+# Export SOCKET_CARDHOP_MCP_DIR before starting Hermes; it must name the local mcp directory.
+mcp_servers:
+  cardhop_app_socket:
+    command: sh
+    args: ["-lc", "cd \"$SOCKET_CARDHOP_MCP_DIR\" && exec uv run python app/server.py"]

--- a/docs/maintainers/hermes-mcp/cloud-inference-skills.yaml
+++ b/docs/maintainers/hermes-mcp/cloud-inference-skills.yaml
@@ -1,0 +1,9 @@
+# Set RUNPOD_API_KEY in the Hermes process environment before enabling the Runpod API server.
+mcp_servers:
+  runpod:
+    command: npx
+    args: ["-y", "@runpod/mcp-server@latest"]
+    env:
+      RUNPOD_API_KEY: "${RUNPOD_API_KEY}"
+  runpod-docs:
+    url: https://docs.runpod.io/mcp

--- a/docs/maintainers/hermes-mcp/index.yaml
+++ b/docs/maintainers/hermes-mcp/index.yaml
@@ -1,0 +1,38 @@
+# Inventory of every Socket MCP declaration and its checked-in Hermes translation.
+# Each `translation` path is a standalone mcp_servers fragment that an operator can
+# merge into ~/.hermes/config.yaml after completing the documented setup.
+translations:
+  apple-dev-skills:
+    source: plugins/apple-dev-skills/.mcp.json
+    translation: docs/maintainers/hermes-mcp/apple-dev-skills.yaml
+    status: manual_setup_required
+    required_environment: []
+    setup: Xcode must be installed and its MCP capability enabled before either bridge can start.
+  cardhop-app:
+    source: plugins/cardhop-app/.mcp.json
+    translation: docs/maintainers/hermes-mcp/cardhop-app.yaml
+    status: manual_setup_required
+    required_environment:
+      - SOCKET_CARDHOP_MCP_DIR
+    setup: Point SOCKET_CARDHOP_MCP_DIR at a local Cardhop MCP checkout with its uv environment synced.
+  cloud-inference-skills:
+    source: plugins/cloud-inference-skills/.mcp.json
+    translation: docs/maintainers/hermes-mcp/cloud-inference-skills.yaml
+    status: ready
+    required_environment:
+      - RUNPOD_API_KEY
+    setup: Set RUNPOD_API_KEY only when enabling the mutation-capable Runpod API server; the docs server needs no secret.
+  productivity-skills:
+    source: plugins/productivity-skills/.mcp.json
+    translation: docs/maintainers/hermes-mcp/productivity-skills.yaml
+    status: ready
+    required_environment: []
+    setup: The public Dice search endpoint requires no credential for basic search.
+  things-app:
+    source: plugins/things-app/.mcp.json
+    translation: docs/maintainers/hermes-mcp/things-app.yaml
+    status: manual_setup_required
+    required_environment:
+      - SOCKET_THINGS_MCP_DIR
+      - THINGS_AUTH_TOKEN
+    setup: Point SOCKET_THINGS_MCP_DIR at a local Things MCP checkout; THINGS_AUTH_TOKEN is required only for Things update operations.

--- a/docs/maintainers/hermes-mcp/productivity-skills.yaml
+++ b/docs/maintainers/hermes-mcp/productivity-skills.yaml
@@ -1,0 +1,3 @@
+mcp_servers:
+  dice:
+    url: https://mcp.dice.com/mcp

--- a/docs/maintainers/hermes-mcp/things-app.yaml
+++ b/docs/maintainers/hermes-mcp/things-app.yaml
@@ -1,0 +1,7 @@
+# Export SOCKET_THINGS_MCP_DIR before starting Hermes; THINGS_AUTH_TOKEN enables update operations.
+mcp_servers:
+  things-app:
+    command: sh
+    args: ["-lc", "cd \"$SOCKET_THINGS_MCP_DIR\" && exec uv run python app/server.py"]
+    env:
+      THINGS_AUTH_TOKEN: "${THINGS_AUTH_TOKEN}"

--- a/docs/maintainers/hermes-plugin-adapters.md
+++ b/docs/maintainers/hermes-plugin-adapters.md
@@ -1,0 +1,49 @@
+# Hermes Native Python Plugin Adapter Plan
+
+This is a prioritized implementation plan, not an adapter implementation.
+Socket keeps its portable workflows as skills and its external tools as MCP
+servers. A native Hermes Python plugin is warranted only when a real runtime
+behavior cannot be represented by either surface. In particular,
+`.codex-plugin/plugin.json` remains a Codex distribution bundle; it is not a
+Hermes `plugin.yaml` equivalent.
+
+Future adapters should be independently installable Hermes plugins with a
+small `plugin.yaml`, an `__init__.py` that calls `register(ctx)`, and focused
+schema/handler tests. Do not introduce a generic Socket-to-Hermes bridge: it
+would duplicate three intentionally different host models without serving a
+current concrete behavior.
+
+## Priority Order
+
+| Priority | Socket package | Why a skill or MCP is insufficient | Adapter shape | Likely future ownership | Required configuration | Validation strategy |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `speak-swiftly` | Speech control needs session-aware local playback, queue state, and operator commands beyond a static workflow or remote MCP declaration. | General plugin: tools for status and queue control, slash command for playback state, optional post-tool hook only if a concrete accessibility flow requires it. | Standalone `SpeakSwiftlyServer` plugin source: `hermes-plugin/plugin.yaml`, `hermes-plugin/__init__.py`, `schemas.py`, `tools.py`, and tests. | Existing Speak Swiftly local endpoint or command configuration; do not embed machine paths or credentials. | Unit-test registration and handlers with a fake local client; run an opt-in local smoke test against a separately configured service. |
+| 2 | `cardhop-app` | MCP already covers contact actions, but an adapter could provide a narrow slash command or local readiness tool that unifies the macOS capability check and Cardhop dispatch. | General plugin with one readiness tool and, only after a real operator need, a `/cardhop` command dispatching the documented integration route. | `plugins/cardhop-app/hermes-plugin/` with `plugin.yaml`, `__init__.py`, handler module, schemas, and tests. | macOS, Cardhop.app, `uv`, and an explicit configured MCP checkout path. | Mock AppleScript and URL-scheme execution; opt-in Mac smoke test verifies only `healthcheck` before action tools. |
+| 3 | `things-app` | The MCP server carries the tools, while a native command can safely summarize a confirmed task workflow or expose explicit auth readiness without broad tool discovery. | General plugin with read-only readiness/status tool; defer task mutation tools to MCP unless a slash-command workflow proves necessary. | `plugins/things-app/hermes-plugin/` with manifest, registration, status handler, and tests. | macOS, Things.app, local MCP checkout path; `THINGS_AUTH_TOKEN` only for future update behavior. | Unit-test token-state redaction and registration; opt-in app-presence/read-only smoke test. |
+| 4 | `cloud-inference-skills` | The existing Runpod MCP server is the right API surface. A Python plugin is justified only for a concrete Hermes-native provider/backend configuration or an account-safe preflight command. | Start with no adapter. If demanded, general plugin CLI command for read-only preflight; model-provider or backend plugin only when Hermes directly owns the provider integration. | `plugins/cloud-inference-skills/hermes-plugin/` only after a defined provider contract and owner. | Provider credentials such as `RUNPOD_API_KEY`, explicit account/region/cost policy. | Fake provider-client tests, redaction tests, and a separately approved no-mutation account probe. |
+| 5 | `productivity-skills` | Dice's remote MCP endpoint is sufficient for job search. Static workflow guidance belongs in the skill tap. | None. Consider a slash command only if a repeatable Hermes session workflow cannot be expressed as a skill plus MCP. | No adapter files planned. | None for the documented public Dice search path. | Reassess against a concrete command request; retain MCP configuration validation. |
+| 6 | `apple-dev-skills` | Xcode MCP bridges already expose runtime tools, and the skill corpus is the portable instruction surface. A plugin would duplicate Xcode's capability discovery without a defined behavior. | None. Consider a general plugin only for a verified Hermes-specific Xcode project-context command that cannot be an MCP tool. | No adapter files planned. | macOS, compatible Xcode, and Xcode MCP enablement. | Preserve MCP launch checks and require a real Xcode project smoke test before proposing an adapter. |
+
+## Delivery Rules For A Future Adapter
+
+1. State the missing user behavior and why the existing skill or MCP fragment cannot provide it.
+2. Choose one Hermes extension point: tool, hook, slash command, CLI command,
+   bundled read-only skill, platform/backend provider, or none. Do not combine
+   them speculatively.
+3. Keep configuration in documented environment variables or private Hermes
+   configuration; never commit local checkout paths, tokens, or app secrets.
+4. Add `plugin.yaml` requirements such as `requires_env` only for values that
+   are truly required at plugin load time. Make mutation-capable behavior
+   explicit and test it separately from read-only readiness.
+5. Keep the plugin opt-in through Hermes `plugins.enabled`, with a documented
+   install and enable flow. Hermes treats third-party general plugins as
+   disabled until the operator enables them.
+
+## Authoritative References
+
+- [Hermes Plugins](https://hermes-agent.nousresearch.com/docs/user-guide/features/plugins)
+  defines `plugin.yaml`, `register(ctx)`, the general plugin extension points,
+  discovery locations, and opt-in enablement.
+- [Hermes MCP Config Reference](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference)
+  defines the configuration surface that remains preferable for external MCP
+  servers.

--- a/scripts/validate_hermes_compatibility.py
+++ b/scripts/validate_hermes_compatibility.py
@@ -17,9 +17,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 EXPORT_ROOT = REPO_ROOT / "skills"
 GROUPINGS_PATH = REPO_ROOT / "skills.sh.json"
 MCP_EXAMPLES_PATH = REPO_ROOT / "docs" / "maintainers" / "hermes-mcp-examples.yaml"
+MCP_TRANSLATIONS_INDEX_PATH = REPO_ROOT / "docs" / "maintainers" / "hermes-mcp" / "index.yaml"
 HERMES_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 MAX_FRIENDLY_DESCRIPTION_LENGTH = 240
 MACHINE_LOCAL_PATH_RE = re.compile(r"(?:^|[\s'\"])~[/\\]|/Users/|(?:^|[\s'\"])\.\./")
+ENV_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*)\}|\$([A-Z][A-Z0-9_]*)")
+MCP_TRANSLATION_STATUSES = {"ready", "manual_setup_required", "not_supported"}
 
 
 class ValidationError(RuntimeError):
@@ -145,10 +148,112 @@ def validate_mcp_examples() -> None:
             )
 
 
+def load_socket_mcp_servers(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} is not valid JSON: {error}") from error
+    servers = document.get("mcpServers") if isinstance(document, dict) else None
+    if servers is None:
+        servers = document
+    if not isinstance(servers, dict) or not servers:
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} must define a non-empty MCP server mapping.")
+    if not all(isinstance(name, str) and isinstance(config, dict) for name, config in servers.items()):
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} must map string server names to configurations.")
+    return servers
+
+
+def placeholders_in(value: object) -> set[str]:
+    if isinstance(value, str):
+        return {match.group(1) or match.group(2) for match in ENV_PLACEHOLDER_RE.finditer(value)}
+    if isinstance(value, list):
+        return set().union(*(placeholders_in(item) for item in value)) if value else set()
+    if isinstance(value, dict):
+        return set().union(*(placeholders_in(item) for item in value.values())) if value else set()
+    return set()
+
+
+def validate_hermes_server(name: str, config: dict[str, Any], path: Path) -> set[str]:
+    transports = [field for field in ("command", "url") if field in config]
+    if len(transports) != 1:
+        raise ValidationError(
+            f"{path.relative_to(REPO_ROOT)} server {name!r} must define exactly one transport: command or url."
+        )
+    if "cwd" in config:
+        raise ValidationError(
+            f"{path.relative_to(REPO_ROOT)} server {name!r} uses unsupported Hermes field 'cwd'; use a documented portable launcher."
+        )
+    if not isinstance(config[transports[0]], str) or not config[transports[0]].strip():
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} server {name!r} has an empty {transports[0]!r}.")
+    args = config.get("args")
+    if args is not None and (not isinstance(args, list) or not all(isinstance(arg, str) for arg in args)):
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} server {name!r} args must be a string list.")
+    env = config.get("env")
+    if env is not None and (not isinstance(env, dict) or not all(isinstance(key, str) and isinstance(value, str) for key, value in env.items())):
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} server {name!r} env must be a string mapping.")
+    if contains_machine_local_path(config):
+        raise ValidationError(f"{path.relative_to(REPO_ROOT)} server {name!r} contains a machine-local path.")
+    return placeholders_in(config)
+
+
+def validate_mcp_translations() -> None:
+    index = load_yaml_mapping(MCP_TRANSLATIONS_INDEX_PATH)
+    translations = index.get("translations")
+    if not isinstance(translations, dict) or not translations:
+        raise ValidationError("hermes-mcp/index.yaml must define a non-empty translations mapping.")
+    declared_sources = {path.relative_to(REPO_ROOT).as_posix() for path in REPO_ROOT.glob("plugins/**/.mcp.json")}
+    indexed_sources: set[str] = set()
+    for plugin_name, entry in translations.items():
+        if not isinstance(plugin_name, str) or not isinstance(entry, dict):
+            raise ValidationError("Each Hermes MCP translation index entry must be a plugin-name mapping.")
+        source = entry.get("source")
+        translation = entry.get("translation")
+        status = entry.get("status")
+        documented_environment = entry.get("required_environment")
+        setup = entry.get("setup")
+        if not isinstance(source, str) or source not in declared_sources:
+            raise ValidationError(f"Hermes MCP translation {plugin_name!r} has no declared Socket .mcp.json source.")
+        if not isinstance(translation, str) or not translation.startswith("docs/maintainers/hermes-mcp/"):
+            raise ValidationError(f"Hermes MCP translation {plugin_name!r} must use a checked-in hermes-mcp translation path.")
+        if not isinstance(status, str) or status not in MCP_TRANSLATION_STATUSES:
+            raise ValidationError(f"Hermes MCP translation {plugin_name!r} has unsupported status {status!r}.")
+        if not isinstance(documented_environment, list) or not all(isinstance(item, str) for item in documented_environment):
+            raise ValidationError(f"Hermes MCP translation {plugin_name!r} must list documented required_environment names.")
+        if not isinstance(setup, str) or not setup.strip():
+            raise ValidationError(f"Hermes MCP translation {plugin_name!r} must include a setup note.")
+        translation_path = REPO_ROOT / translation
+        document = load_yaml_mapping(translation_path)
+        servers = document.get("mcp_servers")
+        if not isinstance(servers, dict) or not servers:
+            raise ValidationError(f"{translation} must define a non-empty mcp_servers mapping.")
+        source_servers = load_socket_mcp_servers(REPO_ROOT / source)
+        if set(servers) != set(source_servers):
+            raise ValidationError(f"{translation} server names must exactly match {source}.")
+        placeholders: set[str] = set()
+        for name, config in servers.items():
+            if not isinstance(name, str) or not isinstance(config, dict):
+                raise ValidationError(f"{translation} must map string server names to mappings.")
+            placeholders.update(validate_hermes_server(name, config, translation_path))
+        undocumented = placeholders - set(documented_environment)
+        if undocumented:
+            raise ValidationError(f"{translation} has undocumented environment placeholders: {', '.join(sorted(undocumented))}.")
+        indexed_sources.add(source)
+    missing = declared_sources - indexed_sources
+    extra = indexed_sources - declared_sources
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing translations for {', '.join(sorted(missing))}")
+        if extra:
+            details.append(f"unknown translation sources {', '.join(sorted(extra))}")
+        raise ValidationError("Hermes MCP translation inventory is incomplete: " + "; ".join(details) + ".")
+
+
 def main() -> int:
     warnings = validate_exported_skills()
     validate_groupings()
     validate_mcp_examples()
+    validate_mcp_translations()
     for warning in warnings:
         print(f"Warning: {warning}")
     print("Socket Hermes compatibility validation passed.")

--- a/tests/test_validate_hermes_compatibility.py
+++ b/tests/test_validate_hermes_compatibility.py
@@ -53,6 +53,18 @@ def make_repo(tmp_path: Path) -> Path:
         tmp_path / "docs" / "maintainers" / "hermes-mcp-examples.yaml",
         "mcp_servers:\n  example:\n    command: tool\n",
     )
+    write(
+        tmp_path / "plugins" / "example-skills" / ".mcp.json",
+        '{"mcpServers": {"example": {"command": "tool"}}}',
+    )
+    write(
+        tmp_path / "docs" / "maintainers" / "hermes-mcp" / "index.yaml",
+        "translations:\n  example-skills:\n    source: plugins/example-skills/.mcp.json\n    translation: docs/maintainers/hermes-mcp/example-skills.yaml\n    status: ready\n    required_environment: []\n    setup: Ready for use.\n",
+    )
+    write(
+        tmp_path / "docs" / "maintainers" / "hermes-mcp" / "example-skills.yaml",
+        "mcp_servers:\n  example:\n    command: tool\n",
+    )
     return tmp_path
 
 
@@ -63,6 +75,7 @@ def configure_paths(repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(validate_hermes_compatibility, "EXPORT_ROOT", repo_root / "skills")
     monkeypatch.setattr(validate_hermes_compatibility, "GROUPINGS_PATH", repo_root / "skills.sh.json")
     monkeypatch.setattr(validate_hermes_compatibility, "MCP_EXAMPLES_PATH", repo_root / "docs" / "maintainers" / "hermes-mcp-examples.yaml")
+    monkeypatch.setattr(validate_hermes_compatibility, "MCP_TRANSLATIONS_INDEX_PATH", repo_root / "docs" / "maintainers" / "hermes-mcp" / "index.yaml")
 
 
 def test_main_accepts_exact_export_and_valid_metadata(
@@ -121,3 +134,26 @@ def test_export_check_detects_missing_skill(tmp_path: Path) -> None:
     shutil.rmtree(export_root / "sync-skills-repo-guidance")
 
     assert not export_hermes_skills.has_exact_export(source_root, export_root)
+
+
+def test_mcp_translation_rejects_missing_socket_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = make_repo(tmp_path)
+    configure_paths(repo_root, monkeypatch)
+    (repo_root / "plugins" / "example-skills" / ".mcp.json").unlink()
+
+    with pytest.raises(validate_hermes_compatibility.ValidationError, match="no declared Socket .mcp.json source"):
+        validate_hermes_compatibility.validate_mcp_translations()
+
+
+def test_mcp_translation_rejects_undocumented_environment_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = make_repo(tmp_path)
+    configure_paths(repo_root, monkeypatch)
+    write(
+        repo_root / "docs" / "maintainers" / "hermes-mcp" / "example-skills.yaml",
+        "mcp_servers:\n  example:\n    command: tool\n    env:\n      API_KEY: ${API_KEY}\n",
+    )
+
+    with pytest.raises(validate_hermes_compatibility.ValidationError, match="undocumented environment placeholders"):
+        validate_hermes_compatibility.validate_mcp_translations()


### PR DESCRIPTION
Summary: add checked-in Hermes mcp_servers fragments for every Socket MCP declaration; validate complete translation inventory, portable paths, and documented environment placeholders; document a prioritized native Hermes Python adapter plan without speculative bridge code.\n\nValidation: uv run scripts/validate_socket_metadata.py; uv run scripts/validate_hermes_compatibility.py; uv run pytest; uv run ruff check scripts/validate_hermes_compatibility.py tests/test_validate_hermes_compatibility.py.