### PR TITLE
hermes: shorten exported skill descriptions

### DIFF
--- a/plugins/agent-portability-skills/skills/bootstrap-skills-plugin-repo/SKILL.md
+++ b/plugins/agent-portability-skills/skills/bootstrap-skills-plugin-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap-skills-plugin-repo
-description: Bootstrap or align a source-first Agent Skills repository with root `skills/`, repo-local discovery mirrors, maintainer docs, and clear Codex plugin-boundary wording. Use when creating a new skills repo or structurally aligning an existing one. Do not use this for narrow README-only, roadmap-only, or host-adapter design work.
+description: Bootstrap or align a source-first Agent Skills repository with root `skills/`, discovery mirrors, maintainer docs, and explicit Codex plugin boundaries. Use for new skills repos or structural alignment, not narrow docs or host-adapter work.
 metadata:
   hermes:
     category: agent-portability

--- a/plugins/agent-portability-skills/skills/sync-skills-repo-guidance/SKILL.md
+++ b/plugins/agent-portability-skills/skills/sync-skills-repo-guidance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-skills-repo-guidance
-description: Audit guidance across AGENTS.md, optional README.md, maintainer docs, and discovery mirrors in an existing Agent Skills or Codex plugin repository. Use when a skills repo may have stale guidance, missing discovery mirrors, outdated OpenAI Codex policy, or unclear boundaries between portable skills and host-specific plugin surfaces. Defer narrow README-only, roadmap-only, or host-adapter design requests to the specialized maintainer skills.
+description: Audit Agent Skills or Codex plugin guidance and discovery mirrors. Use for stale policy, missing mirrors, or unclear portable-skill and host-plugin boundaries; defer narrow docs work.
 metadata:
   hermes:
     category: agent-portability

--- a/plugins/cybersecurity-skills/skills/analyze-suspicious-script-or-document/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/analyze-suspicious-script-or-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-suspicious-script-or-document
-description: Decode and analyze suspicious scripts and active documents without triggering them. Use for shell, AppleScript, JavaScript, Python, PowerShell, shortcuts, Office files, PDFs, configuration profiles, encoded commands, macros, embedded objects, external templates, staged downloads, or mixed document-to-script payload chains.
+description: Decode and analyze suspicious scripts and active documents without triggering them. Use for shell, AppleScript, JavaScript, Python, PowerShell, shortcuts, Office files, PDFs, profiles, macros, embedded objects, and staged payloads.
 ---
 
 # Analyze Suspicious Script Or Document

--- a/plugins/cybersecurity-skills/skills/assess-and-explain-threat/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/assess-and-explain-threat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-and-explain-threat
-description: Assess whether suspicious evidence indicates a real threat and explain the result in practical language. Use when a person needs a confidence-calibrated conclusion, immediate protective actions, remaining uncertainty, impact, or understandable advice after artifact, endpoint, vulnerability, identity, or incident evidence has been collected.
+description: Assess whether suspicious evidence indicates a real threat and explain it plainly. Use for confidence, protective actions, uncertainty, impact, and advice after artifact, endpoint, identity, or incident evidence.
 ---
 
 # Assess And Explain Threat

--- a/plugins/cybersecurity-skills/skills/assess-exposure-and-impact/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/assess-exposure-and-impact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-exposure-and-impact
-description: Prioritize a validated or plausible vulnerability using actual asset exposure and impact. Use when affected versions, deployment reachability, attacker prerequisites, privileges, sensitive data, exploit maturity, CISA KEV status, vendor guidance, mitigations, detection, business criticality, CVSS, and remediation urgency must be combined without relying on a severity score alone.
+description: Prioritize a vulnerability using actual asset exposure and impact. Use when versions, reachability, prerequisites, privileges, data, exploit maturity, mitigations, detection, business criticality, and urgency matter beyond CVSS.
 ---
 
 # Assess Exposure And Impact

--- a/plugins/cybersecurity-skills/skills/assess-macos-threat/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/assess-macos-threat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-macos-threat
-description: Assess a suspected macOS security threat using exact host, artifact, and platform evidence. Use for suspicious apps, packages, processes, prompts, downloads, profiles, extensions, XProtect or Gatekeeper alerts, account behavior, persistence, privacy access, or unexpected network activity when signing, notarization, quarantine, TCC, SIP, and observed behavior must remain distinct.
+description: Assess a suspected macOS threat using exact host and artifact evidence. Use for suspicious apps, processes, downloads, profiles, extensions, alerts, persistence, privacy, or network activity while keeping protections distinct.
 ---
 
 # Assess macOS Threat

--- a/plugins/cybersecurity-skills/skills/author-detection-content/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/author-detection-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-detection-content
-description: Turn validated security behavior into tested detection content. Use for Sigma, osquery, YARA-X routing, endpoint queries, SIEM rules, cloud or application detections, correlation logic, alert enrichment, or regression fixtures when telemetry prerequisites, provenance, expected matches, benign negatives, false-positive controls, performance, severity, response, deployment, and maintenance ownership must be explicit.
+description: Turn validated security behavior into tested detection content. Use for Sigma, osquery, YARA-X, endpoint or SIEM queries, cloud detections, correlation, alert enrichment, and fixtures with explicit telemetry and false-positive controls.
 ---
 
 # Author Detection Content

--- a/plugins/cybersecurity-skills/skills/author-yara-x-rules/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/author-yara-x-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-yara-x-rules
-description: Author, test, tune, and document YARA-X detection rules from validated artifact evidence. Use when malware, suspicious files, scripts, documents, or binary features need local pattern detection with stable discriminators, metadata, positive and negative fixtures, performance checks, false-positive review, rule provenance, and regression testing.
+description: Author, test, tune, and document YARA-X rules from validated artifact evidence. Use when suspicious files, scripts, documents, or binary features need local detection with stable patterns, fixtures, performance checks, and regression tests.
 ---
 
 # Author YARA-X Rules

--- a/plugins/cybersecurity-skills/skills/check-artifact-reputation/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/check-artifact-reputation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-artifact-reputation
-description: Check local and external reputation for a suspicious artifact, signer, hash, URL, domain, certificate, package, or vendor. Use when provenance and threat-intelligence context could inform triage, while sample-upload privacy, stale intelligence, hash-only misses, false positives, and reputation-versus-behavior limits must remain explicit.
+description: Check reputation for a suspicious artifact, signer, hash, URL, domain, certificate, package, or vendor. Use when threat intelligence informs triage while privacy, stale data, false positives, and behavior limits stay explicit.
 ---
 
 # Check Artifact Reputation

--- a/plugins/cybersecurity-skills/skills/contain-and-recover-macos/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/contain-and-recover-macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contain-and-recover-macos
-description: Contain a suspected or confirmed macOS threat and verify recovery. Use when a Mac may need network isolation, process or service containment, account and credential response, persistence removal, artifact quarantine, backup/restore, erase/reinstall, monitoring, or return-to-service decisions while evidence loss, user impact, and platform protections remain explicit.
+description: Contain a macOS threat and verify recovery. Use for isolation, process or service containment, credential response, persistence removal, quarantine, restore, erase/reinstall, monitoring, and return-to-service decisions.
 ---
 
 # Contain And Recover macOS

--- a/plugins/cybersecurity-skills/skills/contain-security-incident/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/contain-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contain-security-incident
-description: Contain an active or credible cybersecurity incident across hosts, identities, applications, services, cloud resources, networks, or data. Use when ongoing access, execution, exfiltration, fraud, destruction, lateral movement, unsafe service behavior, or repeated compromise must be interrupted with authorized, reversible actions while evidence, business impact, dependencies, communication, and rollback are tracked.
+description: Contain an active or credible incident across hosts, identities, applications, cloud resources, networks, or data. Use when access, execution, exfiltration, fraud, destruction, or repeated compromise needs authorized interruption.
 ---
 
 # Contain Security Incident

--- a/plugins/cybersecurity-skills/skills/harden-macos/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/harden-macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harden-macos
-description: Review and improve macOS defensive posture after a threat assessment, incident, or general security request. Use for updates, XProtect/Gatekeeper posture, FileVault, firewall and sharing, remote access, accounts, login/background items, profiles/extensions, browser safety, privacy permissions, backups, credential habits, and monitoring while preserving usability and managed-device policy.
+description: Review and improve macOS defensive posture. Use for updates, XProtect and Gatekeeper, FileVault, firewall, remote access, accounts, background items, privacy, backups, credentials, and monitoring after a security assessment or incident.
 ---
 
 # Harden macOS

--- a/plugins/cybersecurity-skills/skills/hunt-security-indicators/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/hunt-security-indicators/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hunt-security-indicators
-description: Hunt scoped systems and telemetry for supplied security indicators or behaviors. Use for hashes, paths, domains, addresses, certificates, accounts, processes, commands, persistence, ATT&CK behaviors, cloud or application events, or incident expansion when data sources, time window, query logic, coverage, false positives, privacy, and follow-up validation must be explicit.
+description: Hunt scoped systems and telemetry for supplied indicators or behaviors. Use for hashes, paths, domains, addresses, accounts, processes, persistence, ATT&CK behaviors, cloud events, or incident expansion with explicit scope and validation.
 ---
 
 # Hunt Security Indicators

--- a/plugins/cybersecurity-skills/skills/inspect-macos-persistence/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/inspect-macos-persistence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect-macos-persistence
-description: Inspect macOS persistence and recurring execution without deleting evidence. Use for suspicious login items, background items, launch agents or daemons, system or network extensions, configuration profiles, shell startup files, scheduled tasks, browser extensions, helper tools, app registrations, or startup behavior that may survive logout, reboot, or application exit.
+description: Inspect macOS persistence and recurring execution without deleting evidence. Use for login items, launch agents or daemons, extensions, profiles, shell startup files, scheduled tasks, browser extensions, helpers, and startup behavior.
 ---
 
 # Inspect macOS Persistence

--- a/plugins/cybersecurity-skills/skills/inspect-macos-runtime-activity/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/inspect-macos-runtime-activity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect-macos-runtime-activity
-description: Correlate suspicious macOS process, file, network, permission, and log activity. Use for unexpected processes, child execution, downloads, open files, DNS/connections, privacy prompts, XProtect or Gatekeeper events, file mutations, injected or deleted executables, and Endpoint Security or eslogger evidence when exact permissions and telemetry gaps must remain visible.
+description: Correlate suspicious macOS process, file, network, permission, and log activity. Use for unexpected processes, downloads, open files, DNS, privacy prompts, alerts, file mutations, injected executables, and Endpoint Security evidence.
 ---
 
 # Inspect macOS Runtime Activity

--- a/plugins/cybersecurity-skills/skills/map-malware-behavior/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/map-malware-behavior/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-malware-behavior
-description: Map observed or strongly evidenced malicious behavior to current MITRE ATT&CK techniques and platform context. Use when static or dynamic analysis, endpoint telemetry, incident evidence, or a malware report needs a behavior map for detection, response, comparison, or communication without inferring an actor, campaign, family, or complete attack chain from labels alone.
+description: Map observed malicious behavior to MITRE ATT&CK techniques. Use when analysis, telemetry, incident evidence, or a report needs a behavior map for detection, response, or communication without inferring an actor or campaign.
 ---
 
 # Map Malware Behavior

--- a/plugins/cybersecurity-skills/skills/operate-agentic-security-tools/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/operate-agentic-security-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operate-agentic-security-tools
-description: Operate security tools through an AI agent with explicit authority and evidence boundaries. Use when an agent may invoke local CLIs, GUI apps, browser automation, MCP servers, remote scanners, sandboxes, vulnerability tools, packet tools, or containment actions and permissions, mounts, network, secrets, approvals, logging, output, and cleanup must be constrained.
+description: Operate security tools through an AI agent with explicit authority boundaries. Use when an agent may invoke CLIs, GUI apps, browser automation, MCP servers, scanners, sandboxes, or containment actions with constrained approvals and logging.
 ---
 
 # Operate Agentic Security Tools

--- a/plugins/cybersecurity-skills/skills/perform-dynamic-malware-analysis/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/perform-dynamic-malware-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perform-dynamic-malware-analysis
-description: Observe suspicious content in a disposable, instrumented environment. Use when execution, process ancestry, file changes, persistence, network behavior, configuration decryption, child payloads, environment gates, or user interaction must be measured after static analysis and an isolation boundary, authorization, baseline, stop conditions, evidence export, and teardown plan are explicit.
+description: Observe suspicious content in a disposable environment. Use when execution, process ancestry, file changes, persistence, network behavior, payloads, or user interaction need measurement after static analysis with isolation and teardown.
 ---
 
 # Perform Dynamic Malware Analysis

--- a/plugins/cybersecurity-skills/skills/perform-static-malware-analysis/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/perform-static-malware-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perform-static-malware-analysis
-description: Analyze a suspicious artifact for capabilities without executing it. Use for binaries, apps, packages, archives, scripts, libraries, extensions, firmware, or embedded payloads when metadata, signatures, imports, strings, resources, configuration, rules, obfuscation, and likely behavior must be inspected and deep binary work may hand off to reverse-engineering-skills.
+description: Analyze a suspicious artifact without executing it. Use for binaries, apps, packages, archives, scripts, libraries, extensions, firmware, or payloads when metadata, signatures, imports, strings, resources, and obfuscation need inspection.
 ---
 
 # Perform Static Malware Analysis

--- a/plugins/cybersecurity-skills/skills/preserve-security-evidence/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/preserve-security-evidence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preserve-security-evidence
-description: Preserve and document security evidence before analysis, containment, or remediation changes it. Use for suspicious artifacts, volatile host state, vulnerability validation, incident records, logs, screenshots, commands, hashes, timelines, transformations, and analyst handoffs that need reproducible provenance without claiming legal-forensics certification.
+description: Preserve security evidence before analysis, containment, or remediation changes it. Use for artifacts, volatile host state, vulnerability validation, records, logs, screenshots, commands, hashes, timelines, and reproducible handoffs.
 ---
 
 # Preserve Security Evidence

--- a/plugins/cybersecurity-skills/skills/recover-security-incident/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/recover-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recover-security-incident
-description: Eradicate verified compromise mechanisms, restore trusted service, and monitor after a cybersecurity incident. Use when affected hosts, identities, applications, cloud resources, network controls, or data need rebuild/restore, patching, secret rotation, configuration repair, validation, staged return to service, temporary-control removal, lessons learned, and residual-risk ownership.
+description: Recover from an incident by eradicating compromise and restoring service. Use when hosts, identities, applications, cloud resources, network controls, or data need rebuild, patching, rotation, repair, validation, and return to service.
 ---
 
 # Recover Security Incident

--- a/plugins/cybersecurity-skills/skills/report-security-assessment/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/report-security-assessment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-security-assessment
-description: Write a reproducible security assessment or penetration-test report from validated evidence. Use when technical findings, negative results, scope, methodology, limitations, exposure, impact, confidence, remediation, retest criteria, evidence handling, and a plain-language executive explanation must be assembled without overstating scanner output or untested coverage.
+description: Write a security assessment or penetration-test report from evidence. Use when findings, scope, methodology, limitations, impact, remediation, retest criteria, and an executive explanation need calibrated reporting.
 ---
 
 # Report Security Assessment

--- a/plugins/cybersecurity-skills/skills/route-security-work/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/route-security-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: route-security-work
-description: Route an ambiguous cybersecurity request before tools run. Use for suspicious files, links, messages, host behavior, malware questions, vulnerability reports, authorized pentests, security incidents, threat hunting, detection work, or security advice when the correct workflow and specialist owner are not yet clear.
+description: Route an ambiguous cybersecurity request before tools run. Use for suspicious files, links, messages, host behavior, malware, vulnerability reports, authorized pentests, incidents, threat hunting, detection work, or security advice.
 ---
 
 # Route Security Work

--- a/plugins/cybersecurity-skills/skills/scope-authorized-security-test/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/scope-authorized-security-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope-authorized-security-test
-description: Define and verify authorization, targets, rules of engagement, data handling, safety controls, and stop conditions before active security testing. Use for penetration tests, vulnerability scans, exploit validation, web/API tests, network probing, red-team-like exercises, bug bounty work, or agent-driven testing where ownership and allowed techniques must be explicit.
+description: Define authorization, targets, rules, safety controls, and stop conditions before active security testing. Use for penetration tests, scans, exploit validation, web or API tests, network probing, bug bounty, or agent-driven testing.
 ---
 
 # Scope Authorized Security Test

--- a/plugins/cybersecurity-skills/skills/select-analysis-isolation/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/select-analysis-isolation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: select-analysis-isolation
-description: Select and configure an isolation boundary before inspecting or executing untrusted content. Use when choosing among local read-only analysis, a disposable container, Linux VM, macOS VM, remote sandbox, or spare physical device and deciding network, mount, clipboard, credential, device, snapshot, evidence-export, and teardown controls.
+description: Select isolation before inspecting or executing untrusted content. Use for local analysis, a container, Linux or macOS VM, remote sandbox, or spare device with defined network, mounts, credentials, snapshots, evidence export, and teardown.
 ---
 
 # Select Analysis Isolation

--- a/plugins/cybersecurity-skills/skills/test-network-services/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/test-network-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-network-services
-description: Inventory and test explicitly authorized network services with bounded discovery and protocol-aware validation. Use for approved hosts, address ranges, ports, TLS, banners, service versions, authentication, exposure, segmentation, configuration, packet evidence, or narrowly reviewed vulnerability checks when rate, source, third-party boundaries, and stop conditions are explicit.
+description: Test authorized network services with bounded discovery and protocol-aware validation. Use for hosts, ranges, ports, TLS, banners, versions, authentication, exposure, segmentation, configuration, packet evidence, or vulnerability checks.
 ---
 
 # Test Network Services

--- a/plugins/cybersecurity-skills/skills/test-web-and-api-security/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/test-web-and-api-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-web-and-api-security
-description: Test an explicitly authorized web application or API using current OWASP guidance and bounded manual or automated checks. Use for authentication, authorization, session, input, browser, API schema, business logic, file handling, server-side request, configuration, transport, error, and data-exposure tests when accounts, roles, target, rate, evidence, and stop conditions are defined.
+description: Test an authorized web application or API using OWASP guidance. Use for authentication, authorization, sessions, input, schemas, business logic, file handling, server-side requests, configuration, transport, errors, and data exposure.
 ---
 
 # Test Web And API Security

--- a/plugins/cybersecurity-skills/skills/triage-security-incident/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/triage-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-security-incident
-description: Triage a suspected cybersecurity incident across endpoints, identities, applications, services, cloud resources, networks, or data. Use when an alert, report, compromise indicator, service disruption, unauthorized access, malware event, credential concern, or data exposure needs an incident owner, affected scope, urgency, evidence plan, immediate harm-reduction decision, and communication path.
+description: Triage a suspected incident across endpoints, identities, applications, cloud resources, networks, or data. Use when an alert, compromise, disruption, unauthorized access, malware, credential concern, or exposure needs scope and ownership.
 ---
 
 # Triage Security Incident

--- a/plugins/cybersecurity-skills/skills/triage-suspicious-content/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/triage-suspicious-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-suspicious-content
-description: Safely classify suspicious files, archives, installers, packages, scripts, documents, configuration profiles, browser extensions, URLs, QR codes, messages, and nested payloads before execution. Use when someone receives or discovers sketchy content and needs to know what it is, what active behavior it may contain, and the smallest safe next analysis step.
+description: Safely classify suspicious files, archives, installers, packages, scripts, documents, profiles, browser extensions, URLs, QR codes, messages, and nested payloads before execution. Use when someone needs the smallest safe next analysis step.
 ---
 
 # Triage Suspicious Content

--- a/plugins/cybersecurity-skills/skills/triage-vulnerability-report/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/triage-vulnerability-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-vulnerability-report
-description: Normalize and triage a supplied vulnerability report, scanner result, advisory, CVE, proof of concept, bug bounty submission, security ticket, or researcher note. Use when affected component/version, source credibility, prerequisites, evidence, duplicate status, asset applicability, source-code owner, validation plan, and immediate exposure questions must be established before accepting or rejecting a finding.
+description: Triage a vulnerability report, scanner result, advisory, CVE, PoC, bug bounty, ticket, or researcher note. Use when affected versions, credibility, prerequisites, evidence, applicability, validation, and exposure must be established.
 ---
 
 # Triage Vulnerability Report

--- a/plugins/cybersecurity-skills/skills/use-objective-see-tools/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/use-objective-see-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-objective-see-tools
-description: Use installed Objective-See macOS security tools as thin evidence adapters. Use for KnockKnock persistence inventory, BlockBlock persistence alerts, LuLu network decisions, ProcessMonitor or FileMonitor activity, WhatsYourSign signature inspection, TaskExplorer process review, or related Objective-See tools while exact version, permissions, user actions, tool limits, and owning investigation workflow remain explicit.
+description: Use installed Objective-See macOS security tools as evidence adapters. Use for KnockKnock, BlockBlock, LuLu, ProcessMonitor, FileMonitor, WhatsYourSign, TaskExplorer, or related tools with explicit permissions, limits, and ownership.
 ---
 
 # Use Objective-See Tools

--- a/plugins/cybersecurity-skills/skills/validate-vulnerability/SKILL.md
+++ b/plugins/cybersecurity-skills/skills/validate-vulnerability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-vulnerability
-description: Determine whether a specific vulnerability claim is valid, reachable, exploitable, and impactful in an authorized environment. Use for scanner candidates, advisories, CVEs, supplied PoCs, source-level concerns, configuration weaknesses, or regression tests when the smallest safe proof, negative controls, exact build, prerequisites, boundary crossed, and confidence must be recorded.
+description: Validate a vulnerability claim in an authorized environment. Use for scanner candidates, advisories, CVEs, PoCs, source concerns, configuration weaknesses, or regressions with a safe proof and controls.
 ---
 
 # Validate Vulnerability

--- a/plugins/messaging-collaboration-skills/skills/choose-platform-integration/SKILL.md
+++ b/plugins/messaging-collaboration-skills/skills/choose-platform-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: choose-platform-integration
-description: Choose a supported chat, calling, business-messaging, or collaboration integration shape before implementation. Use for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, iMessage collaboration, and Apple VoIP requests.
+description: Choose a supported chat, calling, business-messaging, or collaboration integration before implementation. Use for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, iMessage collaboration, and Apple VoIP.
 ---
 
 # Choose Platform Integration

--- a/skills/analyze-suspicious-script-or-document/SKILL.md
+++ b/skills/analyze-suspicious-script-or-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-suspicious-script-or-document
-description: Decode and analyze suspicious scripts and active documents without triggering them. Use for shell, AppleScript, JavaScript, Python, PowerShell, shortcuts, Office files, PDFs, configuration profiles, encoded commands, macros, embedded objects, external templates, staged downloads, or mixed document-to-script payload chains.
+description: Decode and analyze suspicious scripts and active documents without triggering them. Use for shell, AppleScript, JavaScript, Python, PowerShell, shortcuts, Office files, PDFs, profiles, macros, embedded objects, and staged payloads.
 ---
 
 # Analyze Suspicious Script Or Document

--- a/skills/assess-and-explain-threat/SKILL.md
+++ b/skills/assess-and-explain-threat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-and-explain-threat
-description: Assess whether suspicious evidence indicates a real threat and explain the result in practical language. Use when a person needs a confidence-calibrated conclusion, immediate protective actions, remaining uncertainty, impact, or understandable advice after artifact, endpoint, vulnerability, identity, or incident evidence has been collected.
+description: Assess whether suspicious evidence indicates a real threat and explain it plainly. Use for confidence, protective actions, uncertainty, impact, and advice after artifact, endpoint, identity, or incident evidence.
 ---
 
 # Assess And Explain Threat

--- a/skills/assess-exposure-and-impact/SKILL.md
+++ b/skills/assess-exposure-and-impact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-exposure-and-impact
-description: Prioritize a validated or plausible vulnerability using actual asset exposure and impact. Use when affected versions, deployment reachability, attacker prerequisites, privileges, sensitive data, exploit maturity, CISA KEV status, vendor guidance, mitigations, detection, business criticality, CVSS, and remediation urgency must be combined without relying on a severity score alone.
+description: Prioritize a vulnerability using actual asset exposure and impact. Use when versions, reachability, prerequisites, privileges, data, exploit maturity, mitigations, detection, business criticality, and urgency matter beyond CVSS.
 ---
 
 # Assess Exposure And Impact

--- a/skills/assess-macos-threat/SKILL.md
+++ b/skills/assess-macos-threat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assess-macos-threat
-description: Assess a suspected macOS security threat using exact host, artifact, and platform evidence. Use for suspicious apps, packages, processes, prompts, downloads, profiles, extensions, XProtect or Gatekeeper alerts, account behavior, persistence, privacy access, or unexpected network activity when signing, notarization, quarantine, TCC, SIP, and observed behavior must remain distinct.
+description: Assess a suspected macOS threat using exact host and artifact evidence. Use for suspicious apps, processes, downloads, profiles, extensions, alerts, persistence, privacy, or network activity while keeping protections distinct.
 ---
 
 # Assess macOS Threat

--- a/skills/author-detection-content/SKILL.md
+++ b/skills/author-detection-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-detection-content
-description: Turn validated security behavior into tested detection content. Use for Sigma, osquery, YARA-X routing, endpoint queries, SIEM rules, cloud or application detections, correlation logic, alert enrichment, or regression fixtures when telemetry prerequisites, provenance, expected matches, benign negatives, false-positive controls, performance, severity, response, deployment, and maintenance ownership must be explicit.
+description: Turn validated security behavior into tested detection content. Use for Sigma, osquery, YARA-X, endpoint or SIEM queries, cloud detections, correlation, alert enrichment, and fixtures with explicit telemetry and false-positive controls.
 ---
 
 # Author Detection Content

--- a/skills/author-yara-x-rules/SKILL.md
+++ b/skills/author-yara-x-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-yara-x-rules
-description: Author, test, tune, and document YARA-X detection rules from validated artifact evidence. Use when malware, suspicious files, scripts, documents, or binary features need local pattern detection with stable discriminators, metadata, positive and negative fixtures, performance checks, false-positive review, rule provenance, and regression testing.
+description: Author, test, tune, and document YARA-X rules from validated artifact evidence. Use when suspicious files, scripts, documents, or binary features need local detection with stable patterns, fixtures, performance checks, and regression tests.
 ---
 
 # Author YARA-X Rules

--- a/skills/bootstrap-skills-plugin-repo/SKILL.md
+++ b/skills/bootstrap-skills-plugin-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap-skills-plugin-repo
-description: Bootstrap or align a source-first Agent Skills repository with root `skills/`, repo-local discovery mirrors, maintainer docs, and clear Codex plugin-boundary wording. Use when creating a new skills repo or structurally aligning an existing one. Do not use this for narrow README-only, roadmap-only, or host-adapter design work.
+description: Bootstrap or align a source-first Agent Skills repository with root `skills/`, discovery mirrors, maintainer docs, and explicit Codex plugin boundaries. Use for new skills repos or structural alignment, not narrow docs or host-adapter work.
 metadata:
   hermes:
     category: agent-portability

--- a/skills/check-artifact-reputation/SKILL.md
+++ b/skills/check-artifact-reputation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-artifact-reputation
-description: Check local and external reputation for a suspicious artifact, signer, hash, URL, domain, certificate, package, or vendor. Use when provenance and threat-intelligence context could inform triage, while sample-upload privacy, stale intelligence, hash-only misses, false positives, and reputation-versus-behavior limits must remain explicit.
+description: Check reputation for a suspicious artifact, signer, hash, URL, domain, certificate, package, or vendor. Use when threat intelligence informs triage while privacy, stale data, false positives, and behavior limits stay explicit.
 ---
 
 # Check Artifact Reputation

--- a/skills/choose-platform-integration/SKILL.md
+++ b/skills/choose-platform-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: choose-platform-integration
-description: Choose a supported chat, calling, business-messaging, or collaboration integration shape before implementation. Use for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, iMessage collaboration, and Apple VoIP requests.
+description: Choose a supported chat, calling, business-messaging, or collaboration integration before implementation. Use for Discord, Telegram, Slack, Teams, WhatsApp Business, SMS/MMS/RCS, Google Meet, iMessage collaboration, and Apple VoIP.
 ---
 
 # Choose Platform Integration

--- a/skills/contain-and-recover-macos/SKILL.md
+++ b/skills/contain-and-recover-macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contain-and-recover-macos
-description: Contain a suspected or confirmed macOS threat and verify recovery. Use when a Mac may need network isolation, process or service containment, account and credential response, persistence removal, artifact quarantine, backup/restore, erase/reinstall, monitoring, or return-to-service decisions while evidence loss, user impact, and platform protections remain explicit.
+description: Contain a macOS threat and verify recovery. Use for isolation, process or service containment, credential response, persistence removal, quarantine, restore, erase/reinstall, monitoring, and return-to-service decisions.
 ---
 
 # Contain And Recover macOS

--- a/skills/contain-security-incident/SKILL.md
+++ b/skills/contain-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contain-security-incident
-description: Contain an active or credible cybersecurity incident across hosts, identities, applications, services, cloud resources, networks, or data. Use when ongoing access, execution, exfiltration, fraud, destruction, lateral movement, unsafe service behavior, or repeated compromise must be interrupted with authorized, reversible actions while evidence, business impact, dependencies, communication, and rollback are tracked.
+description: Contain an active or credible incident across hosts, identities, applications, cloud resources, networks, or data. Use when access, execution, exfiltration, fraud, destruction, or repeated compromise needs authorized interruption.
 ---
 
 # Contain Security Incident

--- a/skills/harden-macos/SKILL.md
+++ b/skills/harden-macos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harden-macos
-description: Review and improve macOS defensive posture after a threat assessment, incident, or general security request. Use for updates, XProtect/Gatekeeper posture, FileVault, firewall and sharing, remote access, accounts, login/background items, profiles/extensions, browser safety, privacy permissions, backups, credential habits, and monitoring while preserving usability and managed-device policy.
+description: Review and improve macOS defensive posture. Use for updates, XProtect and Gatekeeper, FileVault, firewall, remote access, accounts, background items, privacy, backups, credentials, and monitoring after a security assessment or incident.
 ---
 
 # Harden macOS

--- a/skills/hunt-security-indicators/SKILL.md
+++ b/skills/hunt-security-indicators/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hunt-security-indicators
-description: Hunt scoped systems and telemetry for supplied security indicators or behaviors. Use for hashes, paths, domains, addresses, certificates, accounts, processes, commands, persistence, ATT&CK behaviors, cloud or application events, or incident expansion when data sources, time window, query logic, coverage, false positives, privacy, and follow-up validation must be explicit.
+description: Hunt scoped systems and telemetry for supplied indicators or behaviors. Use for hashes, paths, domains, addresses, accounts, processes, persistence, ATT&CK behaviors, cloud events, or incident expansion with explicit scope and validation.
 ---
 
 # Hunt Security Indicators

--- a/skills/inspect-macos-persistence/SKILL.md
+++ b/skills/inspect-macos-persistence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect-macos-persistence
-description: Inspect macOS persistence and recurring execution without deleting evidence. Use for suspicious login items, background items, launch agents or daemons, system or network extensions, configuration profiles, shell startup files, scheduled tasks, browser extensions, helper tools, app registrations, or startup behavior that may survive logout, reboot, or application exit.
+description: Inspect macOS persistence and recurring execution without deleting evidence. Use for login items, launch agents or daemons, extensions, profiles, shell startup files, scheduled tasks, browser extensions, helpers, and startup behavior.
 ---
 
 # Inspect macOS Persistence

--- a/skills/inspect-macos-runtime-activity/SKILL.md
+++ b/skills/inspect-macos-runtime-activity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect-macos-runtime-activity
-description: Correlate suspicious macOS process, file, network, permission, and log activity. Use for unexpected processes, child execution, downloads, open files, DNS/connections, privacy prompts, XProtect or Gatekeeper events, file mutations, injected or deleted executables, and Endpoint Security or eslogger evidence when exact permissions and telemetry gaps must remain visible.
+description: Correlate suspicious macOS process, file, network, permission, and log activity. Use for unexpected processes, downloads, open files, DNS, privacy prompts, alerts, file mutations, injected executables, and Endpoint Security evidence.
 ---
 
 # Inspect macOS Runtime Activity

--- a/skills/map-malware-behavior/SKILL.md
+++ b/skills/map-malware-behavior/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-malware-behavior
-description: Map observed or strongly evidenced malicious behavior to current MITRE ATT&CK techniques and platform context. Use when static or dynamic analysis, endpoint telemetry, incident evidence, or a malware report needs a behavior map for detection, response, comparison, or communication without inferring an actor, campaign, family, or complete attack chain from labels alone.
+description: Map observed malicious behavior to MITRE ATT&CK techniques. Use when analysis, telemetry, incident evidence, or a report needs a behavior map for detection, response, or communication without inferring an actor or campaign.
 ---
 
 # Map Malware Behavior

--- a/skills/operate-agentic-security-tools/SKILL.md
+++ b/skills/operate-agentic-security-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operate-agentic-security-tools
-description: Operate security tools through an AI agent with explicit authority and evidence boundaries. Use when an agent may invoke local CLIs, GUI apps, browser automation, MCP servers, remote scanners, sandboxes, vulnerability tools, packet tools, or containment actions and permissions, mounts, network, secrets, approvals, logging, output, and cleanup must be constrained.
+description: Operate security tools through an AI agent with explicit authority boundaries. Use when an agent may invoke CLIs, GUI apps, browser automation, MCP servers, scanners, sandboxes, or containment actions with constrained approvals and logging.
 ---
 
 # Operate Agentic Security Tools

--- a/skills/perform-dynamic-malware-analysis/SKILL.md
+++ b/skills/perform-dynamic-malware-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perform-dynamic-malware-analysis
-description: Observe suspicious content in a disposable, instrumented environment. Use when execution, process ancestry, file changes, persistence, network behavior, configuration decryption, child payloads, environment gates, or user interaction must be measured after static analysis and an isolation boundary, authorization, baseline, stop conditions, evidence export, and teardown plan are explicit.
+description: Observe suspicious content in a disposable environment. Use when execution, process ancestry, file changes, persistence, network behavior, payloads, or user interaction need measurement after static analysis with isolation and teardown.
 ---
 
 # Perform Dynamic Malware Analysis

--- a/skills/perform-static-malware-analysis/SKILL.md
+++ b/skills/perform-static-malware-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perform-static-malware-analysis
-description: Analyze a suspicious artifact for capabilities without executing it. Use for binaries, apps, packages, archives, scripts, libraries, extensions, firmware, or embedded payloads when metadata, signatures, imports, strings, resources, configuration, rules, obfuscation, and likely behavior must be inspected and deep binary work may hand off to reverse-engineering-skills.
+description: Analyze a suspicious artifact without executing it. Use for binaries, apps, packages, archives, scripts, libraries, extensions, firmware, or payloads when metadata, signatures, imports, strings, resources, and obfuscation need inspection.
 ---
 
 # Perform Static Malware Analysis

--- a/skills/preserve-security-evidence/SKILL.md
+++ b/skills/preserve-security-evidence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preserve-security-evidence
-description: Preserve and document security evidence before analysis, containment, or remediation changes it. Use for suspicious artifacts, volatile host state, vulnerability validation, incident records, logs, screenshots, commands, hashes, timelines, transformations, and analyst handoffs that need reproducible provenance without claiming legal-forensics certification.
+description: Preserve security evidence before analysis, containment, or remediation changes it. Use for artifacts, volatile host state, vulnerability validation, records, logs, screenshots, commands, hashes, timelines, and reproducible handoffs.
 ---
 
 # Preserve Security Evidence

--- a/skills/recover-security-incident/SKILL.md
+++ b/skills/recover-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recover-security-incident
-description: Eradicate verified compromise mechanisms, restore trusted service, and monitor after a cybersecurity incident. Use when affected hosts, identities, applications, cloud resources, network controls, or data need rebuild/restore, patching, secret rotation, configuration repair, validation, staged return to service, temporary-control removal, lessons learned, and residual-risk ownership.
+description: Recover from an incident by eradicating compromise and restoring service. Use when hosts, identities, applications, cloud resources, network controls, or data need rebuild, patching, rotation, repair, validation, and return to service.
 ---
 
 # Recover Security Incident

--- a/skills/report-security-assessment/SKILL.md
+++ b/skills/report-security-assessment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-security-assessment
-description: Write a reproducible security assessment or penetration-test report from validated evidence. Use when technical findings, negative results, scope, methodology, limitations, exposure, impact, confidence, remediation, retest criteria, evidence handling, and a plain-language executive explanation must be assembled without overstating scanner output or untested coverage.
+description: Write a security assessment or penetration-test report from evidence. Use when findings, scope, methodology, limitations, impact, remediation, retest criteria, and an executive explanation need calibrated reporting.
 ---
 
 # Report Security Assessment

--- a/skills/route-security-work/SKILL.md
+++ b/skills/route-security-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: route-security-work
-description: Route an ambiguous cybersecurity request before tools run. Use for suspicious files, links, messages, host behavior, malware questions, vulnerability reports, authorized pentests, security incidents, threat hunting, detection work, or security advice when the correct workflow and specialist owner are not yet clear.
+description: Route an ambiguous cybersecurity request before tools run. Use for suspicious files, links, messages, host behavior, malware, vulnerability reports, authorized pentests, incidents, threat hunting, detection work, or security advice.
 ---
 
 # Route Security Work

--- a/skills/scope-authorized-security-test/SKILL.md
+++ b/skills/scope-authorized-security-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope-authorized-security-test
-description: Define and verify authorization, targets, rules of engagement, data handling, safety controls, and stop conditions before active security testing. Use for penetration tests, vulnerability scans, exploit validation, web/API tests, network probing, red-team-like exercises, bug bounty work, or agent-driven testing where ownership and allowed techniques must be explicit.
+description: Define authorization, targets, rules, safety controls, and stop conditions before active security testing. Use for penetration tests, scans, exploit validation, web or API tests, network probing, bug bounty, or agent-driven testing.
 ---
 
 # Scope Authorized Security Test

--- a/skills/select-analysis-isolation/SKILL.md
+++ b/skills/select-analysis-isolation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: select-analysis-isolation
-description: Select and configure an isolation boundary before inspecting or executing untrusted content. Use when choosing among local read-only analysis, a disposable container, Linux VM, macOS VM, remote sandbox, or spare physical device and deciding network, mount, clipboard, credential, device, snapshot, evidence-export, and teardown controls.
+description: Select isolation before inspecting or executing untrusted content. Use for local analysis, a container, Linux or macOS VM, remote sandbox, or spare device with defined network, mounts, credentials, snapshots, evidence export, and teardown.
 ---
 
 # Select Analysis Isolation

--- a/skills/sync-skills-repo-guidance/SKILL.md
+++ b/skills/sync-skills-repo-guidance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-skills-repo-guidance
-description: Audit guidance across AGENTS.md, optional README.md, maintainer docs, and discovery mirrors in an existing Agent Skills or Codex plugin repository. Use when a skills repo may have stale guidance, missing discovery mirrors, outdated OpenAI Codex policy, or unclear boundaries between portable skills and host-specific plugin surfaces. Defer narrow README-only, roadmap-only, or host-adapter design requests to the specialized maintainer skills.
+description: Audit Agent Skills or Codex plugin guidance and discovery mirrors. Use for stale policy, missing mirrors, or unclear portable-skill and host-plugin boundaries; defer narrow docs work.
 metadata:
   hermes:
     category: agent-portability

--- a/skills/test-network-services/SKILL.md
+++ b/skills/test-network-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-network-services
-description: Inventory and test explicitly authorized network services with bounded discovery and protocol-aware validation. Use for approved hosts, address ranges, ports, TLS, banners, service versions, authentication, exposure, segmentation, configuration, packet evidence, or narrowly reviewed vulnerability checks when rate, source, third-party boundaries, and stop conditions are explicit.
+description: Test authorized network services with bounded discovery and protocol-aware validation. Use for hosts, ranges, ports, TLS, banners, versions, authentication, exposure, segmentation, configuration, packet evidence, or vulnerability checks.
 ---
 
 # Test Network Services

--- a/skills/test-web-and-api-security/SKILL.md
+++ b/skills/test-web-and-api-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-web-and-api-security
-description: Test an explicitly authorized web application or API using current OWASP guidance and bounded manual or automated checks. Use for authentication, authorization, session, input, browser, API schema, business logic, file handling, server-side request, configuration, transport, error, and data-exposure tests when accounts, roles, target, rate, evidence, and stop conditions are defined.
+description: Test an authorized web application or API using OWASP guidance. Use for authentication, authorization, sessions, input, schemas, business logic, file handling, server-side requests, configuration, transport, errors, and data exposure.
 ---
 
 # Test Web And API Security

--- a/skills/triage-security-incident/SKILL.md
+++ b/skills/triage-security-incident/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-security-incident
-description: Triage a suspected cybersecurity incident across endpoints, identities, applications, services, cloud resources, networks, or data. Use when an alert, report, compromise indicator, service disruption, unauthorized access, malware event, credential concern, or data exposure needs an incident owner, affected scope, urgency, evidence plan, immediate harm-reduction decision, and communication path.
+description: Triage a suspected incident across endpoints, identities, applications, cloud resources, networks, or data. Use when an alert, compromise, disruption, unauthorized access, malware, credential concern, or exposure needs scope and ownership.
 ---
 
 # Triage Security Incident

--- a/skills/triage-suspicious-content/SKILL.md
+++ b/skills/triage-suspicious-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-suspicious-content
-description: Safely classify suspicious files, archives, installers, packages, scripts, documents, configuration profiles, browser extensions, URLs, QR codes, messages, and nested payloads before execution. Use when someone receives or discovers sketchy content and needs to know what it is, what active behavior it may contain, and the smallest safe next analysis step.
+description: Safely classify suspicious files, archives, installers, packages, scripts, documents, profiles, browser extensions, URLs, QR codes, messages, and nested payloads before execution. Use when someone needs the smallest safe next analysis step.
 ---
 
 # Triage Suspicious Content

--- a/skills/triage-vulnerability-report/SKILL.md
+++ b/skills/triage-vulnerability-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-vulnerability-report
-description: Normalize and triage a supplied vulnerability report, scanner result, advisory, CVE, proof of concept, bug bounty submission, security ticket, or researcher note. Use when affected component/version, source credibility, prerequisites, evidence, duplicate status, asset applicability, source-code owner, validation plan, and immediate exposure questions must be established before accepting or rejecting a finding.
+description: Triage a vulnerability report, scanner result, advisory, CVE, PoC, bug bounty, ticket, or researcher note. Use when affected versions, credibility, prerequisites, evidence, applicability, validation, and exposure must be established.
 ---
 
 # Triage Vulnerability Report

--- a/skills/use-objective-see-tools/SKILL.md
+++ b/skills/use-objective-see-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-objective-see-tools
-description: Use installed Objective-See macOS security tools as thin evidence adapters. Use for KnockKnock persistence inventory, BlockBlock persistence alerts, LuLu network decisions, ProcessMonitor or FileMonitor activity, WhatsYourSign signature inspection, TaskExplorer process review, or related Objective-See tools while exact version, permissions, user actions, tool limits, and owning investigation workflow remain explicit.
+description: Use installed Objective-See macOS security tools as evidence adapters. Use for KnockKnock, BlockBlock, LuLu, ProcessMonitor, FileMonitor, WhatsYourSign, TaskExplorer, or related tools with explicit permissions, limits, and ownership.
 ---
 
 # Use Objective-See Tools

--- a/skills/validate-vulnerability/SKILL.md
+++ b/skills/validate-vulnerability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-vulnerability
-description: Determine whether a specific vulnerability claim is valid, reachable, exploitable, and impactful in an authorized environment. Use for scanner candidates, advisories, CVEs, supplied PoCs, source-level concerns, configuration weaknesses, or regression tests when the smallest safe proof, negative controls, exact build, prerequisites, boundary crossed, and confidence must be recorded.
+description: Validate a vulnerability claim in an authorized environment. Use for scanner candidates, advisories, CVEs, PoCs, source concerns, configuration weaknesses, or regressions with a safe proof and controls.
 ---
 
 # Validate Vulnerability


### PR DESCRIPTION
## Summary

- Shorten every exported Hermes skill description to 240 characters or fewer.
- Regenerate the checked-in `skills/` tap mirror from the authored plugin skills.

## Verification

- `uv run scripts/export_hermes_skills.py`
- `uv run scripts/validate_hermes_compatibility.py`
- `uv run scripts/validate_socket_metadata.py`
- Explicit scan confirming zero over-limit exported descriptions.
